### PR TITLE
fix(aikit-sdk): harden quota normalization contract and bump to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,14 @@ Agent selection is **CLI-only**: `-a` / `--agent` is required. `aikit run` does 
 - **`raw_line`**: UTF-8 text line that is not JSON
 - **`raw_bytes`**: non-UTF-8 data as a byte array in JSON
 - **`token_usage_line`**: normalized token counts extracted from a preceding `json_line` (fields: `usage`, `source`, `raw_agent_line_seq`)
+- **`quota_exceeded`**: emitted when the agent reports a rate-limit or quota exhaustion; carries `QuotaExceededInfo` (`agent_key`, `category`, `raw_message`); consumers MUST NOT parse provider text themselves — aikit-sdk owns all quota detection
 
 Example lines:
 
 ```json
 {"agent_key":"claude","seq":1,"stream":"stdout","payload":{"json_line":{"type":"progress","message":"Starting..."}}}
 {"agent_key":"claude","seq":2,"stream":"stdout","payload":{"token_usage_line":{"usage":{"input_tokens":100,"output_tokens":50,"total_tokens":150,"cache_read_tokens":null,"cache_creation_tokens":null,"reasoning_tokens":null},"source":"Claude","raw_agent_line_seq":1}}}
+{"agent_key":"claude","seq":3,"stream":"stderr","payload":{"quota_exceeded":{"agent_key":"claude","category":"Hourly","raw_message":"Claude usage limit reached. Your limit will reset at 5 PM hour."}}}
 ```
 
 On **Windows**, the Cursor agent is often `agent.cmd`. If spawn fails, set **`AIKIT_CURSOR_AGENT`** to the full path (see [aikit-sdk README: Windows Configuration](aikit-sdk/README.md#windows-configuration)).

--- a/aikit-sdk/Cargo.toml
+++ b/aikit-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aikit-sdk"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust gateway: agent catalog, paths, deploy, detection, and run/event APIs for coding-agent CLIs"

--- a/aikit-sdk/tests/streaming_agents.rs
+++ b/aikit-sdk/tests/streaming_agents.rs
@@ -555,6 +555,41 @@ printf '{"type":"result","subtype":"success","result":"OK"}\n'"#,
     }
 
     #[test]
+    fn test_stub_claude_quota_uuid_false_positive() {
+        // UUID false-positive regression: successful output containing "429" only inside a UUID
+        // field and a `usage` telemetry field must NOT produce QuotaExceededInfo.
+        let _guard = PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        write_stub(
+            dir.path(),
+            "claude",
+            r#"printf '{"type":"result","subtype":"success","request_id":"req-429-abc123-uuid","usage":{"input_tokens":100,"output_tokens":50},"result":"All done."}\n'"#,
+        );
+
+        let mut events = Vec::new();
+        let result = with_stub_path(dir.path(), || {
+            run_agent_events("claude", "test", RunOptions::default(), |ev| {
+                events.push(ev)
+            })
+        });
+
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+        let rr = result.unwrap();
+        assert!(
+            rr.quota_exceeded.is_none(),
+            "UUID-only '429' must not produce QuotaExceededInfo"
+        );
+        let quota_events: Vec<_> = events
+            .iter()
+            .filter(|ev| matches!(ev.payload, AgentEventPayload::QuotaExceeded { .. }))
+            .collect();
+        assert!(
+            quota_events.is_empty(),
+            "UUID-only '429' must not emit QuotaExceeded events"
+        );
+    }
+
+    #[test]
     fn test_run_agent_returns_quota_exceeded_error() {
         let _guard = PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- Adds UUID false-positive regression test: successful output with `429` only inside a UUID field must not produce `QuotaExceededInfo`
- Documents `quota_exceeded` as the normalized NDJSON event consumers should read
- Bumps aikit-sdk from 0.2.0 to 0.2.1

## Test plan
- [ ] `cargo test -p aikit-sdk --test streaming_agents` passes including `test_stub_claude_quota_uuid_false_positive`
- [ ] `cargo test -p aikit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)