### PR TITLE
fix(run): require --agent, fix cursor agent stdin hang, spawn debug logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ chrono = { version = "0.4", features = ["serde"] }
 # Environment variable loading
 dotenv = "0.15"
 
+# Structured logging (spawn argv, run diagnostics)
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
 # YAML frontmatter parsing
 yaml-front-matter = "0.1"
 serde_yaml = "0.9"

--- a/README.md
+++ b/README.md
@@ -144,11 +144,6 @@ aikit run --agent opencode -p "Help me refactor this code"
 # Read prompt from stdin
 echo "Add error handling" | aikit run --agent claude
 
-# Use environment variables for default agent and model
-export CODING_AGENT=opencode
-export CODING_AGENT_MODEL=zai-coding-plan/glm-4.7
-echo "Write tests" | aikit run
-
 # Emit structured NDJSON events to stdout (one JSON object per line)
 aikit run --agent claude --events -p "Summarize the project"
 
@@ -162,8 +157,8 @@ aikit run --agent claude --events --stream -p "Refactor this module"
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
-| `--agent` | `-a` | Agent to run | `CODING_AGENT` env var, then `opencode` |
-| `--model` | `-m` | Model to use | `CODING_AGENT_MODEL` env var, then `zai-coding-plan/glm-4.7` |
+| `--agent` | `-a` | Runnable agent key (`codex`, `claude`, `gemini`, `opencode`, `agent`) | **Required** |
+| `--model` | `-m` | Model passed to the agent | Omitted unless `-m` is set; no CLI default (agent binary decides) |
 | `--prompt` | `-p` | Prompt to run | Reads from stdin if omitted |
 | `--yolo` | | Auto-confirm, skip checks | `false` |
 | `--stream` | | Enable agent-native streaming output flags | `false` |
@@ -171,9 +166,7 @@ aikit run --agent claude --events --stream -p "Refactor this module"
 
 `aikit run` also accepts the root **`--debug`** flag (global on the `aikit` CLI; it appears in `aikit run --help`).
 
-**Environment variables:**
-- `CODING_AGENT`: Default agent (falls back to `opencode`)
-- `CODING_AGENT_MODEL`: Default model (falls back to `zai-coding-plan/glm-4.7`)
+Agent selection is **CLI-only**: `-a` / `--agent` is required. `aikit run` does not read `CODING_AGENT` or `CODING_AGENT_MODEL`. When `-m` is omitted, no model flag is passed to the agent; the spawned agent applies its own defaults or errors if it requires an explicit model.
 
 **`--stream` vs `--events`:**
 - `--stream`: Tunes agent-native partial output flags (e.g. `--stream-partial-output`, `stream-json`). Passed through to the agent argv builder.

--- a/aikit-sdk/Cargo.toml
+++ b/aikit-sdk/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["ai", "agents", "deploy", "catalog", "capabilities"]
 categories = ["command-line-utilities"]
 
 [dependencies]
+tracing = "0.1"
 glob = "0.3"
 walkdir = "2"
 toml = "0.8"

--- a/aikit-sdk/src/runner.rs
+++ b/aikit-sdk/src/runner.rs
@@ -574,6 +574,23 @@ fn spawn_agent_piped(
         }
     };
 
+    let argv_display: Vec<String> = argv
+        .iter()
+        .map(|s| s.to_string_lossy().into_owned())
+        .collect();
+    tracing::debug!(
+        target: "aikit_sdk::runner",
+        agent_key = %agent_key,
+        argv = ?argv_display,
+        cwd = ?options.current_dir.as_ref().map(|p| p.display().to_string()),
+        timeout = ?options.timeout.map(|d| format!("{}s", d.as_secs())),
+        events_mode,
+        yolo = options.yolo,
+        stream = options.stream,
+        write_prompt_to_stdin = should_write_stdin(agent_key),
+        "spawning agent child process"
+    );
+
     let binary = &argv[0];
     let args = &argv[1..];
 
@@ -681,17 +698,31 @@ where
 {
     use std::sync::{Arc, Mutex};
 
+    tracing::debug!(
+        target: "aikit_sdk::runner",
+        agent_key = %agent_key,
+        prompt_len = prompt.len(),
+        timeout = ?options.timeout.map(|d| d.as_secs()),
+        stream = options.stream,
+        yolo = options.yolo,
+        "run_agent_events"
+    );
+
     let (mut child, _argv) = spawn_agent_piped(agent_key, prompt, &options, true)?;
 
     // Write prompt and close stdin before reading output.
     // Cursor Agent ("agent") takes the prompt as a positional argument, so
-    // stdin is left unused for that key.
+    // we do not write stdin; we still must `take()` and drop it so the write
+    // end of the pipe closes. Otherwise the child's stdin stays open and some
+    // agents block reading it when stdout is a pipe (non-TTY).
     if should_write_stdin(agent_key) {
         if let Some(mut stdin) = child.stdin.take() {
             stdin
                 .write_all(prompt.as_bytes())
                 .map_err(RunError::StdinFailed)?;
         }
+    } else {
+        drop(child.stdin.take());
     }
 
     let stdout_pipe = child.stdout.take().expect("stdout was piped");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -59,9 +59,29 @@ pub enum Commands {
     Run(run::RunArgs),
 }
 
+/// Initialize `tracing` when `RUST_LOG` is set or `--debug` is passed (so SDK logs are visible).
+fn init_tracing(cli: &Cli) {
+    let rust_log = std::env::var_os("RUST_LOG").is_some();
+    if !rust_log && !cli.debug {
+        return;
+    }
+    use tracing_subscriber::EnvFilter;
+    let filter = if rust_log {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    } else {
+        EnvFilter::new("aikit_sdk=debug,aikit::cli::run=debug,warn")
+    };
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_writer(std::io::stderr)
+        .try_init();
+}
+
 /// Run the CLI application
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
+    init_tracing(&cli);
 
     // Initialization banner (binary name and version)
     eprintln!("aikit {}", env!("CARGO_PKG_VERSION"));

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -7,12 +7,12 @@ use std::io::{self, Read, Write};
 #[derive(Parser, Debug)]
 #[command(about = "Run a coding agent with a prompt (stdin or -p)")]
 pub struct RunArgs {
-    /// Agent to run (default: CODING_AGENT env var, then opencode)
-    #[arg(long, short = 'a')]
-    pub agent: Option<String>,
+    /// Runnable agent key (e.g. `codex`, `claude`, `gemini`, `opencode`, `agent`)
+    #[arg(long, short = 'a', value_name = "AGENT")]
+    pub agent: String,
 
-    /// Model to use (default: CODING_AGENT_MODEL env var, then zai-coding-plan/glm-4.7)
-    #[arg(long, short = 'm')]
+    /// Model passed to the agent; if omitted, the agent binary applies its own default
+    #[arg(long, short = 'm', value_name = "MODEL")]
     pub model: Option<String>,
 
     /// Prompt to run (if not provided, reads from stdin)
@@ -37,15 +37,8 @@ pub struct RunArgs {
 }
 
 pub fn execute(args: RunArgs) -> Result<()> {
-    let agent = args
-        .agent
-        .or_else(|| std::env::var("CODING_AGENT").ok())
-        .unwrap_or_else(|| "opencode".to_string());
-
-    let model = args
-        .model
-        .or_else(|| std::env::var("CODING_AGENT_MODEL").ok())
-        .unwrap_or_else(|| "zai-coding-plan/glm-4.7".to_string());
+    let agent = args.agent;
+    let model = args.model;
 
     let prompt = match args.prompt {
         Some(p) => p,
@@ -56,11 +49,24 @@ pub fn execute(args: RunArgs) -> Result<()> {
         }
     };
 
+    tracing::debug!(
+        agent = %agent,
+        model = ?model,
+        prompt_chars = prompt.len(),
+        yolo = args.yolo,
+        stream = args.stream,
+        events = args.events,
+        "aikit run dispatch"
+    );
+
     // Dry-run mode: validate inputs but don't execute
     if args.dry_run {
         println!("Dry-run mode enabled");
-        println!("Agent: {}", agent);
-        println!("Model: {}", model);
+        println!("Agent: {}", &agent);
+        println!(
+            "Model: {}",
+            model.as_deref().unwrap_or("(not set; agent default)")
+        );
         println!("Prompt length: {} chars", prompt.len());
         println!("Yolo mode: {}", args.yolo);
         println!("Stream mode: {}", args.stream);
@@ -69,10 +75,12 @@ pub fn execute(args: RunArgs) -> Result<()> {
         return Ok(());
     }
 
-    let options = RunOptions::new()
-        .with_model(model)
+    let mut options = RunOptions::new()
         .with_yolo(args.yolo)
         .with_stream(args.stream);
+    if let Some(ref m) = model {
+        options = options.with_model(m.clone());
+    }
 
     if args.events {
         match run_agent_events(&agent, &prompt, options, |event: AgentEvent| {
@@ -81,7 +89,8 @@ pub fn execute(args: RunArgs) -> Result<()> {
             }
         }) {
             Ok(result) => {
-                let exit_code = result.status.code().unwrap_or(1);
+                let _ = io::stderr().write_all(&result.stderr);
+                let exit_code = result.exit_code().unwrap_or(1);
                 std::process::exit(exit_code);
             }
             Err(RunError::AgentNotRunnable(key)) => {

--- a/tests/cli_integration_test.rs
+++ b/tests/cli_integration_test.rs
@@ -1002,6 +1002,18 @@ description = "Test package with invalid name"
         Ok(())
     }
 
+    /// `aikit run` requires `--agent` (no env-based default)
+    #[test]
+    fn test_aikit_run_requires_agent_flag() -> Result<(), Box<dyn std::error::Error>> {
+        cargo_bin_cmd!("aikit")
+            .args(["run", "-p", "hello"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--agent"));
+
+        Ok(())
+    }
+
     /// Test installing Newton template and verifying .newton/ layout
     #[test]
     fn test_install_newton_template() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/cli_parsing_test.rs
+++ b/tests/cli_parsing_test.rs
@@ -348,7 +348,7 @@ mod tests {
 
         match cli.command.unwrap() {
             aikit::cli::Commands::Run(args) => {
-                assert_eq!(args.agent, Some("opencode".to_string()));
+                assert_eq!(args.agent, "opencode");
                 assert_eq!(args.prompt, Some("hello".to_string()));
                 assert!(args.model.is_none());
                 assert!(!args.yolo);
@@ -377,7 +377,7 @@ mod tests {
 
         match cli.command.unwrap() {
             aikit::cli::Commands::Run(args) => {
-                assert_eq!(args.agent, Some("claude".to_string()));
+                assert_eq!(args.agent, "claude");
                 assert_eq!(args.model, Some("claude-3-opus".to_string()));
                 assert_eq!(args.prompt, Some("task".to_string()));
                 assert!(args.yolo);
@@ -404,6 +404,9 @@ mod tests {
 
         // Missing required version for release
         assert!(Cli::try_parse_from(["aikit", "release"]).is_err());
+
+        // `aikit run` requires --agent
+        assert!(Cli::try_parse_from(["aikit", "run", "-p", "hello"]).is_err());
     }
 
     /// Test that no arguments triggers help (clap exits with help)

--- a/tests/integration/commands.rs
+++ b/tests/integration/commands.rs
@@ -233,7 +233,10 @@ fn test_aikit_run_help() {
     assert!(output_str.contains("--prompt"));
     assert!(output_str.contains("--yolo"));
     assert!(output_str.contains("--stream"));
-    assert!(output_str.contains("CODING_AGENT"));
+    assert!(
+        !output_str.contains("CODING_AGENT"),
+        "run help must not document removed env vars"
+    );
 }
 
 /// Test run command with stdin (using dry-run mode)

--- a/webdocs/cli-commands.mdx
+++ b/webdocs/cli-commands.mdx
@@ -163,11 +163,6 @@ aikit run --agent claude -p "Refactor this function for clarity"
 # Read prompt from stdin
 echo "Add error handling to main.rs" | aikit run --agent opencode
 
-# Use environment variable defaults
-export CODING_AGENT=claude
-export CODING_AGENT_MODEL=claude-3-opus
-echo "Write tests" | aikit run
-
 # Enable agent-native streaming output
 aikit run --agent claude --stream -p "Summarize the project"
 
@@ -182,17 +177,15 @@ aikit run --agent claude --events --stream -p "Refactor this module"
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
-| `--agent` | `-a` | Agent to run | `CODING_AGENT` env var, then `opencode` |
-| `--model` | `-m` | Model to use | `CODING_AGENT_MODEL` env var, then `zai-coding-plan/glm-4.7` |
+| `--agent` | `-a` | Runnable agent key | **Required** |
+| `--model` | `-m` | Model passed to the agent | Omitted unless `-m` is set; agent binary defines behavior |
 | `--prompt` | `-p` | Prompt to run | Reads from stdin if omitted |
 | `--yolo` | | Auto-confirm, skip checks | `false` |
 | `--stream` | | Enable agent-native streaming output flags | `false` |
 | `--events` | | Emit NDJSON event stream to stdout | `false` |
 | `--debug` | | Verbose diagnostic output (global `aikit` flag; shown on `run` help) | `false` |
 
-**Environment variables:**
-- `CODING_AGENT` - Default agent (fallback: `opencode`)
-- `CODING_AGENT_MODEL` - Default model (fallback: `zai-coding-plan/glm-4.7`)
+`-a` / `--agent` is required. `aikit run` does not use `CODING_AGENT` or `CODING_AGENT_MODEL`. Without `-m`, no model is passed through to the agent.
 
 #### `--stream` vs `--events`
 


### PR DESCRIPTION
## Summary
- **Mandatory `-a/--agent`:** `aikit run` no longer reads `CODING_AGENT` or falls back to `opencode`.
- **Model:** Only passed when `-m` is set; removed `CODING_AGENT_MODEL` and hardcoded defaults.
- **Cursor `agent` hang:** Close the stdin pipe write end when the prompt is not written on stdin, so the child sees EOF (fixes blocking when stdout/stderr are pipes).
- **Observability:** `tracing` in aikit-sdk for spawn argv and run metadata; CLI initializes subscriber when `RUST_LOG` is set or global `--debug` is passed.
- **`--events`:** Write child stderr before exit so errors (e.g. invalid model) are visible.

## Tests
- Parsing and integration tests updated; `test_aikit_run_requires_agent_flag` added.

Docs: README and webdocs updated for CLI-only agent selection.