### PR TITLE
feat(agent): inject skills catalog into system context + agent definition parser (RFC #6/7)

### DIFF
--- a/aikit-agent/src/loop_runner.rs
+++ b/aikit-agent/src/loop_runner.rs
@@ -37,11 +37,13 @@ pub(crate) fn run_inner(
 ) -> Result<Vec<AgentInternalEvent>, AgentError> {
     let mut events = Vec::new();
 
-    // 1. Load AGENTS.md if present
-    let system_instructions = build_system_instructions(&config)?;
-
-    // 2. Discover skills using the appropriate backend
+    // 1. Discover skills using the appropriate backend
     let (skills, provider) = discover_skills_for_run(&config)?;
+
+    // 2. Build system instructions (includes skills catalog when skills are present)
+    let skill_metadatas: Vec<crate::skills::SkillMetadata> =
+        skills.iter().map(|s| s.metadata.clone()).collect();
+    let system_instructions = build_system_instructions(&config, &skill_metadatas)?;
 
     // 3. Build initial context packet
     let budget = TokenBudget {
@@ -195,7 +197,30 @@ pub(crate) fn discover_skills_for_run(
     }
 }
 
-fn build_system_instructions(config: &AgentConfig) -> Result<String, AgentError> {
+pub(crate) fn build_skills_catalog_block(
+    skills: &[crate::skills::SkillMetadata],
+) -> Option<String> {
+    if skills.is_empty() {
+        return None;
+    }
+    let mut lines = Vec::with_capacity(skills.len() + 4);
+    lines.push("## Available Skills".to_string());
+    lines.push(String::new());
+    lines.push(
+        "Use the `read_skill` tool with one of the following names to load a skill's instructions:"
+            .to_string(),
+    );
+    lines.push(String::new());
+    for skill in skills {
+        lines.push(format!("- `{}`: {}", skill.name, skill.description));
+    }
+    Some(lines.join("\n"))
+}
+
+fn build_system_instructions(
+    config: &AgentConfig,
+    skills: &[crate::skills::SkillMetadata],
+) -> Result<String, AgentError> {
     let mut parts = Vec::new();
     parts.push(
         "You are a helpful AI agent. Complete the requested task carefully and accurately."
@@ -207,6 +232,10 @@ fn build_system_instructions(config: &AgentConfig) -> Result<String, AgentError>
             reason: e.to_string(),
         })?;
         parts.push(content);
+    }
+
+    if let Some(catalog) = build_skills_catalog_block(skills) {
+        parts.push(catalog);
     }
 
     Ok(parts.join("\n\n"))
@@ -819,11 +848,83 @@ mod tests {
         std::fs::write(&md_path, "Custom system instructions for testing").unwrap();
         let mut config = make_config(&tmp, false);
         config.agents_md_path = Some(md_path);
-        let instructions = build_system_instructions(&config).unwrap();
+        let instructions = build_system_instructions(&config, &[]).unwrap();
         assert!(
             instructions.contains("Custom system instructions for testing"),
             "build_system_instructions should include md file content"
         );
+    }
+
+    fn make_skill(name: &str, description: &str) -> crate::skills::SkillMetadata {
+        crate::skills::SkillMetadata {
+            name: name.to_string(),
+            description: description.to_string(),
+            path: std::path::PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn test_catalog_block_empty_returns_none() {
+        assert!(build_skills_catalog_block(&[]).is_none());
+    }
+
+    #[test]
+    fn test_catalog_block_single_skill() {
+        let skills = vec![make_skill("git-summarize", "Summarize git activity")];
+        let block = build_skills_catalog_block(&skills).unwrap();
+        assert!(block.contains("## Available Skills"));
+        assert!(block.contains("- `git-summarize`: Summarize git activity"));
+    }
+
+    #[test]
+    fn test_catalog_block_multiple_skills() {
+        let skills = vec![
+            make_skill("skill-a", "First skill"),
+            make_skill("skill-b", "Second skill"),
+        ];
+        let block = build_skills_catalog_block(&skills).unwrap();
+        let pos_a = block.find("- `skill-a`: First skill").unwrap();
+        let pos_b = block.find("- `skill-b`: Second skill").unwrap();
+        assert!(pos_a < pos_b, "skill-a must appear before skill-b");
+    }
+
+    #[test]
+    fn test_catalog_block_empty_description() {
+        let skills = vec![make_skill("no-desc", "")];
+        let block = build_skills_catalog_block(&skills).unwrap();
+        assert!(
+            block.contains("- `no-desc`: "),
+            "empty description renders as colon-space"
+        );
+    }
+
+    #[test]
+    fn test_catalog_block_header_literal() {
+        let skills = vec![make_skill("x", "y")];
+        let block = build_skills_catalog_block(&skills).unwrap();
+        assert!(block.contains("## Available Skills"));
+    }
+
+    #[test]
+    fn test_build_system_instructions_catalog_after_agents_md() {
+        let tmp = TempDir::new().unwrap();
+        let md_path = tmp.path().join("AGENTS.md");
+        std::fs::write(&md_path, "AGENTS MD CONTENT").unwrap();
+        let mut config = make_config(&tmp, false);
+        config.agents_md_path = Some(md_path);
+        let skills = vec![
+            make_skill("skill-one", "Does thing one"),
+            make_skill("skill-two", "Does thing two"),
+        ];
+        let instructions = build_system_instructions(&config, &skills).unwrap();
+        let pos_agents = instructions.find("AGENTS MD CONTENT").unwrap();
+        let pos_catalog = instructions.find("## Available Skills").unwrap();
+        assert!(
+            pos_agents < pos_catalog,
+            "AGENTS.md content must appear before the skills catalog"
+        );
+        assert!(instructions.contains("- `skill-one`: Does thing one"));
+        assert!(instructions.contains("- `skill-two`: Does thing two"));
     }
 
     #[cfg(feature = "fastskill")]

--- a/aikit-agent/src/tools.rs
+++ b/aikit-agent/src/tools.rs
@@ -377,7 +377,12 @@ impl Tool for ReadSkillTool {
             tool_type: "function".to_string(),
             function: FunctionDefinition {
                 name: "read_skill".to_string(),
-                description: Some("Read the full content of a skill by name".to_string()),
+                description: Some(
+                    "Read the full content of a skill by name. \
+                     Valid skill names are listed in the system prompt under \
+                     '## Available Skills'. Using an unlisted name will return an error."
+                        .to_string(),
+                ),
                 parameters: serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -542,6 +547,22 @@ mod tests {
         let result = tool.execute(input, &ctx).unwrap();
         assert!(!result.is_error, "should succeed");
         assert_eq!(result.content, "mock skill content");
+    }
+
+    #[test]
+    fn test_read_skill_schema_description_references_catalog() {
+        let provider = Arc::new(MockProvider { content: None });
+        let tool = ReadSkillTool {
+            skills: vec![],
+            provider,
+        };
+        let schema = tool.schema();
+        let desc = schema.function.description.unwrap_or_default();
+        assert!(
+            desc.contains("'## Available Skills'"),
+            "read_skill description must reference '## Available Skills', got: {}",
+            desc
+        );
     }
 
     #[test]

--- a/src/core/agent_definition.rs
+++ b/src/core/agent_definition.rs
@@ -1,0 +1,668 @@
+//! Session / persisted agent definitions aligned with RFC goaikit/aikit#6.
+//!
+//! Parses Markdown + YAML front-matter (Claude-style body as system prompt) and
+//! ephemeral JSON maps (same fields as Claude `--agents`). VS CodeCopilot extras
+//! `user-invocable`, `disable-model-invocation`, and `argument-hint` are not
+//! read or surfaced; YAML may still contain them and parsing succeeds.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+
+/// Which subagents a coordinator may delegate to (VS Code **`agents`** field subset).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DelegationAllowlist {
+    /// `*` — any available delegate
+    All,
+    /// `[]` — no delegation from this definition
+    None,
+    /// Named agents only.
+    Names(Vec<String>),
+}
+
+/// Normalized definition after parsing and validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentDefinition {
+    pub name: String,
+    pub description: String,
+    pub prompt: String,
+    pub tools: Option<Vec<String>>,
+    pub disallowed_tools: Option<Vec<String>>,
+    pub model: Option<String>,
+    pub delegation: Option<DelegationAllowlist>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    MissingField { field: &'static str },
+    InvalidJson(String),
+    InvalidYaml(String),
+    InvalidMarkdown(String),
+    EmptyDocument,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::MissingField { field } => write!(f, "missing required field `{}`", field),
+            ParseError::InvalidJson(s) => write!(f, "invalid JSON: {}", s),
+            ParseError::InvalidYaml(s) => write!(f, "invalid YAML: {}", s),
+            ParseError::InvalidMarkdown(s) => write!(f, "{}", s),
+            ParseError::EmptyDocument => write!(f, "empty document"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawJsonAgent {
+    name: Option<String>,
+    description: Option<String>,
+    prompt: Option<String>,
+    #[serde(default)]
+    tools: Option<JsonValue>,
+    #[serde(default, alias = "disallowed_tools")]
+    disallowed_tools: Option<JsonValue>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    agents: Option<JsonValue>,
+}
+
+fn normalize_tool_list(v: Option<JsonValue>) -> Result<Option<Vec<String>>, ParseError> {
+    match v {
+        None => Ok(None),
+        Some(JsonValue::Null) => Ok(None),
+        Some(JsonValue::Array(a)) => {
+            let mut out = Vec::with_capacity(a.len());
+            for item in a {
+                match item {
+                    JsonValue::String(s) if !s.is_empty() => out.push(s),
+                    JsonValue::String(_) => {}
+                    _ => {
+                        return Err(ParseError::InvalidJson(
+                            "tools entries must be strings".into(),
+                        ))
+                    }
+                }
+            }
+            Ok(Some(out))
+        }
+        Some(JsonValue::String(s)) => Ok(Some(split_comma_tools(&s))),
+        _ => Err(ParseError::InvalidJson(
+            "tools must be a JSON array or string".into(),
+        )),
+    }
+}
+
+fn split_comma_tools(s: &str) -> Vec<String> {
+    s.split([',', ';'])
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_string())
+        .collect()
+}
+
+fn delegation_from_json(v: Option<JsonValue>) -> Result<Option<DelegationAllowlist>, ParseError> {
+    match v {
+        None | Some(JsonValue::Null) => Ok(None),
+        Some(JsonValue::String(s)) => {
+            if s == "*" {
+                Ok(Some(DelegationAllowlist::All))
+            } else {
+                Err(ParseError::InvalidJson(
+                    "agents as string must be '*'".into(),
+                ))
+            }
+        }
+        Some(JsonValue::Array(a)) => {
+            if a.is_empty() {
+                return Ok(Some(DelegationAllowlist::None));
+            }
+            let mut names = Vec::new();
+            for item in a {
+                match item {
+                    JsonValue::String(s) if !s.is_empty() => names.push(s),
+                    JsonValue::String(_) => {}
+                    _ => {
+                        return Err(ParseError::InvalidJson(
+                            "agents list entries must be strings".into(),
+                        ))
+                    }
+                }
+            }
+            Ok(Some(DelegationAllowlist::Names(names)))
+        }
+        _ => Err(ParseError::InvalidJson(
+            "agents must be '*', [] or a string array".into(),
+        )),
+    }
+}
+
+fn raw_json_to_def(id: &str, raw: RawJsonAgent) -> Result<AgentDefinition, ParseError> {
+    let name = raw
+        .name
+        .unwrap_or_else(|| id.to_string())
+        .trim()
+        .to_string();
+    if name.is_empty() {
+        return Err(ParseError::MissingField { field: "name" });
+    }
+    let description = raw
+        .description
+        .ok_or(ParseError::MissingField {
+            field: "description",
+        })?
+        .trim()
+        .to_string();
+    if description.is_empty() {
+        return Err(ParseError::MissingField {
+            field: "description",
+        });
+    }
+    let prompt = raw.prompt.unwrap_or_default().trim().to_string();
+
+    Ok(AgentDefinition {
+        name,
+        description,
+        prompt,
+        tools: normalize_tool_list(raw.tools)?,
+        disallowed_tools: normalize_tool_list(raw.disallowed_tools)?,
+        model: raw
+            .model
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty()),
+        delegation: delegation_from_json(raw.agents)?,
+    })
+}
+
+/// Parse Claude-style `--agents` JSON: `{ "<id>": { ... per-agent fields } }`.
+///
+/// The returned map is keyed by **outer JSON id** so session merges and overrides behave as in the RFC.
+pub fn parse_session_agents_json(s: &str) -> Result<HashMap<String, AgentDefinition>, ParseError> {
+    let value: JsonValue =
+        serde_json::from_str(s).map_err(|e| ParseError::InvalidJson(e.to_string()))?;
+    let map = value.as_object().ok_or_else(|| {
+        ParseError::InvalidJson("session-agents JSON must be a single object".into())
+    })?;
+
+    let mut out = HashMap::new();
+    for (key, agent_val) in map {
+        let raw: RawJsonAgent = serde_json::from_value(agent_val.clone())
+            .map_err(|e| ParseError::InvalidJson(format!("agent `{}`: {}", key, e)))?;
+        let def = raw_json_to_def(key, raw)?;
+        out.insert(key.clone(), def);
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Deserialize)]
+struct YamlFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    tools: Option<serde_yaml::Value>,
+    #[serde(default, alias = "disallowedTools")]
+    disallowed_tools: Option<serde_yaml::Value>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    agents: Option<serde_yaml::Value>,
+}
+
+fn tools_from_yaml(v: serde_yaml::Value) -> Result<Vec<String>, ParseError> {
+    match v {
+        serde_yaml::Value::Sequence(seq) => {
+            let mut out = Vec::new();
+            for item in seq {
+                match item {
+                    serde_yaml::Value::String(s) if !s.is_empty() => out.push(s),
+                    serde_yaml::Value::Null | serde_yaml::Value::String(_) => {}
+                    _ => {
+                        return Err(ParseError::InvalidYaml(
+                            "tools sequence must contain only strings".into(),
+                        ))
+                    }
+                }
+            }
+            Ok(out)
+        }
+        serde_yaml::Value::String(s) => Ok(split_comma_tools(&s)),
+        serde_yaml::Value::Bool(_) => Err(ParseError::InvalidYaml("invalid tools value".into())),
+        _ => Err(ParseError::InvalidYaml(
+            "tools must be a YAML sequence or string".into(),
+        )),
+    }
+}
+
+fn normalize_yaml_tools(v: Option<serde_yaml::Value>) -> Result<Option<Vec<String>>, ParseError> {
+    match v {
+        None => Ok(None),
+        Some(serde_yaml::Value::Null) => Ok(None),
+        Some(v) => Ok(Some(tools_from_yaml(v)?)),
+    }
+}
+
+fn delegation_from_yaml(
+    v: Option<serde_yaml::Value>,
+) -> Result<Option<DelegationAllowlist>, ParseError> {
+    match v {
+        None | Some(serde_yaml::Value::Null) => Ok(None),
+        Some(serde_yaml::Value::String(s)) => {
+            if s == "*" {
+                Ok(Some(DelegationAllowlist::All))
+            } else {
+                Ok(Some(DelegationAllowlist::Names(vec![s])))
+            }
+        }
+        Some(serde_yaml::Value::Sequence(seq)) => {
+            if seq.is_empty() {
+                return Ok(Some(DelegationAllowlist::None));
+            }
+            let mut names = Vec::new();
+            for item in seq {
+                match item {
+                    serde_yaml::Value::String(s) if !s.is_empty() => names.push(s),
+                    serde_yaml::Value::String(_) => {}
+                    _ => {
+                        return Err(ParseError::InvalidYaml(
+                            "agents sequence must contain only strings".into(),
+                        ))
+                    }
+                }
+            }
+            Ok(Some(DelegationAllowlist::Names(names)))
+        }
+        _ => Err(ParseError::InvalidYaml(
+            "agents must be '*', a string, or a sequence".into(),
+        )),
+    }
+}
+
+/// Parse Markdown with `---` YAML front-matter; body is the system prompt unless `prompt:` is set in front-matter.
+pub fn parse_agent_markdown(content: &str) -> Result<AgentDefinition, ParseError> {
+    let content = content.trim_start();
+    if content.is_empty() {
+        return Err(ParseError::EmptyDocument);
+    }
+
+    let (yaml_part, body) = if content.starts_with("---") {
+        let after_first = content.strip_prefix("---").unwrap();
+        let end = after_first.find("\n---").ok_or_else(|| {
+            ParseError::InvalidMarkdown("missing closing --- for YAML frontmatter".into())
+        })?;
+        let yaml_text = after_first[..end].trim();
+        let rest = after_first[end + "\n---".len()..].trim_start();
+        (Some(yaml_text), rest)
+    } else {
+        (None, content)
+    };
+
+    let body = body.trim();
+    let ym: YamlFrontmatter = match yaml_part {
+        None => YamlFrontmatter {
+            name: None,
+            description: None,
+            prompt: None,
+            tools: None,
+            disallowed_tools: None,
+            model: None,
+            agents: None,
+        },
+        Some(txt) => {
+            serde_yaml::from_str(txt).map_err(|e| ParseError::InvalidYaml(e.to_string()))?
+        }
+    };
+
+    let name = ym
+        .name
+        .clone()
+        .ok_or(ParseError::MissingField { field: "name" })?
+        .trim()
+        .to_string();
+    if name.is_empty() {
+        return Err(ParseError::MissingField { field: "name" });
+    }
+    let description = ym
+        .description
+        .clone()
+        .ok_or(ParseError::MissingField {
+            field: "description",
+        })?
+        .trim()
+        .to_string();
+    if description.is_empty() {
+        return Err(ParseError::MissingField {
+            field: "description",
+        });
+    }
+
+    let prompt = ym
+        .prompt
+        .clone()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| body.to_string());
+
+    if prompt.is_empty() {
+        return Err(ParseError::MissingField { field: "prompt" });
+    }
+
+    Ok(AgentDefinition {
+        name,
+        description,
+        prompt,
+        tools: normalize_yaml_tools(ym.tools)?,
+        disallowed_tools: normalize_yaml_tools(ym.disallowed_tools)?,
+        model: ym
+            .model
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty()),
+        delegation: delegation_from_yaml(ym.agents)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_minimal_body_prompt() {
+        let md = r"---
+name: code-reviewer
+description: Runs focused reviews after edits
+---
+
+You review code.";
+        let d = parse_agent_markdown(md).unwrap();
+        assert_eq!(d.name, "code-reviewer");
+        assert_eq!(d.description, "Runs focused reviews after edits");
+        assert_eq!(d.prompt.trim(), "You review code.");
+        assert!(d.tools.is_none());
+        assert!(d.disallowed_tools.is_none());
+        assert!(d.model.is_none());
+        assert!(d.delegation.is_none());
+    }
+
+    #[test]
+    fn markdown_full_frontmatter_tools_model_agents_star() {
+        let md = r"---
+name: coord
+description: Coordinates specialized workers
+tools: ['agent', 'read', 'search']
+model: inherit
+disallowedTools: Write, Edit
+agents: '*'
+---
+
+Route work.";
+        let d = parse_agent_markdown(md).unwrap();
+        assert_eq!(d.name, "coord");
+        assert_eq!(
+            d.tools.as_ref().unwrap(),
+            &vec![
+                "agent".to_string(),
+                "read".to_string(),
+                "search".to_string()
+            ]
+        );
+        assert_eq!(
+            d.disallowed_tools.as_ref().unwrap(),
+            &vec!["Write".to_string(), "Edit".to_string()]
+        );
+        assert_eq!(d.model.as_deref(), Some("inherit"));
+        assert_eq!(d.delegation, Some(DelegationAllowlist::All));
+    }
+
+    #[test]
+    fn markdown_agents_empty_list_means_no_delegation() {
+        let md = r"---
+name: leaf
+description: No sub-delegation
+tools: [Read]
+agents: []
+---
+
+Do work.";
+        let d = parse_agent_markdown(md).unwrap();
+        assert_eq!(d.delegation, Some(DelegationAllowlist::None));
+    }
+
+    #[test]
+    fn markdown_agents_named_list() {
+        let md = r"---
+name: tdd
+description: TDD flow
+tools: [agent]
+agents: [Red, Green, Refactor]
+---
+
+Implement with TDD.";
+        let d = parse_agent_markdown(md).unwrap();
+        assert_eq!(
+            d.delegation,
+            Some(DelegationAllowlist::Names(vec![
+                "Red".into(),
+                "Green".into(),
+                "Refactor".into()
+            ]))
+        );
+    }
+
+    #[test]
+    fn markdown_tools_inline_string() {
+        let md = r"---
+name: explore
+description: Read-only search
+tools: Read, Grep, Glob
+---
+
+Explore.";
+        let d = parse_agent_markdown(md).unwrap();
+        assert_eq!(
+            d.tools.as_ref().unwrap(),
+            &vec!["Read".to_string(), "Grep".to_string(), "Glob".to_string()]
+        );
+    }
+
+    #[test]
+    fn markdown_ignores_vscode_dropped_keys_still_parses() {
+        let md = r"---
+name: internal-helper
+description: Hidden from interoperability layer
+user-invocable: false
+disable-model-invocation: true
+argument-hint: foo bar
+tools: [Read]
+---
+
+Only subagents.";
+        let d = parse_agent_markdown(md).unwrap();
+        assert_eq!(d.name, "internal-helper");
+        assert_eq!(d.tools.as_ref().unwrap(), &vec!["Read".to_string()]);
+        assert!(d.prompt.contains("Only subagents."));
+    }
+
+    #[test]
+    fn markdown_missing_description_errors() {
+        let md = r"---
+name: x
+---
+
+body";
+        assert!(matches!(
+            parse_agent_markdown(md),
+            Err(ParseError::MissingField {
+                field: "description"
+            })
+        ));
+    }
+
+    #[test]
+    fn markdown_explicit_prompt_overrides_body() {
+        let md = r"---
+name: x
+description: d
+prompt: |
+
+  Override prompt here
+---
+
+Ignored body.";
+        let d = parse_agent_markdown(md).unwrap();
+        assert!(d.prompt.contains("Override prompt"));
+        assert!(!d.prompt.contains("Ignored body."));
+    }
+
+    #[test]
+    fn markdown_no_prompt_in_fm_and_empty_body_errors() {
+        let md = r"---
+name: x
+description: y
+---
+
+
+";
+        assert!(matches!(
+            parse_agent_markdown(md),
+            Err(ParseError::MissingField { field: "prompt" })
+        ));
+    }
+
+    #[test]
+    fn json_session_single_agent_full() {
+        let j = r#"{
+  "worker": {
+    "description": "Does work",
+    "prompt": "You are worker",
+    "tools": ["Read", "Edit"],
+    "disallowedTools": ["Bash"],
+    "model": "sonnet",
+    "agents": ["a", "b"]
+  }
+}"#;
+        let m = parse_session_agents_json(j).unwrap();
+        let d = m.get("worker").expect("outer JSON key");
+        assert_eq!(d.name, "worker");
+        assert_eq!(d.description, "Does work");
+        assert_eq!(d.prompt, "You are worker");
+        assert_eq!(
+            d.delegation,
+            Some(DelegationAllowlist::Names(vec!["a".into(), "b".into()]))
+        );
+    }
+
+    #[test]
+    fn json_name_defaults_to_map_key() {
+        let j = r#"{"my-key": {"description": "d", "prompt": "p"}}"#;
+        let m = parse_session_agents_json(j).unwrap();
+        assert_eq!(m["my-key"].name, "my-key");
+    }
+
+    #[test]
+    fn json_agents_star_and_empty() {
+        let j = r#"{
+  "a": {"description": "d1", "prompt": "p", "agents": "*"},
+  "b": {"description": "d2", "prompt": "p", "agents": []}
+}"#;
+        let m = parse_session_agents_json(j).unwrap();
+        assert_eq!(m["a"].delegation, Some(DelegationAllowlist::All));
+        assert_eq!(m["b"].delegation, Some(DelegationAllowlist::None));
+    }
+
+    #[test]
+    fn json_tools_string_comma_split() {
+        let j = r#"{"x": {"description": "d", "prompt": "p", "tools": "Read, Grep"}}"#;
+        let m = parse_session_agents_json(j).unwrap();
+        assert_eq!(m["x"].tools, Some(vec!["Read".into(), "Grep".into()]));
+    }
+
+    #[test]
+    fn json_invalid_missing_description() {
+        let j = r#"{"x": {"prompt": "only"}}"#;
+        assert!(matches!(
+            parse_session_agents_json(j),
+            Err(ParseError::MissingField {
+                field: "description"
+            })
+        ));
+    }
+
+    #[test]
+    fn json_invalid_not_object() {
+        let j = r#"[]"#;
+        assert!(matches!(
+            parse_session_agents_json(j),
+            Err(ParseError::InvalidJson(_))
+        ));
+    }
+
+    #[test]
+    fn markdown_invalid_unclosed_frontmatter() {
+        let md = r"---
+name: x
+description: y
+Still open";
+        assert!(parse_agent_markdown(md).is_err());
+    }
+
+    #[test]
+    fn json_agents_string_only_star_allowed() {
+        let j = r#"{"x": {"description": "d", "prompt": "p", "agents": "nope"}}"#;
+        assert!(parse_session_agents_json(j).is_err());
+    }
+
+    #[test]
+    fn json_tools_invalid_type() {
+        let j = r#"{"x": {"description": "d", "prompt": "p", "tools": 3}}"#;
+        assert!(parse_session_agents_json(j).is_err());
+    }
+
+    #[test]
+    fn json_multi_agent_merge_map() {
+        let j = r#"{
+  "a": {"description": "da", "prompt": "pa"},
+  "b": {"description": "db", "prompt": "pb", "name": "override-b"}
+}"#;
+        let m = parse_session_agents_json(j).unwrap();
+        assert_eq!(m.len(), 2);
+        assert_eq!(m["a"].name, "a");
+        assert_eq!(m["b"].name, "override-b");
+        assert_eq!(m["b"].description, "db");
+    }
+
+    #[test]
+    fn markdown_snake_disallowed_tools_key() {
+        let md = r"---
+name: z
+description: zd
+disallowed_tools: [Write]
+---
+
+Body.";
+        let d = parse_agent_markdown(md).unwrap();
+        assert_eq!(d.disallowed_tools, Some(vec!["Write".into()]));
+    }
+
+    #[test]
+    fn markdown_agents_single_string_other_than_star_is_name() {
+        let md = r"---
+name: only-one
+description: d
+agents: SingleAgent
+---
+
+x";
+        let d = parse_agent_markdown(md).unwrap();
+        assert_eq!(
+            d.delegation,
+            Some(DelegationAllowlist::Names(vec!["SingleAgent".into()]))
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,8 @@
 //! Core functionality for AIKIT
 
 pub mod agent;
+#[allow(dead_code)] // parsers used by RFC #6 CLI path; exercised in unit tests and lib re-exports
+pub mod agent_definition;
 pub mod fallback;
 pub mod filesystem;
 pub mod git;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,10 @@ pub mod github;
 pub mod models;
 pub mod tui;
 
+pub use core::agent_definition::{
+    parse_agent_markdown, parse_session_agents_json, AgentDefinition, DelegationAllowlist,
+    ParseError,
+};
 pub use error::AikError;
 /// Re-export commonly used types
 pub use models::{


### PR DESCRIPTION
## Summary

- **Skills catalog in system prompt**: Discovered skills are now listed in the agent's system context under an `## Available Skills` section, so the model knows which skills are available before calling `read_skill`. Skills discovery runs first; the resulting metadata is forwarded to `build_system_instructions` via the new `build_skills_catalog_block` helper.
- **`read_skill` description updated**: Tool description now explicitly references `## Available Skills` so the model knows where to look for valid names.
- **Agent definition parser (RFC #6)**: New `src/core/agent_definition.rs` module implements `parse_agent_markdown` (Markdown + YAML front-matter) and `parse_session_agents_json` (Claude-style `--agents` JSON map). Supports `tools`, `disallowedTools`/`disallowed_tools`, `model`, and `agents` (delegation allowlist: `*`, `[]`, or named list). VS Code-only keys (`user-invocable`, `disable-model-invocation`, `argument-hint`) are silently ignored. Types re-exported from `src/lib.rs`.

## Test plan

- [x] All 322 tests pass (pre-push hook)
- [x] `test_catalog_block_*` — catalog block rendering (empty, single, multiple, empty description, header literal)
- [x] `test_build_system_instructions_catalog_after_agents_md` — ordering: AGENTS.md content precedes catalog
- [x] `test_read_skill_schema_description_references_catalog` — tool description references section header
- [x] `markdown_*` / `json_*` — full coverage of both parser paths including edge cases (unclosed frontmatter, missing fields, star/empty/named delegation, VS Code dropped keys, snake_case alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)