### PR TITLE
chore: remove interim test snapshot file

### DIFF
--- a/src/cli/commands/snapshots/aikit__cli__commands__package__tests__package_publish_full_workflow.snap.new
+++ b/src/cli/commands/snapshots/aikit__cli__commands__package__tests__package_publish_full_workflow.snap.new
@@ -1,6 +1,0 @@
----
-source: src/cli/commands/package.rs
-assertion_line: 1219
-expression: result.unwrap_err().to_string()
----
-Package ZIP not found: test-package-0.1.0.zip. Run 'aikit package build' first, or specify path with --package.


### PR DESCRIPTION
## Summary
- Removes interim test snapshot file created during Newton test run
- Cleans up `.snap.new` file that is not needed in the repository

## Changes
- Deleted: `src/cli/commands/snapshots/aikit__cli__commands__package__tests__package_publish_full_workflow.snap.new`

This is a cleanup PR to remove test artifacts from the Newton run.