### PR TITLE
feat(aikit): MCP deploy for six agents and mcp CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,48 @@ aikit list
 | `aikit package build` | Build distributable package (output: dist/ or .genreleases/) |
 | `aikit package publish <owner/repo>` | Publish package to GitHub (release and assets) |
 | `aikit llm` | Invoke an LLM via OpenAI-compatible API (supports streaming and JSON output) |
+| `aikit mcp list` | Show which agents support MCP config merge and target file paths |
+| `aikit mcp add` | Merge one MCP server into agent config: Cursor / Claude / Gemini / VS Code (`servers`) / OpenCode (`mcp`) / Codex (TOML `mcp_servers`) |
 | `aikit release <version>` | Create GitHub release from .genreleases/ (e.g. v1.0.0) |
+
+## MCP servers (`aikit mcp`)
+
+The catalog has **18** agents; **`aikit mcp add`** supports **six** keys: `cursor-agent` (alias `cursor`), `claude`, `gemini`, `copilot` (alias `vscode`), `opencode`, `codex`. Run `aikit mcp list` for paths.
+
+| Agent key | Scope project | Scope global |
+|-----------|---------------|----------------|
+| `cursor-agent` | `.cursor/mcp.json` (`mcpServers`) | `~/.cursor/mcp.json` |
+| `claude` | `.mcp.json` | `~/.claude.json` (`mcpServers`) |
+| `gemini` | `.gemini/settings.json` | `~/.gemini/settings.json` |
+| `copilot` | `.vscode/mcp.json` (`servers`, VS Code shape) | VS Code `Code/User/mcp.json` (OS-specific) |
+| `opencode` | `opencode.json` (`mcp`) | XDG `.../opencode/opencode.json` |
+| `codex` | `.codex/config.toml` | `~/.codex/config.toml` |
+
+```bash
+aikit mcp list
+
+# Cursor (HTTP)
+aikit mcp add --agent cursor-agent --scope project --name newton \
+  --url http://127.0.0.1:8730/mcp
+
+# Claude Code (stdio)
+aikit mcp add --agent claude --scope project --name gh \
+  --command npx --arg -y --arg @modelcontextprotocol/server-github
+
+# Gemini CLI (merges into settings.json)
+aikit mcp add --agent gemini --scope project --name demo --url http://127.0.0.1:8080/mcp
+
+# VS Code / Copilot (`type` + `servers` entry)
+aikit mcp add --agent copilot --scope project --name fetch --command uvx --arg mcp-server-fetch
+
+# OpenCode (`mcp.<name>` local or remote)
+aikit mcp add --agent opencode --scope project --name tools --command npx --arg -y --arg @pkg/mcp
+
+# Codex (`[mcp_servers.name]` in config.toml)
+aikit mcp add --agent codex --scope project --name ctx7 --command npx --arg -y --arg @upstash/context7-mcp
+```
+
+Use `--overwrite` to replace an existing server id. Repeat `--arg`, `--env KEY=val`, `--header KEY=val` as needed. **Windows:** global `copilot` uses `%APPDATA%\Code\User\mcp.json`, or `<home>\AppData\Roaming\...` if `APPDATA` is unset; global OpenCode uses `%APPDATA%` / Roaming when `config_dir()` is unavailable.
 
 ## Creating and publishing packages
 

--- a/aikit-py/CONTRIBUTING.md
+++ b/aikit-py/CONTRIBUTING.md
@@ -23,6 +23,12 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test -p aikit-py
 ```
 
+Python tests (`tests/test_aikit_py.py`, `tests/test_mcp_deploy.py`) require an editable install:
+
+```bash
+cd aikit-py && maturin develop && pytest tests/
+```
+
 ## Guidelines
 
 - Preserve API naming and output shapes already exposed in `aikit_py`.

--- a/aikit-py/README.md
+++ b/aikit-py/README.md
@@ -6,6 +6,7 @@ It exposes the same core capabilities from Python:
 - agent catalog lookup
 - deterministic path resolution
 - command/skill/subagent deployment
+- MCP server entries merged into agent config files (JSON/TOML)
 - runnable-agent availability checks
 - agent execution (`run_agent`)
 - streaming callbacks (`run_agent_events_py`)
@@ -21,6 +22,12 @@ It exposes the same core capabilities from Python:
 pip install aikit-py
 ```
 
+With **uv**:
+
+```bash
+uv add aikit-py
+```
+
 For local development from this workspace:
 
 ```bash
@@ -28,6 +35,7 @@ cd aikit-py
 python -m venv .venv
 source .venv/bin/activate
 pip install -U pip maturin
+# or: uv pip install maturin
 maturin develop
 ```
 
@@ -51,6 +59,60 @@ with TemporaryDirectory() as root:
     )
     print(path)
 ```
+
+## MCP server config (merge)
+
+Supported agent keys match the Rust SDK: `cursor-agent`, `claude`, `gemini`, `copilot`, `opencode`, `codex`. Aliases `cursor` and `vscode` are normalized like the CLI.
+
+- `mcp_config_path(agent_key, scope, project_root)` returns the config file path. `scope` is `"project"` or `"global"`.
+- `add_mcp_server(...)` merges one server (stdio or HTTP) into that file. Raises `McpDeployError` on I/O, parse, duplicate name (unless `overwrite=True`), or invalid input.
+- `mcp_supported_agents()` returns rows with `agent_key`, `display_name`, `project_config_path`, `global_config_path`.
+- `mcp_supported_agent_keys()` returns the key list.
+- `normalize_mcp_agent_key(key)` returns the catalog key string.
+- `mcp_parse_env_pairs` / `mcp_parse_header_pairs` parse `KEY=value` lines into a string map (same rules as `aikit mcp add`).
+
+```python
+import json
+import aikit_py
+from tempfile import TemporaryDirectory
+
+with TemporaryDirectory() as root:
+    written = aikit_py.add_mcp_server(
+        "claude",
+        root,
+        "my-tools",
+        scope="project",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-filesystem", root],
+        env=None,
+        url=None,
+        headers=None,
+        overwrite=False,
+    )
+    with open(written) as f:
+        cfg = json.load(f)
+    assert "my-tools" in cfg["mcpServers"]
+```
+
+Global scope uses the real user home (same as the CLI). Use project scope in tests and automation so paths stay inside a temp directory.
+
+HTTP example:
+
+```python
+written = aikit_py.add_mcp_server(
+    "gemini",
+    root,
+    "remote",
+    scope="project",
+    url="http://127.0.0.1:8730/mcp",
+    headers={"Authorization": "Bearer token"},
+    overwrite=False,
+)
+```
+
+Errors: path/catalog failures raise `McpDeployError`; deploy helpers raise `DeployError`.
+
+Runnable script: `examples/mcp_deploy_stdio.py`. MCP narrative for the doc site: `../webdocs/mcp.mdx`. Rust API tables: [aikit-sdk README](../aikit-sdk/README.md#mcp-config-merge).
 
 ## Run an agent
 
@@ -106,6 +168,7 @@ Event payload contains exactly one of:
 - `all_agents()`, `agent(key)`, `validate_agent_key(key)`
 - `commands_dir(...)`, `skill_dir(...)`, `subagent_path(...)`
 - `deploy_command(...)`, `deploy_skill(...)`, `deploy_subagent(...)`
+- `mcp_config_path`, `add_mcp_server`, `mcp_supported_agents`, `mcp_supported_agent_keys`, `normalize_mcp_agent_key`, `mcp_parse_env_pairs`, `mcp_parse_header_pairs`
 - `run_agent(...)`, `run_agent_events_py(...)`
 - `runnable_agents_list()`, `is_runnable_py(key)`
 - `is_agent_available(key)`, `get_installed_agents()`, `get_agent_status()`
@@ -116,338 +179,18 @@ From workspace root:
 
 ```bash
 cargo test -p aikit-py
+cd aikit-py && maturin develop && pytest tests/
 ```
 
-Python integration test file is `aikit-py/tests/test_aikit_py.py`.
+Python tests: `aikit-py/tests/test_aikit_py.py`, `aikit-py/tests/test_mcp_deploy.py`.
 
 ## Related docs
 
 - Workspace overview: `../README.md`
 - Rust gateway: `../aikit-sdk/README.md`
+- MCP (site source): `../webdocs/mcp.mdx`
 - Contributor guide: `CONTRIBUTING.md`
 
 ## License
 
 Apache-2.0
-# aikit-py
-
-Python bindings for **[aikit-sdk](../aikit-sdk/README.md)**: the same **programmatic gateway** from Python. Use it to query the **agent catalog**, **resolve paths**, **deploy** commands/skills/subagents, **check** which runnable agent CLIs are installed, and **run** agents with either **buffered** output (`run_agent`) or **per-event callbacks** (`run_agent_events_py`) matching the NDJSON shape of `aikit run --events` (including `token_usage_line` when the agent emits parseable usage).
-
-## Requirements
-
-- Python 3.9+
-- Rust toolchain (for building from source or development)
-
-## Installation
-
-You can install `aikit-py` using `pip`, `poetry`, or `uv`.
-
-### pip
-
-```bash
-# It's recommended to use a virtual environment
-python -m venv .venv
-source .venv/bin/activate
-pip install aikit-py
-```
-
-### poetry
-
-```bash
-# Add to an existing project
-poetry add aikit-py
-
-# Or create a new project and add it
-poetry new my-aikit-project
-cd my-aikit-project
-poetry add aikit-py
-```
-
-### uv
-
-```bash
-# In your project directory
-uv add aikit-py
-
-# Global installation (use with caution)
-uv pip install aikit-py
-```
-
-## Quick Start
-
-Here's a quick example to get started with `aikit-py`:
-
-```python
-import aikit_py
-import tempfile
-import os
-
-# List all available agents
-print("Available Agents:")
-for agent_config in aikit_py.all_agents():
-    print(f"- {agent_config.name} (Key: {agent_config.key()})")
-
-# Get a specific agent's configuration
-claude_config = aikit_py.agent("claude")
-if claude_config:
-    print(f"
-Claude Agent Commands Dir: {claude_config.commands_dir}")
-
-# Validate an agent key
-try:
-    aikit_py.validate_agent_key("claude")
-    print("
-'claude' is a valid agent key.")
-except aikit_py.DeployError as e:
-    print(f"
-Error: {str(e)}")
-
-# Deploy a command
-with tempfile.TemporaryDirectory() as project_root:
-    command_content = "# My Test Command
-print('Hello from aikit_py!')"
-    command_path = aikit_py.deploy_command("claude", project_root, "my-python-command", command_content)
-    print(f"
-Deployed command to: {command_path}")
-    # Verify content
-    with open(command_path, "r") as f:
-        print(f"Command content:
-{f.read()}")
-
-```
-
-## Adding a new skill
-
-You can programmatically add new skills to agents using `deploy_skill`. This function creates the skill's directory structure and writes the `SKILL.md` content, along with any optional scripts.
-
-```python
-import aikit_py
-import tempfile
-import os
-
-with tempfile.TemporaryDirectory() as project_root:
-    agent_key = "cursor-agent" # An agent that supports skills
-    skill_name = "my-new-python-skill"
-    skill_md_content = """---
-name: My New Python Skill
-description: A skill deployed via aikit-py.
-license: Apache-2.0
----
-This is the content of my new skill, written from Python.
-"""
-    # Optional scripts to be included with the skill
-    optional_scripts = [
-        ("setup.sh", b"#!/bin/sh
-echo 'Running skill setup'"),
-        ("run.py", b"#!/usr/bin/env python
-print('Skill executed!')")
-    ]
-
-    try:
-        skill_path = aikit_py.deploy_skill(
-            agent_key,
-            project_root,
-            skill_name,
-            skill_md_content,
-            optional_scripts
-        )
-        print(f"Skill '{skill_name}' deployed successfully to: {skill_path}")
-
-        # Verify files were created
-        expected_skill_md_path = os.path.join(project_root, ".cursor/skills/my-new-python-skill/SKILL.md")
-        assert os.path.exists(expected_skill_md_path)
-        print(f"SKILL.md exists at: {expected_skill_md_path}")
-
-        expected_setup_script = os.path.join(project_root, ".cursor/skills/my-new-python-skill/scripts/setup.sh")
-        assert os.path.exists(expected_setup_script)
-        print(f"Setup script exists at: {expected_setup_script}")
-
-        expected_run_script = os.path.join(project_root, ".cursor/skills/my-new-python-skill/scripts/run.py")
-        assert os.path.exists(expected_run_script)
-        print(f"Run script exists at: {expected_run_script}")
-
-    except aikit_py.DeployError as e:
-        print(f"Failed to deploy skill: {str(e)}")
-
-    # Example of trying to deploy a skill for an agent that doesn't support them
-    try:
-        aikit_py.deploy_skill("qwen", project_root, "unsupported-skill", "# Unsupported", None)
-    except aikit_py.DeployError as e:
-        print(f"
-Expected error when deploying skill to 'qwen': {str(e)}")
-```
-
-## Running agents
-
-You can run a coding agent from Python. Only these agent keys are runnable: `codex`, `claude`, `gemini`, `opencode`, `agent`. Use `aikit_py.is_runnable_py(agent_key)` or `aikit_py.runnable_agents_list()` to check.
-
-```python
-import aikit_py
-
-# Optional: check before calling
-if aikit_py.is_runnable_py("claude"):
-    result = aikit_py.run_agent("claude", "Suggest a refactor", model=None, yolo=False, stream=False)
-    # result is a dict: status_code (int | None), stdout (bytes), stderr (bytes)
-    print(result["stdout"].decode())
-    exit(result["status_code"] or 1)
-```
-
-Raises an exception if the agent is not runnable or the process fails to start.
-
-### Streaming events
-
-Use `run_agent_events_py` to receive real-time events as the agent produces output. A callback function is invoked for each event with a dictionary matching the NDJSON format.
-
-```python
-import aikit_py
-
-def on_event(event):
-    seq = event["seq"]
-    stream = event["stream"]  # "stdout" or "stderr"
-    payload = event["payload"]
-    if "json_line" in payload:
-        print(f"seq={seq} [{stream}] JSON: {payload['json_line']}")
-    elif "raw_line" in payload:
-        print(f"seq={seq} [{stream}] text: {payload['raw_line']}")
-    elif "token_usage_line" in payload:
-        print(f"seq={seq} [{stream}] usage: {payload['token_usage_line']}")
-    else:
-        print(f"seq={seq} [{stream}] bytes: {payload['raw_bytes']}")
-
-result = aikit_py.run_agent_events_py(
-    "claude",
-    "Summarize the project",
-    on_event,
-    model=None,
-    yolo=False,
-    stream=True,
-)
-# result is a dict: status_code (int | None), stdout (bytes), stderr (bytes)
-print(result["stdout"].decode())
-```
-
-The event dictionary schema:
-```python
-{
-    "agent_key": str,           # e.g., "claude"
-    "seq": int,                 # monotonic sequence number 0..n-1
-    "stream": str,              # "stdout" or "stderr"
-    "payload": {                # exactly one of:
-        "json_line": dict,      # parsed JSON object
-        "raw_line": str,        # UTF-8 text line (not JSON)
-        "raw_bytes": list[int], # non-UTF-8 bytes as integer array
-        "token_usage_line": {   # normalized usage after a json_line (when emitted)
-            "usage": dict,      # input_tokens, output_tokens, optional totals/cache/reasoning
-            "source": str,      # e.g. "Claude" (matches Rust UsageSource)
-            "raw_agent_line_seq": int,
-        },
-    }
-}
-```
-
-If the callback raises an exception, the exception propagates to the caller after the agent process completes. Subsequent callback invocations are skipped after the first exception.
-
-The return value has the same structure as `run_agent`: `{"status_code": int | None, "stdout": bytes, "stderr": bytes}`.
-
-See `aikit run --help` or the [aikit-sdk README](../aikit-sdk/README.md) for complete streaming event documentation and NDJSON format details.
-
-## Agent Detection
-
-### Check if Agent is Installed
-
-```python
-import aikit_py
-
-# Check if a specific agent is available
-if aikit_py.is_agent_available("claude"):
-    print("Claude is installed and ready to run")
-else:
-    print("Claude is not available")
-
-# Compatibility alias (same behavior)
-if aikit_py.is_agent_available_py("claude"):
-    print("Claude is installed and ready to run")
-```
-
-### List Installed Agents
-
-```python
-import aikit_py
-
-# Get all installed runnable agents (sorted alphabetically)
-installed = aikit_py.get_installed_agents()
-print(f"Installed agents: {installed}")
-# Output: ['agent', 'claude', 'codex', 'gemini', 'opencode']
-
-# Compatibility alias (same behavior)
-installed_py = aikit_py.get_installed_agents_py()
-```
-
-### Get Detailed Agent Status
-
-```python
-import aikit_py
-
-# Get status for all runnable agents
-status = aikit_py.get_agent_status()
-for agent_key, agent_status in status.items():
-    print(f"{agent_key}: {'Available' if agent_status['available'] else 'Not available'}")
-    if agent_status['reason']:
-        print(f"  Reason: {agent_status['reason']}")
-
-# Compatibility alias (same behavior)
-status_py = aikit_py.get_agent_status_py()
-```
-
-### Agent Status Structure
-
-Agent status is returned as a dictionary with the following structure:
-
-```python
-{
-    "agent_key": {
-        "available": bool,       # Whether the agent is installed and runnable
-        "reason": Optional[str]  # Optional explanation if not available
-    }
-}
-```
-
-The `reason` field contains one of the following values when unavailable:
-- `"not_runnable"` - Agent is not in runnable_agents list
-- `"binary_not_found"` - Binary not found in PATH
-- `"version_check_failed"` - Binary found but --version failed
-- `"timed_out"` - Probe timed out (1500ms timeout)
-
-**Detection behavior**:
-- Detection is bounded by a 1500ms timeout per binary probe
-- The `opencode` agent checks multiple binary candidates: `opencode` and `opencode-desktop`
-- Status is returned in deterministic order (sorted by agent key)
-- Only runnable agents are included in the status map
-
-## API Overview
-
-The `aikit_py` module exposes functions and classes that mirror the `aikit-sdk` Rust library:
-
--   `all_agents()`: Returns a list of `AgentConfig` objects for all known agents.
--   `agent(key: str)`: Returns an `AgentConfig` object for the specified agent key, or `None` if not found.
--   `validate_agent_key(key: str)`: Validates if an agent key exists, raises `aikit_py.DeployError` if not.
--   `commands_dir(project_root: str, agent_key: str)`: Returns the path to an agent's commands directory.
--   `skill_dir(project_root: str, agent_key: str, skill_name: str)`: Returns the path to a specific skill directory.
--   `subagent_path(project_root: str, agent_key: str, name: str)`: Returns the path to a subagent file.
--   `deploy_command(agent_key: str, project_root: str, name: str, content: str)`: Deploys a command file.
--   `deploy_skill(agent_key: str, project_root: str, skill_name: str, skill_md_content: str, optional_scripts: Optional[List[Tuple[str, bytes]]])`: Deploys a skill, including `SKILL.md` and optional script files.
--   `deploy_subagent(agent_key: str, project_root: str, name: str, content: str)`: Deploys a subagent file.
--   `command_filename(agent_key: str, name: str)`: Returns the conventional filename for a command.
--   `subagent_filename(agent_key: str, name: str)`: Returns the conventional filename for a subagent.
--   `run_agent(agent_key, prompt, model=None, yolo=False, stream=False)`: Runs the agent CLI; returns a dict with `status_code`, `stdout`, `stderr`. Raises on invalid agent or spawn failure. Output is buffered until the agent completes.
--   `run_agent_events_py(agent_key, prompt, on_event, model=None, yolo=False, stream=False)`: Runs the agent CLI with streaming event delivery via callback. Returns the same dict structure as `run_agent`. The `on_event` callback receives event dictionaries matching the NDJSON format. Raises `aikit_py.DeployError` on invalid agent or spawn failure; re-raises any exception from the callback.
--   `runnable_agents_list()`: Returns list of runnable agent keys (`codex`, `claude`, `gemini`, `opencode`, `agent`).
--   `is_runnable_py(agent_key: str)`: Returns whether the agent can be run via `run_agent`.
--   `PyRunOptions`: Optional builder for run options (model, yolo, stream); used internally by `run_agent`.
--   `AgentConfig`: A Python class representing an agent's configuration, with properties like `name`, `commands_dir`, `skills_dir`, `agents_dir`, and `key()`.
--   `DeployError`: A Python exception class for errors originating from the `aikit-sdk`. Use `str(e)` to get the error message.
--   `PyDeployConcept`: A Python enum mirroring `DeployConcept` (Command, Skill, Subagent).
-
-## License
-
-This project is licensed under the Apache-2.0 License.

--- a/aikit-py/examples/README.md
+++ b/aikit-py/examples/README.md
@@ -1,0 +1,11 @@
+# aikit-py examples
+
+| Script | Purpose |
+| --- | --- |
+| `mcp_deploy_stdio.py` | Project-local Claude MCP merge via `add_mcp_server` (stdio) |
+
+Run from repo after `maturin develop` in `aikit-py/`:
+
+```bash
+uv run python examples/mcp_deploy_stdio.py --project-root /path/to/repo
+```

--- a/aikit-py/examples/mcp_deploy_stdio.py
+++ b/aikit-py/examples/mcp_deploy_stdio.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Merge a stdio MCP server into a project-local Claude `.mcp.json` (demo)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+
+def main() -> int:
+    try:
+        import aikit_py
+    except ImportError:
+        print("Install aikit-py (e.g. maturin develop in aikit-py/)", file=sys.stderr)
+        return 1
+
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--project-root",
+        default=".",
+        help="Project directory (default: current directory)",
+    )
+    p.add_argument("--server-name", default="demo-fs", help="Entry name under mcpServers")
+    p.add_argument(
+        "--path",
+        default=None,
+        help="Filesystem MCP root path (default: project root)",
+    )
+    p.add_argument("--overwrite", action="store_true")
+    args = p.parse_args()
+
+    root = os.path.abspath(args.project_root)
+    scan = os.path.abspath(args.path) if args.path else root
+
+    written = aikit_py.add_mcp_server(
+        "claude",
+        root,
+        args.server_name,
+        scope="project",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-filesystem", scan],
+        overwrite=args.overwrite,
+    )
+    print(written)
+    with open(written, encoding="utf-8") as f:
+        print(json.dumps(json.load(f), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/aikit-py/pyproject.toml
+++ b/aikit-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "aikit-py"
 version = "0.2.1"
 requires-python = ">=3.9"
 license = "Apache-2.0"
-description = "Python gateway to aikit-sdk: catalog, deploy, detection, run_agent, run_agent_events_py"
+description = "Python gateway to aikit-sdk: catalog, deploy, MCP merge, detection, run_agent, run_agent_events_py"
 readme = "README.md"
 authors = [
     { name = "goaikit", email = "info@goaikit.dev" }

--- a/aikit-py/src/lib.rs
+++ b/aikit-py/src/lib.rs
@@ -1,14 +1,21 @@
 use aikit_sdk::{
-    get_agent_status as get_agent_status_impl, get_installed_agents as get_installed_agents_impl,
-    is_agent_available as is_agent_available_impl, is_runnable, run_agent as run_agent_impl,
-    run_agent_events, runnable_agents, AgentConfig, AgentStatus, DeployConcept, DeployError,
-    RunOptions,
+    add_mcp_server as add_mcp_server_impl, get_agent_status as get_agent_status_impl,
+    get_installed_agents as get_installed_agents_impl,
+    is_agent_available as is_agent_available_impl, is_runnable,
+    mcp_config_path as mcp_config_path_impl, mcp_supported_agents as mcp_supported_agents_impl,
+    normalize_mcp_agent_key, parse_env_pairs, parse_header_pairs, run_agent as run_agent_impl,
+    run_agent_events, runnable_agents, AddMcpServerOptions, AgentConfig, AgentStatus,
+    DeployConcept, DeployError, McpScope, McpServerTransport, RunOptions,
 };
-use pyo3::exceptions::PyException;
+use pyo3::create_exception;
+use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+
+create_exception!(aikit_py, McpDeployError, PyException);
 
 // Removed PyDeployError struct and its #[pyclass]
 
@@ -16,6 +23,18 @@ use std::sync::{Arc, Mutex};
 // This replaces the impl From<DeployError> for PyErr, addressing the orphan rule
 fn to_py_result<T>(result: Result<T, DeployError>) -> PyResult<T> {
     result.map_err(|e| PyException::new_err(format!("{}", e)))
+}
+
+fn mcp_to_py<T>(result: Result<T, aikit_sdk::McpDeployError>) -> PyResult<T> {
+    result.map_err(|e| McpDeployError::new_err(e.to_string()))
+}
+
+fn mcp_scope_from_str(scope: &str) -> PyResult<McpScope> {
+    match scope.to_ascii_lowercase().as_str() {
+        "project" => Ok(McpScope::Project),
+        "global" => Ok(McpScope::Global),
+        _ => Err(PyValueError::new_err("scope must be 'project' or 'global'")),
+    }
 }
 
 // Implement the PyO3 bindings for DeployConcept enum.
@@ -393,9 +412,108 @@ fn get_agent_status_py(py: Python<'_>) -> PyResult<Py<PyDict>> {
     get_agent_status(py)
 }
 
+#[pyfunction]
+#[pyo3(name = "mcp_config_path")]
+fn mcp_config_path_py(agent_key: &str, scope: &str, project_root: PathBuf) -> PyResult<String> {
+    let sc = mcp_scope_from_str(scope)?;
+    mcp_to_py(
+        mcp_config_path_impl(agent_key, sc, &project_root)
+            .map(|p| p.to_string_lossy().into_owned()),
+    )
+}
+
+#[pyfunction]
+#[pyo3(signature = (agent_key, project_root, server_name, *, scope="project", command=None, args=None, env=None, url=None, headers=None, overwrite=false))]
+#[allow(clippy::too_many_arguments)]
+fn add_mcp_server(
+    agent_key: String,
+    project_root: PathBuf,
+    server_name: String,
+    scope: &str,
+    command: Option<String>,
+    args: Option<Vec<String>>,
+    env: Option<HashMap<String, String>>,
+    url: Option<String>,
+    headers: Option<HashMap<String, String>>,
+    overwrite: bool,
+) -> PyResult<String> {
+    let sc = mcp_scope_from_str(scope)?;
+    let transport = match (&command, &url) {
+        (Some(cmd), None) => McpServerTransport::Stdio {
+            command: cmd.clone(),
+            args: args.unwrap_or_default(),
+            env,
+        },
+        (None, Some(u)) => McpServerTransport::Http {
+            url: u.clone(),
+            headers,
+        },
+        (Some(_), Some(_)) => {
+            return Err(PyValueError::new_err(
+                "provide either command= (stdio) or url= (http), not both",
+            ));
+        }
+        (None, None) => {
+            return Err(PyValueError::new_err(
+                "provide command= for stdio or url= for http transport",
+            ));
+        }
+    };
+    let opts = AddMcpServerOptions {
+        agent_key,
+        scope: sc,
+        project_root,
+        server_name,
+        transport,
+        overwrite,
+    };
+    mcp_to_py(add_mcp_server_impl(opts).map(|p| p.to_string_lossy().into_owned()))
+}
+
+#[pyfunction]
+#[pyo3(name = "mcp_supported_agents")]
+fn mcp_supported_agents_py(py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+    let mut out = Vec::new();
+    for row in mcp_supported_agents_impl() {
+        let d = PyDict::new(py);
+        d.set_item("agent_key", row.agent_key)?;
+        d.set_item("display_name", row.display_name)?;
+        d.set_item("project_config_path", row.project_config_path)?;
+        d.set_item("global_config_path", row.global_config_path)?;
+        out.push(d.into_any().unbind());
+    }
+    Ok(out)
+}
+
+#[pyfunction]
+#[pyo3(name = "mcp_supported_agent_keys")]
+fn mcp_supported_agent_keys_py() -> Vec<String> {
+    aikit_sdk::MCP_SUPPORTED_AGENT_KEYS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect()
+}
+
+#[pyfunction]
+#[pyo3(name = "normalize_mcp_agent_key")]
+fn normalize_mcp_agent_key_py(key: &str) -> String {
+    normalize_mcp_agent_key(key).to_string()
+}
+
+#[pyfunction]
+fn mcp_parse_env_pairs(pairs: Vec<String>) -> PyResult<HashMap<String, String>> {
+    mcp_to_py(parse_env_pairs(&pairs))
+}
+
+#[pyfunction]
+fn mcp_parse_header_pairs(pairs: Vec<String>) -> PyResult<HashMap<String, String>> {
+    mcp_to_py(parse_header_pairs(&pairs))
+}
+
 #[pymodule]
-fn aikit_py(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("DeployError", _py.get_type::<PyException>())?;
+fn aikit_py(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("DeployError", py.get_type::<PyException>())?;
+    m.add("McpDeployError", py.get_type::<McpDeployError>())?;
 
     m.add_class::<PyDeployConcept>()?;
     m.add_class::<PyAgentConfig>()?;
@@ -422,5 +540,12 @@ fn aikit_py(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_installed_agents_py))?;
     m.add_wrapped(wrap_pyfunction!(get_agent_status))?;
     m.add_wrapped(wrap_pyfunction!(get_agent_status_py))?;
+    m.add_wrapped(wrap_pyfunction!(mcp_config_path_py))?;
+    m.add_wrapped(wrap_pyfunction!(add_mcp_server))?;
+    m.add_wrapped(wrap_pyfunction!(mcp_supported_agents_py))?;
+    m.add_wrapped(wrap_pyfunction!(mcp_supported_agent_keys_py))?;
+    m.add_wrapped(wrap_pyfunction!(normalize_mcp_agent_key_py))?;
+    m.add_wrapped(wrap_pyfunction!(mcp_parse_env_pairs))?;
+    m.add_wrapped(wrap_pyfunction!(mcp_parse_header_pairs))?;
     Ok(())
 }

--- a/aikit-py/tests/test_mcp_deploy.py
+++ b/aikit-py/tests/test_mcp_deploy.py
@@ -1,0 +1,169 @@
+import json
+import os
+import tempfile
+
+import pytest
+
+import aikit_py
+
+
+@pytest.fixture
+def temp_project_root():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+def test_normalize_mcp_agent_key():
+    assert aikit_py.normalize_mcp_agent_key("cursor") == "cursor-agent"
+    assert aikit_py.normalize_mcp_agent_key("vscode") == "copilot"
+    assert aikit_py.normalize_mcp_agent_key("claude") == "claude"
+
+
+def test_mcp_supported_agent_keys():
+    keys = aikit_py.mcp_supported_agent_keys()
+    assert "claude" in keys
+    assert "cursor-agent" in keys
+    assert len(keys) == 6
+
+
+def test_mcp_supported_agents_shape():
+    rows = aikit_py.mcp_supported_agents()
+    assert len(rows) == 6
+    for r in rows:
+        assert set(r.keys()) == {
+            "agent_key",
+            "display_name",
+            "project_config_path",
+            "global_config_path",
+        }
+
+
+def test_mcp_config_path_claude_project(temp_project_root):
+    p = aikit_py.mcp_config_path("claude", "project", temp_project_root)
+    assert p == os.path.join(temp_project_root, ".mcp.json")
+
+
+def test_mcp_config_path_cursor_alias(temp_project_root):
+    p = aikit_py.mcp_config_path("cursor", "project", temp_project_root)
+    assert p == os.path.join(temp_project_root, ".cursor/mcp.json")
+
+
+def test_mcp_parse_env_pairs():
+    m = aikit_py.mcp_parse_env_pairs(["A=b", "C=d=e"])
+    assert m == {"A": "b", "C": "d=e"}
+
+
+def test_mcp_parse_env_pairs_invalid():
+    with pytest.raises(aikit_py.McpDeployError):
+        aikit_py.mcp_parse_env_pairs(["NO_EQUALS"])
+
+
+def test_add_mcp_server_claude_stdio(temp_project_root):
+    path = aikit_py.add_mcp_server(
+        "claude",
+        temp_project_root,
+        "demo",
+        scope="project",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-filesystem", temp_project_root],
+        overwrite=False,
+    )
+    assert path == os.path.join(temp_project_root, ".mcp.json")
+    with open(path, encoding="utf-8") as f:
+        cfg = json.load(f)
+    demo = cfg["mcpServers"]["demo"]
+    assert demo["command"] == "npx"
+    assert demo["args"][-1] == temp_project_root
+
+
+def test_add_mcp_server_http(temp_project_root):
+    aikit_py.add_mcp_server(
+        "gemini",
+        temp_project_root,
+        "remote",
+        scope="project",
+        url="http://127.0.0.1:9/mcp",
+        headers={"X-Test": "1"},
+        overwrite=False,
+    )
+    p = os.path.join(temp_project_root, ".gemini", "settings.json")
+    with open(p, encoding="utf-8") as f:
+        cfg = json.load(f)
+    r = cfg["mcpServers"]["remote"]
+    assert r["url"] == "http://127.0.0.1:9/mcp"
+    assert r["headers"]["X-Test"] == "1"
+
+
+def test_add_mcp_server_already_exists(temp_project_root):
+    aikit_py.add_mcp_server(
+        "claude",
+        temp_project_root,
+        "x",
+        command="true",
+        args=[],
+        overwrite=False,
+    )
+    with pytest.raises(aikit_py.McpDeployError):
+        aikit_py.add_mcp_server(
+            "claude",
+            temp_project_root,
+            "x",
+            command="false",
+            args=[],
+            overwrite=False,
+        )
+
+
+def test_add_mcp_server_overwrite(temp_project_root):
+    aikit_py.add_mcp_server(
+        "claude",
+        temp_project_root,
+        "x",
+        command="true",
+        args=[],
+        overwrite=False,
+    )
+    aikit_py.add_mcp_server(
+        "claude",
+        temp_project_root,
+        "x",
+        command="false",
+        args=[],
+        overwrite=True,
+    )
+    with open(os.path.join(temp_project_root, ".mcp.json"), encoding="utf-8") as f:
+        cfg = json.load(f)
+    assert cfg["mcpServers"]["x"]["command"] == "false"
+
+
+def test_add_mcp_server_codex_toml(temp_project_root):
+    os.makedirs(os.path.join(temp_project_root, ".codex"), exist_ok=True)
+    aikit_py.add_mcp_server(
+        "codex",
+        temp_project_root,
+        "demo",
+        scope="project",
+        command="npx",
+        args=["-y", "pkg"],
+        env={"FOO": "bar"},
+        overwrite=False,
+    )
+    p = os.path.join(temp_project_root, ".codex", "config.toml")
+    text = open(p, encoding="utf-8").read()
+    assert "mcp_servers" in text
+    assert "demo" in text
+
+
+def test_mcp_scope_invalid(temp_project_root):
+    with pytest.raises(ValueError):
+        aikit_py.mcp_config_path("claude", "other", temp_project_root)
+
+
+def test_add_mcp_server_transport_invalid(temp_project_root):
+    with pytest.raises(ValueError):
+        aikit_py.add_mcp_server("claude", temp_project_root, "n", command="a", url="b")
+
+
+def test_mcp_config_unknown_agent(temp_project_root):
+    with pytest.raises(aikit_py.McpDeployError):
+        aikit_py.mcp_config_path("qwen", "project", temp_project_root)

--- a/aikit-sdk/Cargo.toml
+++ b/aikit-sdk/Cargo.toml
@@ -15,6 +15,7 @@ walkdir = "2"
 toml = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+dirs = "6.0"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 zip = "2.3"
 tempfile = "3.12"

--- a/aikit-sdk/README.md
+++ b/aikit-sdk/README.md
@@ -9,12 +9,13 @@ It provides deterministic APIs for:
 - package/template install helpers
 - runnable-agent detection
 - buffered and streaming agent execution
+- MCP server registration (merge into agent JSON) for supported assistants
 
 ## Install
 
 ```toml
 [dependencies]
-aikit-sdk = "0.2.0"
+aikit-sdk = "0.2.1"
 ```
 
 Or from this workspace:
@@ -48,6 +49,31 @@ deploy_command("claude", root, "lint", "# command body")?;
 deploy_skill("cursor-agent", root, "my-skill", "# SKILL.md", None)?;
 deploy_subagent("claude", root, "reviewer", "# subagent")?;
 # Ok::<(), aikit_sdk::DeployError>(())
+```
+
+## MCP config merge
+
+Supported keys: `cursor-agent`, `claude`, `gemini`, `copilot`, `opencode`, `codex` (see `mcp_supported_agents()` and `MCP_SUPPORTED_AGENT_KEYS`). Each uses the on-disk format expected by that product (`mcpServers`, VS Code `servers`, OpenCode `mcp`, or Codex TOML tables). On **Windows**, VS Code user MCP and OpenCode global paths fall back to `<home>\\AppData\\Roaming\\...` when `%APPDATA%` / `config_dir` are missing.
+
+```rust
+use aikit_sdk::{
+    add_mcp_server, mcp_config_path, AddMcpServerOptions, McpScope, McpServerTransport,
+};
+use std::path::Path;
+
+let path = add_mcp_server(AddMcpServerOptions {
+    agent_key: "gemini".into(),
+    scope: McpScope::Project,
+    project_root: Path::new(".").to_path_buf(),
+    server_name: "my-cli".into(),
+    transport: McpServerTransport::Http {
+        url: "http://127.0.0.1:8730/mcp".into(),
+        headers: None,
+    },
+    overwrite: false,
+})?;
+println!("{}", path.display());
+# Ok::<(), aikit_sdk::McpDeployError>(())
 ```
 
 ## Instruction files

--- a/aikit-sdk/README.md
+++ b/aikit-sdk/README.md
@@ -53,11 +53,28 @@ deploy_subagent("claude", root, "reviewer", "# subagent")?;
 
 ## MCP config merge
 
-Supported keys: `cursor-agent`, `claude`, `gemini`, `copilot`, `opencode`, `codex` (see `mcp_supported_agents()` and `MCP_SUPPORTED_AGENT_KEYS`). Each uses the on-disk format expected by that product (`mcpServers`, VS Code `servers`, OpenCode `mcp`, or Codex TOML tables). On **Windows**, VS Code user MCP and OpenCode global paths fall back to `<home>\\AppData\\Roaming\\...` when `%APPDATA%` / `config_dir` are missing.
+Merge one MCP server definition into the config file each assistant expects. **Supported keys** (see `mcp_supported_agents()` and `MCP_SUPPORTED_AGENT_KEYS`): `cursor-agent`, `claude`, `gemini`, `copilot`, `opencode`, `codex`. **Aliases** (same as CLI): `cursor` → `cursor-agent`, `vscode` → `copilot`.
+
+| Key | Project file (under `project_root`) | Global scope |
+|-----|--------------------------------------|--------------|
+| `cursor-agent` | `.cursor/mcp.json` | `~/.cursor/mcp.json` |
+| `claude` | `.mcp.json` | `~/.claude.json` |
+| `gemini` | `.gemini/settings.json` | `~/.gemini/settings.json` |
+| `copilot` | `.vscode/mcp.json` | VS Code user `mcp.json` (macOS: `~/Library/Application Support/Code/User/…`; Linux: `~/.config/Code/User/…`; Windows: `%APPDATA%\Code\User\…` or `~\AppData\Roaming\…` if unset) |
+| `opencode` | `opencode.json` | User `opencode.json` via XDG / Roaming fallback |
+| `codex` | `.codex/config.toml` | `~/.codex/config.toml` |
+
+**JSON agents** (`cursor-agent`, `claude`, `gemini`): root `mcpServers.<name>`. **Copilot**: root `servers.<name>` with `type` `stdio` or `http`. **OpenCode**: root `mcp.<name>`. **Codex**: `[mcp_servers.<name>]` in TOML.
+
+**Public API:** `add_mcp_server`, `mcp_config_path`, `normalize_mcp_agent_key`, `mcp_supported_agents`, `parse_env_pairs`, `parse_header_pairs`, `MCP_SUPPORTED_AGENT_KEYS`, `AddMcpServerOptions`, `McpScope`, `McpServerTransport`, `McpDeployError`. Errors are `Result<_, McpDeployError>` (unknown agent, unsupported agent, missing home, I/O, JSON/TOML, duplicate name without `overwrite`, bad `KEY=value` pairs).
+
+On **Windows**, VS Code user MCP and OpenCode global paths fall back to `<home>\AppData\Roaming\...` when `%APPDATA%` or `dirs::config_dir()` is missing.
+
+### HTTP transport
 
 ```rust
 use aikit_sdk::{
-    add_mcp_server, mcp_config_path, AddMcpServerOptions, McpScope, McpServerTransport,
+    add_mcp_server, AddMcpServerOptions, McpScope, McpServerTransport,
 };
 use std::path::Path;
 
@@ -65,7 +82,7 @@ let path = add_mcp_server(AddMcpServerOptions {
     agent_key: "gemini".into(),
     scope: McpScope::Project,
     project_root: Path::new(".").to_path_buf(),
-    server_name: "my-cli".into(),
+    server_name: "remote".into(),
     transport: McpServerTransport::Http {
         url: "http://127.0.0.1:8730/mcp".into(),
         headers: None,
@@ -75,6 +92,36 @@ let path = add_mcp_server(AddMcpServerOptions {
 println!("{}", path.display());
 # Ok::<(), aikit_sdk::McpDeployError>(())
 ```
+
+### Stdio transport
+
+```rust
+use aikit_sdk::{
+    add_mcp_server, AddMcpServerOptions, McpScope, McpServerTransport,
+};
+use std::{collections::HashMap, path::Path};
+
+let path = add_mcp_server(AddMcpServerOptions {
+    agent_key: "claude".into(),
+    scope: McpScope::Project,
+    project_root: Path::new(".").to_path_buf(),
+    server_name: "fs".into(),
+    transport: McpServerTransport::Stdio {
+        command: "npx".into(),
+        args: vec![
+            "-y".into(),
+            "@modelcontextprotocol/server-filesystem".into(),
+            ".".into(),
+        ],
+        env: Some(HashMap::from([("FOO".into(), "bar".into())])),
+    },
+    overwrite: false,
+})?;
+println!("{}", path.display());
+# Ok::<(), aikit_sdk::McpDeployError>(())
+```
+
+**Tests:** `AIKIT_MCP_TEST_HOME` overrides the home directory used for global path resolution when `aikit-sdk` is built with `cfg(test)` only (not in normal library builds).
 
 ## Instruction files
 
@@ -131,6 +178,7 @@ cargo test -p aikit-sdk -- --ignored
 
 - Workspace overview: `../README.md`
 - Python bindings: `../aikit-py/README.md`
+- Site docs (MCP): `../webdocs/mcp.mdx`
 - Contributor guide: `CONTRIBUTING.md`
 
 ## License

--- a/aikit-sdk/src/lib.rs
+++ b/aikit-sdk/src/lib.rs
@@ -433,6 +433,7 @@ pub(crate) mod command_resolve;
 pub mod fetch;
 pub mod install;
 pub mod manifest;
+pub mod mcp_deploy;
 
 pub use fetch::TemplateSource;
 pub use install::{
@@ -440,6 +441,11 @@ pub use install::{
     InstallError, InstallTemplateFromSourceOptions, InstallTemplateOptions,
 };
 pub use manifest::{PackageInfo, TemplateManifest};
+pub use mcp_deploy::{
+    add_mcp_server, mcp_config_path, mcp_supported_agents, normalize_mcp_agent_key,
+    parse_env_pairs, parse_header_pairs, AddMcpServerOptions, McpAgentSupportRow, McpDeployError,
+    McpScope, McpServerTransport, MCP_SUPPORTED_AGENT_KEYS,
+};
 
 /// Agent catalog entry containing all supported agents and their capabilities.
 struct AgentEntry<'a> {

--- a/aikit-sdk/src/mcp_deploy.rs
+++ b/aikit-sdk/src/mcp_deploy.rs
@@ -1,0 +1,897 @@
+//! Merge MCP server definitions into agent-specific config files (JSON or TOML).
+//!
+//! **Windows:** VS Code user MCP uses `%APPDATA%\\Code\\User\\mcp.json`, or
+//! `<userprofile>\\AppData\\Roaming\\Code\\User\\mcp.json` if `APPDATA` is unset.
+//! OpenCode user config uses [`dirs::config_dir`] when available, else the same Roaming fallback.
+//!
+//! **Tests:** When this crate is built with `cfg(test)`, `AIKIT_MCP_TEST_HOME` overrides the home
+//! directory used for global path resolution (not used in normal library builds).
+//!
+//! Supported targets (see [`mcp_supported_agents`]):
+//! - **cursor-agent**: `.cursor/mcp.json` / `~/.cursor/mcp.json` — `mcpServers`
+//! - **claude**: `.mcp.json` / `~/.claude.json` — `mcpServers`
+//! - **gemini**: `.gemini/settings.json` / `~/.gemini/settings.json` — `mcpServers` inside settings
+//! - **copilot**: `.vscode/mcp.json` / VS Code user `mcp.json` — `servers` (VS Code shape)
+//! - **opencode**: `opencode.json` / user config — root `mcp` map
+//! - **codex**: `.codex/config.toml` / `~/.codex/config.toml` — `[mcp_servers.NAME]`
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Map, Value};
+use toml::Value as TomlValue;
+
+/// Where to write the MCP config file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpScope {
+    /// Repository or project directory (agent-specific relative path).
+    Project,
+    /// User home (agent-specific path under the home directory).
+    Global,
+}
+
+/// Stdio or HTTP MCP transport (product-specific JSON/TOML mapping).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpServerTransport {
+    /// `command` / `args` / optional `env`.
+    Stdio {
+        command: String,
+        args: Vec<String>,
+        env: Option<HashMap<String, String>>,
+    },
+    /// Remote Streamable HTTP / SSE URL and optional `headers`.
+    Http {
+        url: String,
+        headers: Option<HashMap<String, String>>,
+    },
+}
+
+/// Target file and agent for [`add_mcp_server`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddMcpServerOptions {
+    pub agent_key: String,
+    pub scope: McpScope,
+    /// Used when `scope` is [`McpScope::Project`]; ignored for [`McpScope::Global`] except path resolution.
+    pub project_root: PathBuf,
+    pub server_name: String,
+    pub transport: McpServerTransport,
+    /// Replace an existing server entry with the same name.
+    pub overwrite: bool,
+}
+
+/// Agent keys that support MCP config deployment through this module.
+pub const MCP_SUPPORTED_AGENT_KEYS: &[&str] = &[
+    "cursor-agent",
+    "claude",
+    "gemini",
+    "copilot",
+    "opencode",
+    "codex",
+];
+
+/// Human-oriented row for [`mcp_supported_agents`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpAgentSupportRow {
+    pub agent_key: &'static str,
+    pub display_name: &'static str,
+    pub project_config_path: &'static str,
+    pub global_config_path: &'static str,
+}
+
+/// Returns supported agents and the config paths (relative to project root or home).
+pub fn mcp_supported_agents() -> Vec<McpAgentSupportRow> {
+    vec![
+        McpAgentSupportRow {
+            agent_key: "cursor-agent",
+            display_name: "Cursor",
+            project_config_path: ".cursor/mcp.json",
+            global_config_path: "~/.cursor/mcp.json",
+        },
+        McpAgentSupportRow {
+            agent_key: "claude",
+            display_name: "Claude Code",
+            project_config_path: ".mcp.json",
+            global_config_path: "~/.claude.json",
+        },
+        McpAgentSupportRow {
+            agent_key: "gemini",
+            display_name: "Gemini CLI",
+            project_config_path: ".gemini/settings.json",
+            global_config_path: "~/.gemini/settings.json",
+        },
+        McpAgentSupportRow {
+            agent_key: "copilot",
+            display_name: "VS Code / Copilot MCP",
+            project_config_path: ".vscode/mcp.json",
+            global_config_path: "Code/User/mcp.json under OS app config (see docs)",
+        },
+        McpAgentSupportRow {
+            agent_key: "opencode",
+            display_name: "OpenCode",
+            project_config_path: "opencode.json",
+            global_config_path: "~/.config/opencode/opencode.json (XDG)",
+        },
+        McpAgentSupportRow {
+            agent_key: "codex",
+            display_name: "Codex CLI",
+            project_config_path: ".codex/config.toml",
+            global_config_path: "~/.codex/config.toml",
+        },
+    ]
+}
+
+/// Normalize CLI aliases to catalog keys.
+pub fn normalize_mcp_agent_key(key: &str) -> &str {
+    match key.trim() {
+        "cursor" => "cursor-agent",
+        "vscode" => "copilot",
+        other => other,
+    }
+}
+
+#[derive(Debug)]
+pub enum McpDeployError {
+    UnknownAgent(String),
+    UnsupportedAgent { agent: String, detail: String },
+    MissingHome,
+    Io(io::Error),
+    Json(serde_json::Error),
+    TomlParse(String),
+    TomlSerialize(String),
+    AlreadyExists { name: String },
+    InvalidEnvPair(String),
+    InvalidConfig(String),
+}
+
+impl fmt::Display for McpDeployError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            McpDeployError::UnknownAgent(k) => write!(f, "unknown agent key: {}", k),
+            McpDeployError::UnsupportedAgent { agent, detail } => {
+                write!(
+                    f,
+                    "agent '{}' does not support MCP deploy via aikit: {}",
+                    agent, detail
+                )
+            }
+            McpDeployError::MissingHome => write!(f, "could not resolve user home directory"),
+            McpDeployError::Io(e) => write!(f, "{}", e),
+            McpDeployError::Json(e) => write!(f, "{}", e),
+            McpDeployError::TomlParse(s) => write!(f, "{}", s),
+            McpDeployError::TomlSerialize(s) => write!(f, "{}", s),
+            McpDeployError::AlreadyExists { name } => write!(
+                f,
+                "MCP server '{}' already exists (pass overwrite=true to replace)",
+                name
+            ),
+            McpDeployError::InvalidEnvPair(s) => {
+                write!(f, "invalid --env value (expected KEY=value): {}", s)
+            }
+            McpDeployError::InvalidConfig(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl Error for McpDeployError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            McpDeployError::Io(e) => Some(e),
+            McpDeployError::Json(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for McpDeployError {
+    fn from(e: io::Error) -> Self {
+        McpDeployError::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for McpDeployError {
+    fn from(e: serde_json::Error) -> Self {
+        McpDeployError::Json(e)
+    }
+}
+
+fn home_dir_for_mcp() -> Result<PathBuf, McpDeployError> {
+    #[cfg(test)]
+    if let Ok(h) = std::env::var("AIKIT_MCP_TEST_HOME") {
+        if !h.is_empty() {
+            return Ok(PathBuf::from(h));
+        }
+    }
+    dirs::home_dir().ok_or(McpDeployError::MissingHome)
+}
+
+/// VS Code stable user `mcp.json` (not Cursor). Windows: `%APPDATA%\Code\User\mcp.json`, or
+/// `<home>\AppData\Roaming\...` when `APPDATA` is unset (e.g. minimal CI).
+fn vscode_user_mcp_path(home: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/Code/User/mcp.json")
+    } else if cfg!(target_os = "windows") {
+        std::env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join("AppData").join("Roaming"))
+            .join("Code")
+            .join("User")
+            .join("mcp.json")
+    } else {
+        home.join(".config/Code/User/mcp.json")
+    }
+}
+
+/// OpenCode user `opencode.json`. Uses [`dirs::config_dir`] when set; otherwise Roaming (Windows)
+/// or `~/.config` (Unix).
+fn opencode_user_config_path(home: &Path) -> PathBuf {
+    dirs::config_dir()
+        .map(|p| p.join("opencode").join("opencode.json"))
+        .unwrap_or_else(|| {
+            if cfg!(target_os = "windows") {
+                std::env::var_os("APPDATA")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| home.join("AppData").join("Roaming"))
+                    .join("opencode")
+                    .join("opencode.json")
+            } else {
+                home.join(".config").join("opencode").join("opencode.json")
+            }
+        })
+}
+
+/// Resolves the config file path for MCP merge for a supported agent.
+pub fn mcp_config_path(
+    agent_key: &str,
+    scope: McpScope,
+    project_root: &Path,
+) -> Result<PathBuf, McpDeployError> {
+    let key = normalize_mcp_agent_key(agent_key);
+    crate::validate_agent_key(key)
+        .map_err(|_| McpDeployError::UnknownAgent(agent_key.to_string()))?;
+
+    if !MCP_SUPPORTED_AGENT_KEYS.contains(&key) {
+        let supported = MCP_SUPPORTED_AGENT_KEYS.join(", ");
+        return Err(McpDeployError::UnsupportedAgent {
+            agent: agent_key.to_string(),
+            detail: format!("only [{}] are implemented", supported),
+        });
+    }
+
+    let home = home_dir_for_mcp()?;
+    let path = match (key, scope) {
+        ("cursor-agent", McpScope::Project) => project_root.join(".cursor/mcp.json"),
+        ("cursor-agent", McpScope::Global) => home.join(".cursor/mcp.json"),
+        ("claude", McpScope::Project) => project_root.join(".mcp.json"),
+        ("claude", McpScope::Global) => home.join(".claude.json"),
+        ("gemini", McpScope::Project) => project_root.join(".gemini/settings.json"),
+        ("gemini", McpScope::Global) => home.join(".gemini/settings.json"),
+        ("copilot", McpScope::Project) => project_root.join(".vscode/mcp.json"),
+        ("copilot", McpScope::Global) => vscode_user_mcp_path(&home),
+        ("opencode", McpScope::Project) => project_root.join("opencode.json"),
+        ("opencode", McpScope::Global) => opencode_user_config_path(&home),
+        ("codex", McpScope::Project) => project_root.join(".codex/config.toml"),
+        ("codex", McpScope::Global) => home.join(".codex/config.toml"),
+        _ => {
+            return Err(McpDeployError::UnsupportedAgent {
+                agent: agent_key.to_string(),
+                detail: "internal mapping error".to_string(),
+            })
+        }
+    };
+    Ok(path)
+}
+
+/// Cursor / Claude / Gemini `mcpServers` entry (no `type` field).
+fn transport_to_mcp_servers_json(t: &McpServerTransport) -> Value {
+    match t {
+        McpServerTransport::Stdio { command, args, env } => {
+            let mut m = Map::new();
+            m.insert("command".to_string(), json!(command));
+            m.insert("args".to_string(), json!(args));
+            if let Some(e) = env {
+                let env_obj: Map<String, Value> =
+                    e.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+                m.insert("env".to_string(), Value::Object(env_obj));
+            }
+            Value::Object(m)
+        }
+        McpServerTransport::Http { url, headers } => {
+            let mut m = Map::new();
+            m.insert("url".to_string(), json!(url));
+            if let Some(h) = headers {
+                let h_obj: Map<String, Value> =
+                    h.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+                m.insert("headers".to_string(), Value::Object(h_obj));
+            }
+            Value::Object(m)
+        }
+    }
+}
+
+/// VS Code `.vscode/mcp.json` server entry ([docs](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration)).
+fn transport_to_vscode_server_json(t: &McpServerTransport) -> Value {
+    match t {
+        McpServerTransport::Stdio { command, args, env } => {
+            let mut m = Map::new();
+            m.insert("type".to_string(), json!("stdio"));
+            m.insert("command".to_string(), json!(command));
+            m.insert("args".to_string(), json!(args));
+            if let Some(e) = env {
+                let env_obj: Map<String, Value> =
+                    e.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+                m.insert("env".to_string(), Value::Object(env_obj));
+            }
+            Value::Object(m)
+        }
+        McpServerTransport::Http { url, headers } => {
+            let mut m = Map::new();
+            m.insert("type".to_string(), json!("http"));
+            m.insert("url".to_string(), json!(url));
+            if let Some(h) = headers {
+                let h_obj: Map<String, Value> =
+                    h.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+                m.insert("headers".to_string(), Value::Object(h_obj));
+            }
+            Value::Object(m)
+        }
+    }
+}
+
+/// OpenCode `mcp.<name>` entry ([docs](https://dev.opencode.ai/docs/mcp-servers)).
+fn transport_to_opencode_server_json(t: &McpServerTransport) -> Value {
+    match t {
+        McpServerTransport::Stdio { command, args, env } => {
+            let mut cmd: Vec<Value> = vec![json!(command)];
+            cmd.extend(args.iter().map(|s| json!(s)));
+            let mut m = Map::new();
+            m.insert("type".to_string(), json!("local"));
+            m.insert("command".to_string(), Value::Array(cmd));
+            m.insert("enabled".to_string(), json!(true));
+            if let Some(e) = env {
+                let env_obj: Map<String, Value> =
+                    e.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+                m.insert("environment".to_string(), Value::Object(env_obj));
+            }
+            Value::Object(m)
+        }
+        McpServerTransport::Http { url, headers } => {
+            let mut m = Map::new();
+            m.insert("type".to_string(), json!("remote"));
+            m.insert("url".to_string(), json!(url));
+            m.insert("enabled".to_string(), json!(true));
+            if let Some(h) = headers {
+                let h_obj: Map<String, Value> =
+                    h.iter().map(|(k, v)| (k.clone(), json!(v))).collect();
+                m.insert("headers".to_string(), Value::Object(h_obj));
+            }
+            Value::Object(m)
+        }
+    }
+}
+
+fn codex_server_table(t: &McpServerTransport) -> toml::map::Map<String, TomlValue> {
+    let mut tbl = toml::map::Map::new();
+    match t {
+        McpServerTransport::Stdio { command, args, env } => {
+            tbl.insert("command".to_string(), TomlValue::String(command.clone()));
+            if !args.is_empty() {
+                tbl.insert(
+                    "args".to_string(),
+                    TomlValue::Array(args.iter().cloned().map(TomlValue::String).collect()),
+                );
+            }
+            if let Some(e) = env {
+                let mut et = toml::map::Map::new();
+                for (k, v) in e {
+                    et.insert(k.clone(), TomlValue::String(v.clone()));
+                }
+                tbl.insert("env".to_string(), TomlValue::Table(et));
+            }
+        }
+        McpServerTransport::Http { url, headers } => {
+            tbl.insert("url".to_string(), TomlValue::String(url.clone()));
+            if let Some(h) = headers {
+                let mut ht = toml::map::Map::new();
+                for (k, v) in h {
+                    ht.insert(k.clone(), TomlValue::String(v.clone()));
+                }
+                tbl.insert("http_headers".to_string(), TomlValue::Table(ht));
+            }
+        }
+    }
+    tbl
+}
+
+fn read_or_empty_json_object(path: &Path) -> Result<Value, McpDeployError> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    let raw = fs::read_to_string(path)?;
+    let v: Value = serde_json::from_str(&raw)?;
+    if !v.is_object() {
+        return Err(McpDeployError::InvalidConfig(
+            "config file must contain a JSON object at the root".to_string(),
+        ));
+    }
+    Ok(v)
+}
+
+fn merge_json_bucket(
+    mut root: Value,
+    bucket_key: &str,
+    server_name: &str,
+    server_json: Value,
+    overwrite: bool,
+) -> Result<Value, McpDeployError> {
+    let obj = root
+        .as_object_mut()
+        .ok_or_else(|| McpDeployError::InvalidConfig("root must be a JSON object".to_string()))?;
+
+    let servers = obj
+        .entry(bucket_key.to_string())
+        .or_insert_with(|| json!({}));
+    let map = servers.as_object_mut().ok_or_else(|| {
+        McpDeployError::InvalidConfig(format!("'{}' must be a JSON object", bucket_key))
+    })?;
+
+    if map.contains_key(server_name) && !overwrite {
+        return Err(McpDeployError::AlreadyExists {
+            name: server_name.to_string(),
+        });
+    }
+    map.insert(server_name.to_string(), server_json);
+    Ok(root)
+}
+
+fn merge_opencode_mcp(
+    mut root: Value,
+    server_name: &str,
+    server_json: Value,
+    overwrite: bool,
+) -> Result<Value, McpDeployError> {
+    let obj = root
+        .as_object_mut()
+        .ok_or_else(|| McpDeployError::InvalidConfig("root must be a JSON object".to_string()))?;
+
+    let mcp = obj.entry("mcp".to_string()).or_insert_with(|| json!({}));
+    let map = mcp
+        .as_object_mut()
+        .ok_or_else(|| McpDeployError::InvalidConfig("'mcp' must be a JSON object".to_string()))?;
+
+    if map.contains_key(server_name) && !overwrite {
+        return Err(McpDeployError::AlreadyExists {
+            name: server_name.to_string(),
+        });
+    }
+    map.insert(server_name.to_string(), server_json);
+    Ok(root)
+}
+
+fn read_or_empty_toml_root(
+    path: &Path,
+) -> Result<toml::map::Map<String, TomlValue>, McpDeployError> {
+    if !path.exists() {
+        return Ok(toml::map::Map::new());
+    }
+    let raw = fs::read_to_string(path)?;
+    let v: TomlValue =
+        toml::from_str(&raw).map_err(|e| McpDeployError::TomlParse(e.to_string()))?;
+    match v {
+        TomlValue::Table(t) => Ok(t),
+        _ => Err(McpDeployError::InvalidConfig(
+            "config.toml root must be a TOML table".to_string(),
+        )),
+    }
+}
+
+fn merge_codex_mcp_servers(
+    mut root: toml::map::Map<String, TomlValue>,
+    server_name: &str,
+    server_tbl: toml::map::Map<String, TomlValue>,
+    overwrite: bool,
+) -> Result<toml::map::Map<String, TomlValue>, McpDeployError> {
+    let servers_val = root
+        .entry("mcp_servers".to_string())
+        .or_insert_with(|| TomlValue::Table(toml::map::Map::new()));
+
+    let servers_tbl = servers_val.as_table_mut().ok_or_else(|| {
+        McpDeployError::InvalidConfig("'mcp_servers' must be a TOML table".to_string())
+    })?;
+
+    if servers_tbl.contains_key(server_name) && !overwrite {
+        return Err(McpDeployError::AlreadyExists {
+            name: server_name.to_string(),
+        });
+    }
+    servers_tbl.insert(server_name.to_string(), TomlValue::Table(server_tbl));
+    Ok(root)
+}
+
+/// Parses `KEY=value` into a map entry (first `=` separates key and value).
+pub fn parse_env_pairs(pairs: &[String]) -> Result<HashMap<String, String>, McpDeployError> {
+    let mut m = HashMap::new();
+    for p in pairs {
+        let (k, v) = p
+            .split_once('=')
+            .ok_or_else(|| McpDeployError::InvalidEnvPair(p.clone()))?;
+        if k.is_empty() {
+            return Err(McpDeployError::InvalidEnvPair(p.clone()));
+        }
+        m.insert(k.to_string(), v.to_string());
+    }
+    Ok(m)
+}
+
+/// Parses `KEY=value` for HTTP headers.
+pub fn parse_header_pairs(pairs: &[String]) -> Result<HashMap<String, String>, McpDeployError> {
+    parse_env_pairs(pairs)
+}
+
+/// Reads (or creates) the agent config file, merges the server entry, writes back.
+///
+/// Returns the path written.
+pub fn add_mcp_server(opts: AddMcpServerOptions) -> Result<PathBuf, McpDeployError> {
+    let key = normalize_mcp_agent_key(&opts.agent_key);
+    let path = mcp_config_path(key, opts.scope, &opts.project_root)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    match key {
+        "codex" => {
+            let mut root = read_or_empty_toml_root(&path)?;
+            let server_tbl = codex_server_table(&opts.transport);
+            root = merge_codex_mcp_servers(root, &opts.server_name, server_tbl, opts.overwrite)?;
+            let out = TomlValue::Table(root);
+            let s = toml::to_string_pretty(&out)
+                .map_err(|e| McpDeployError::TomlSerialize(e.to_string()))?;
+            fs::write(&path, s)?;
+        }
+        "opencode" => {
+            let existing = read_or_empty_json_object(&path)?;
+            let server_json = transport_to_opencode_server_json(&opts.transport);
+            let merged =
+                merge_opencode_mcp(existing, &opts.server_name, server_json, opts.overwrite)?;
+            let out = serde_json::to_string_pretty(&merged)?;
+            fs::write(&path, out)?;
+        }
+        "copilot" => {
+            let existing = read_or_empty_json_object(&path)?;
+            let server_json = transport_to_vscode_server_json(&opts.transport);
+            let merged = merge_json_bucket(
+                existing,
+                "servers",
+                &opts.server_name,
+                server_json,
+                opts.overwrite,
+            )?;
+            let out = serde_json::to_string_pretty(&merged)?;
+            fs::write(&path, out)?;
+        }
+        "cursor-agent" | "claude" | "gemini" => {
+            let existing = read_or_empty_json_object(&path)?;
+            let server_json = transport_to_mcp_servers_json(&opts.transport);
+            let merged = merge_json_bucket(
+                existing,
+                "mcpServers",
+                &opts.server_name,
+                server_json,
+                opts.overwrite,
+            )?;
+            let out = serde_json::to_string_pretty(&merged)?;
+            fs::write(&path, out)?;
+        }
+        _ => {
+            return Err(McpDeployError::UnsupportedAgent {
+                agent: opts.agent_key.clone(),
+                detail: "internal dispatch error".to_string(),
+            });
+        }
+    }
+
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::TempDir;
+
+    fn mcp_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn merge_new_file_cursor_project() {
+        let tmp = TempDir::new().unwrap();
+        let path = add_mcp_server(AddMcpServerOptions {
+            agent_key: "cursor-agent".to_string(),
+            scope: McpScope::Project,
+            project_root: tmp.path().to_path_buf(),
+            server_name: "demo".to_string(),
+            transport: McpServerTransport::Http {
+                url: "http://127.0.0.1:8730/mcp".to_string(),
+                headers: None,
+            },
+            overwrite: false,
+        })
+        .unwrap();
+        assert_eq!(path, tmp.path().join(".cursor/mcp.json"));
+        let v: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            v["mcpServers"]["demo"]["url"],
+            json!("http://127.0.0.1:8730/mcp")
+        );
+    }
+
+    #[test]
+    fn merge_preserves_other_servers_and_keys() {
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join(".cursor/mcp.json");
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(
+            &p,
+            r#"{"mcpServers":{"old":{"url":"http://old/mcp"}},"x":1}"#,
+        )
+        .unwrap();
+        add_mcp_server(AddMcpServerOptions {
+            agent_key: "cursor-agent".to_string(),
+            scope: McpScope::Project,
+            project_root: tmp.path().to_path_buf(),
+            server_name: "new".to_string(),
+            transport: McpServerTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec!["-y".into(), "pkg".into()],
+                env: None,
+            },
+            overwrite: false,
+        })
+        .unwrap();
+        let v: Value = serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap();
+        assert_eq!(v["x"], json!(1));
+        assert_eq!(v["mcpServers"]["old"]["url"], json!("http://old/mcp"));
+        assert_eq!(v["mcpServers"]["new"]["command"], json!("npx"));
+    }
+
+    #[test]
+    fn duplicate_errors_without_overwrite() {
+        let tmp = TempDir::new().unwrap();
+        add_mcp_server(AddMcpServerOptions {
+            agent_key: "claude".to_string(),
+            scope: McpScope::Project,
+            project_root: tmp.path().to_path_buf(),
+            server_name: "s".to_string(),
+            transport: McpServerTransport::Http {
+                url: "http://a".into(),
+                headers: None,
+            },
+            overwrite: false,
+        })
+        .unwrap();
+        let e = add_mcp_server(AddMcpServerOptions {
+            agent_key: "claude".to_string(),
+            scope: McpScope::Project,
+            project_root: tmp.path().to_path_buf(),
+            server_name: "s".to_string(),
+            transport: McpServerTransport::Http {
+                url: "http://b".into(),
+                headers: None,
+            },
+            overwrite: false,
+        })
+        .unwrap_err();
+        assert!(matches!(e, McpDeployError::AlreadyExists { .. }));
+    }
+
+    #[test]
+    fn claude_global_merges_top_level_mcp_servers() {
+        let _lock = mcp_env_lock();
+        let tmp = TempDir::new().unwrap();
+        let prev = std::env::var("AIKIT_MCP_TEST_HOME");
+        std::env::set_var("AIKIT_MCP_TEST_HOME", tmp.path());
+        let fake_claude = tmp.path().join(".claude.json");
+        fs::write(
+            &fake_claude,
+            r#"{"mcpServers":{"keep":{"command":"c"}},"session":"x"}"#,
+        )
+        .unwrap();
+        let path = add_mcp_server(AddMcpServerOptions {
+            agent_key: "claude".to_string(),
+            scope: McpScope::Global,
+            project_root: PathBuf::from("C:\\unused"),
+            server_name: "added".to_string(),
+            transport: McpServerTransport::Http {
+                url: "http://h/mcp".into(),
+                headers: None,
+            },
+            overwrite: false,
+        })
+        .unwrap();
+        assert_eq!(path, fake_claude);
+        let v: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["session"], json!("x"));
+        assert_eq!(v["mcpServers"]["keep"]["command"], json!("c"));
+        assert_eq!(v["mcpServers"]["added"]["url"], json!("http://h/mcp"));
+        match prev {
+            Ok(h) => std::env::set_var("AIKIT_MCP_TEST_HOME", h),
+            Err(_) => std::env::remove_var("AIKIT_MCP_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    fn copilot_global_path_under_fake_home() {
+        let _lock = mcp_env_lock();
+        let tmp = TempDir::new().unwrap();
+        let prev_home = std::env::var("AIKIT_MCP_TEST_HOME");
+        std::env::set_var("AIKIT_MCP_TEST_HOME", tmp.path());
+        #[cfg(windows)]
+        let prev_appdata = std::env::var("APPDATA").ok();
+        #[cfg(windows)]
+        std::env::remove_var("APPDATA");
+
+        let p = mcp_config_path("copilot", McpScope::Global, tmp.path()).unwrap();
+        #[cfg(windows)]
+        assert_eq!(
+            p,
+            tmp.path()
+                .join("AppData")
+                .join("Roaming")
+                .join("Code")
+                .join("User")
+                .join("mcp.json")
+        );
+        #[cfg(not(windows))]
+        assert_eq!(
+            p,
+            tmp.path()
+                .join(".config")
+                .join("Code")
+                .join("User")
+                .join("mcp.json")
+        );
+
+        #[cfg(windows)]
+        match prev_appdata {
+            Some(ref v) => std::env::set_var("APPDATA", v),
+            None => std::env::remove_var("APPDATA"),
+        }
+        match prev_home {
+            Ok(h) => std::env::set_var("AIKIT_MCP_TEST_HOME", h),
+            Err(_) => std::env::remove_var("AIKIT_MCP_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    fn gemini_merges_into_settings_json() {
+        let tmp = TempDir::new().unwrap();
+        let settings = tmp.path().join(".gemini/settings.json");
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            r#"{"editor":"x","mcpServers":{"a":{"command":"old"}}}"#,
+        )
+        .unwrap();
+        add_mcp_server(AddMcpServerOptions {
+            agent_key: "gemini".to_string(),
+            scope: McpScope::Project,
+            project_root: tmp.path().to_path_buf(),
+            server_name: "b".to_string(),
+            transport: McpServerTransport::Http {
+                url: "http://g/mcp".into(),
+                headers: None,
+            },
+            overwrite: false,
+        })
+        .unwrap();
+        let v: Value = serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(v["editor"], json!("x"));
+        assert_eq!(v["mcpServers"]["a"]["command"], json!("old"));
+        assert_eq!(v["mcpServers"]["b"]["url"], json!("http://g/mcp"));
+    }
+
+    #[test]
+    fn copilot_writes_vscode_servers_shape() {
+        let tmp = TempDir::new().unwrap();
+        add_mcp_server(AddMcpServerOptions {
+            agent_key: "copilot".to_string(),
+            scope: McpScope::Project,
+            project_root: tmp.path().to_path_buf(),
+            server_name: "ctx".to_string(),
+            transport: McpServerTransport::Http {
+                url: "https://mcp.example/mcp".into(),
+                headers: None,
+            },
+            overwrite: false,
+        })
+        .unwrap();
+        let p = tmp.path().join(".vscode/mcp.json");
+        let v: Value = serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap();
+        assert_eq!(v["servers"]["ctx"]["type"], json!("http"));
+        assert_eq!(v["servers"]["ctx"]["url"], json!("https://mcp.example/mcp"));
+    }
+
+    #[test]
+    fn opencode_merges_under_mcp() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("opencode.json"),
+            r#"{"mcp":{"old":{"type":"remote","url":"http://x","enabled":true}},"x":1}"#,
+        )
+        .unwrap();
+        add_mcp_server(AddMcpServerOptions {
+            agent_key: "opencode".to_string(),
+            scope: McpScope::Project,
+            project_root: tmp.path().to_path_buf(),
+            server_name: "new".to_string(),
+            transport: McpServerTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec!["-y".into(), "pkg".into()],
+                env: None,
+            },
+            overwrite: false,
+        })
+        .unwrap();
+        let v: Value =
+            serde_json::from_str(&fs::read_to_string(tmp.path().join("opencode.json")).unwrap())
+                .unwrap();
+        assert_eq!(v["x"], json!(1));
+        assert_eq!(v["mcp"]["new"]["type"], json!("local"));
+        assert_eq!(v["mcp"]["new"]["command"][0], json!("npx"));
+    }
+
+    #[test]
+    fn codex_writes_mcp_servers_toml() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join(".codex/config.toml");
+        fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        fs::write(&cfg, "[experimental]\nfoo = 1\n").unwrap();
+        add_mcp_server(AddMcpServerOptions {
+            agent_key: "codex".to_string(),
+            scope: McpScope::Project,
+            project_root: tmp.path().to_path_buf(),
+            server_name: "ctx7".to_string(),
+            transport: McpServerTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec!["-y".into(), "@x/y".into()],
+                env: None,
+            },
+            overwrite: false,
+        })
+        .unwrap();
+        let raw = fs::read_to_string(&cfg).unwrap();
+        assert!(raw.contains("[mcp_servers.ctx7]"));
+        assert!(raw.contains("command = \"npx\""));
+        let v: TomlValue = toml::from_str(&raw).unwrap();
+        let root = v.as_table().unwrap();
+        assert_eq!(root["experimental"]["foo"], TomlValue::Integer(1));
+        let ms = root["mcp_servers"].as_table().unwrap();
+        assert_eq!(ms["ctx7"]["command"], TomlValue::String("npx".into()));
+    }
+
+    #[test]
+    fn normalize_agent_aliases() {
+        assert_eq!(normalize_mcp_agent_key("cursor"), "cursor-agent");
+        assert_eq!(normalize_mcp_agent_key("vscode"), "copilot");
+        assert_eq!(normalize_mcp_agent_key("claude"), "claude");
+    }
+
+    #[test]
+    fn unknown_agent_key_errors() {
+        let tmp = TempDir::new().unwrap();
+        let e = mcp_config_path("not-an-agent", McpScope::Project, tmp.path()).unwrap_err();
+        assert!(matches!(e, McpDeployError::UnknownAgent(_)));
+    }
+
+    #[test]
+    fn unsupported_catalog_agent_errors() {
+        let tmp = TempDir::new().unwrap();
+        let e = mcp_config_path("qwen", McpScope::Project, tmp.path()).unwrap_err();
+        assert!(matches!(e, McpDeployError::UnsupportedAgent { .. }));
+    }
+}

--- a/aikit-sdk/src/mcp_deploy.rs
+++ b/aikit-sdk/src/mcp_deploy.rs
@@ -736,25 +736,25 @@ mod tests {
         std::env::remove_var("APPDATA");
 
         let p = mcp_config_path("copilot", McpScope::Global, tmp.path()).unwrap();
-        #[cfg(windows)]
-        assert_eq!(
-            p,
-            tmp.path()
+        let expected = match std::env::consts::OS {
+            "windows" => tmp
+                .path()
                 .join("AppData")
                 .join("Roaming")
                 .join("Code")
                 .join("User")
-                .join("mcp.json")
-        );
-        #[cfg(not(windows))]
-        assert_eq!(
-            p,
-            tmp.path()
+                .join("mcp.json"),
+            "macos" => tmp
+                .path()
+                .join("Library/Application Support/Code/User/mcp.json"),
+            _ => tmp
+                .path()
                 .join(".config")
                 .join("Code")
                 .join("User")
-                .join("mcp.json")
-        );
+                .join("mcp.json"),
+        };
+        assert_eq!(p, expected);
 
         #[cfg(windows)]
         match prev_appdata {

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,0 +1,148 @@
+//! `aikit mcp` — merge MCP server entries into agent-specific JSON files.
+
+use anyhow::{bail, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+
+use aikit_sdk::{
+    add_mcp_server, mcp_supported_agents, normalize_mcp_agent_key, parse_env_pairs,
+    parse_header_pairs, AddMcpServerOptions, McpScope, McpServerTransport,
+};
+
+#[derive(Parser, Debug)]
+pub struct McpArgs {
+    #[command(subcommand)]
+    pub cmd: McpCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum McpCommands {
+    /// Agents that support `mcp add` and their config paths
+    List,
+    /// Add or replace one MCP server entry (JSON `mcpServers` / `servers` / `mcp`, or Codex TOML)
+    Add(McpAddArgs),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum ScopeArg {
+    Project,
+    Global,
+}
+
+#[derive(Parser, Debug)]
+pub struct McpAddArgs {
+    /// Agent: `cursor-agent`|`cursor`, `claude`, `gemini`, `copilot`|`vscode`, `opencode`, `codex`
+    #[arg(long)]
+    pub agent: String,
+    #[arg(long, value_enum)]
+    pub scope: ScopeArg,
+    /// Project root when `--scope project` (default: current directory)
+    #[arg(long, default_value = ".")]
+    pub project: std::path::PathBuf,
+    /// MCP server id inside `mcpServers`
+    #[arg(long)]
+    pub name: String,
+    /// Streamable HTTP / remote MCP URL (mutually exclusive with `--command`)
+    #[arg(long)]
+    pub url: Option<String>,
+    /// Executable for stdio MCP (mutually exclusive with `--url`)
+    #[arg(long)]
+    pub command: Option<String>,
+    /// One argv token for stdio MCP; repeat for each argument
+    #[arg(long = "arg", action = clap::ArgAction::Append)]
+    pub cmd_args: Vec<String>,
+    /// `KEY=value` for stdio `env`; repeat per variable
+    #[arg(long, action = clap::ArgAction::Append)]
+    pub env: Vec<String>,
+    /// `KEY=value` for HTTP `headers`; repeat per header
+    #[arg(long, action = clap::ArgAction::Append)]
+    pub header: Vec<String>,
+    /// Replace an existing `mcpServers.<name>` entry
+    #[arg(long)]
+    pub overwrite: bool,
+}
+
+pub fn execute(args: McpArgs) -> Result<()> {
+    match args.cmd {
+        McpCommands::List => execute_list(),
+        McpCommands::Add(a) => execute_add(a),
+    }
+}
+
+fn execute_list() -> Result<()> {
+    println!(
+        "{:<14} {:<16} {:<28} GLOBAL_FILE",
+        "AGENT_KEY", "DISPLAY", "PROJECT_FILE",
+    );
+    for row in mcp_supported_agents() {
+        println!(
+            "{:<14} {:<16} {:<28} {}",
+            row.agent_key, row.display_name, row.project_config_path, row.global_config_path
+        );
+    }
+    println!();
+    println!(
+        "Aliases: `--agent cursor` → `{}`; `--agent vscode` → `{}`.",
+        normalize_mcp_agent_key("cursor"),
+        normalize_mcp_agent_key("vscode")
+    );
+    println!(
+        "The aikit catalog has {} agents; {} keys above are supported by `mcp add`.",
+        aikit_sdk::all_agents().len(),
+        aikit_sdk::MCP_SUPPORTED_AGENT_KEYS.len()
+    );
+    Ok(())
+}
+
+fn execute_add(args: McpAddArgs) -> Result<()> {
+    let scope = match args.scope {
+        ScopeArg::Project => McpScope::Project,
+        ScopeArg::Global => McpScope::Global,
+    };
+
+    let project_root = if args.project.as_os_str().is_empty() {
+        bail!("--project must not be empty");
+    } else {
+        std::fs::canonicalize(&args.project).unwrap_or_else(|_| args.project.clone())
+    };
+
+    let transport = match (&args.url, &args.command) {
+        (Some(u), None) => {
+            let headers = if args.header.is_empty() {
+                None
+            } else {
+                Some(parse_header_pairs(&args.header).map_err(|e| anyhow::anyhow!("{}", e))?)
+            };
+            McpServerTransport::Http {
+                url: u.clone(),
+                headers,
+            }
+        }
+        (None, Some(cmd)) => {
+            let env = if args.env.is_empty() {
+                None
+            } else {
+                Some(parse_env_pairs(&args.env).map_err(|e| anyhow::anyhow!("{}", e))?)
+            };
+            McpServerTransport::Stdio {
+                command: cmd.clone(),
+                args: args.cmd_args.clone(),
+                env,
+            }
+        }
+        (None, None) => bail!("specify either --url or --command"),
+        (Some(_), Some(_)) => bail!("specify only one of --url or --command"),
+    };
+
+    let path = add_mcp_server(AddMcpServerOptions {
+        agent_key: args.agent,
+        scope,
+        project_root,
+        server_name: args.name,
+        transport,
+        overwrite: args.overwrite,
+    })
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    println!("{}", path.display());
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod agents;
 mod check;
 mod init;
 mod llm;
+mod mcp;
 mod release;
 mod run;
 mod template_package; // Old template zip archive builder (used by release command)
@@ -63,6 +64,8 @@ pub enum Commands {
     Llm(llm::LlmArgs),
     /// List persisted agent definitions
     Agents(agents::AgentsArgs),
+    /// Register MCP servers in agent JSON config files
+    Mcp(mcp::McpArgs),
 }
 
 /// Initialize `tracing` when `RUST_LOG` is set or `--debug` is passed (so SDK logs are visible).
@@ -131,6 +134,7 @@ pub fn run() -> Result<()> {
         Some(Commands::Run(args)) => run::execute(args)?,
         Some(Commands::Llm(args)) => rt.block_on(llm::execute(args))?,
         Some(Commands::Agents(args)) => agents::execute(args)?,
+        Some(Commands::Mcp(args)) => mcp::execute(args)?,
         // This should never be reached due to arg_required_else_help = true
         None => unreachable!("arg_required_else_help should prevent None commands"),
     }

--- a/webdocs/cli-commands.mdx
+++ b/webdocs/cli-commands.mdx
@@ -14,6 +14,7 @@ AIKit organizes functionality into logical command groups:
 ### Core Commands
 - **`init`** - Initialize new Spec-Driven Development projects
 - **`run`** - Run a coding agent with a prompt (supports streaming events)
+- **`mcp`** - List supported agents or merge one MCP server into agent config files
 - **`llm`** - Invoke an LLM via OpenAI-compatible API (supports streaming and JSON output)
 - **`check`** - Validate installed tools and AI agent CLIs
 - **`version`** - Display version information
@@ -55,6 +56,7 @@ aikit <command> --help
 |---------|---------|---------|
 | `init` | Create new project | `aikit init my-project` |
 | `run` | Run a coding agent | `aikit run --agent claude -p "Task"` |
+| `mcp` | MCP config merge | `aikit mcp list` / `aikit mcp add --agent claude ...` |
 | `llm` | Invoke an LLM | `aikit llm -m gpt-4o -p "Hello"` |
 | `check` | Validate environment | `aikit check` |
 | `install` | Install package | `aikit install https://github.com/user/repo` |
@@ -217,6 +219,35 @@ Fields:
 See [aikit-sdk README](../aikit-sdk/README.md) for complete streaming API documentation.
 
 Run `aikit run --help` for the authoritative option reference.
+
+### mcp
+
+Register MCP servers in agent-specific config files (JSON or TOML). Six catalog keys are supported: `cursor-agent`, `claude`, `gemini`, `copilot`, `opencode`, `codex` (aliases: `cursor`, `vscode`). See [MCP registration](/mcp) for paths, Rust (`aikit-sdk`), and Python (`aikit-py`) equivalents.
+
+```bash
+# Agents and config paths (project vs global)
+aikit mcp list
+
+# Stdio server: repeat --arg for each argv token; repeat --env KEY=value for env
+aikit mcp add --agent claude --scope project --project . --name fs \
+  --command npx --arg -y --arg @modelcontextprotocol/server-filesystem --arg .
+
+# HTTP server: repeat --header KEY=value for headers
+aikit mcp add --agent gemini --scope project --project . --name api \
+  --url http://127.0.0.1:8730/mcp
+```
+
+| Flag | Description |
+| --- | --- |
+| `--agent` | Catalog key or alias (`cursor`, `vscode`) |
+| `--scope` | `project` or `global` |
+| `--project` | Project root when scope is project (default `.`) |
+| `--name` | Server id inside `mcpServers` / `servers` / `mcp` / Codex table |
+| `--command` / `--url` | Stdio executable or HTTP URL (exactly one required) |
+| `--arg` | One argv token for stdio (repeat) |
+| `--env` | `KEY=value` for stdio env (repeat) |
+| `--header` | `KEY=value` for HTTP headers (repeat) |
+| `--overwrite` | Replace existing entry with the same name |
 
 ### llm
 

--- a/webdocs/development.mdx
+++ b/webdocs/development.mdx
@@ -80,6 +80,7 @@ src/
 
 | Module | Responsibility | Key Files |
 |--------|----------------|-----------|
+| `aikit-sdk` | Catalog, deploy, MCP merge, run/events, agent detection | `aikit-sdk/` (Rust crate; used by CLI and **aikit-py**) |
 | `cli` | User interaction, command parsing | `mod.rs`, `commands/` |
 | `core` | Business logic, external integrations | `agent.rs`, `package.rs` |
 | `models` | Data structures, serialization | `config.rs`, `package.rs` |

--- a/webdocs/docs.json
+++ b/webdocs/docs.json
@@ -29,6 +29,7 @@
             "group": "Commands & Usage",
             "pages": [
               "cli-commands",
+              "mcp",
               "examples"
             ]
           },

--- a/webdocs/examples.mdx
+++ b/webdocs/examples.mdx
@@ -34,6 +34,34 @@ npm install -g @anthropic-ai/claude-code
 # Each agent has different installation requirements
 ```
 
+## MCP server registration
+
+**Goal:** Add a project-local MCP server entry for Claude (writes or merges `.mcp.json`).
+
+```bash
+cd /path/to/your/repo
+aikit mcp add --agent claude --scope project --project . --name demo-fs \
+  --command npx \
+  --arg -y \
+  --arg @modelcontextprotocol/server-filesystem \
+  --arg .
+```
+
+From Python (after `maturin develop` in `aikit-py/`):
+
+```python
+import aikit_py
+
+aikit_py.add_mcp_server(
+    "claude", "/path/to/your/repo", "demo-fs",
+    scope="project", command="npx",
+    args=["-y", "@modelcontextprotocol/server-filesystem", "."],
+    overwrite=False,
+)
+```
+
+See [MCP registration](/mcp) and [CLI Commands](cli-commands.mdx#mcp).
+
 ## Basic Usage Examples
 
 ### 1. Initialize a New Project

--- a/webdocs/index.mdx
+++ b/webdocs/index.mdx
@@ -5,7 +5,7 @@ description: "AIKit: multi-agent template package manager, CLI, and Rust/Python 
 
 # AIKit Documentation
 
-**AIKit** is a **multi-agent template package manager and CLI**: install and publish `aikit.toml` packages from GitHub or a local directory, scaffold projects, and run supported coding-agent CLIs. **aikit-sdk** (Rust) and **aikit-py** (Python) provide the same **programmatic gateway** (catalog, paths, deploy, detection, run/events). This site covers installation, commands, packages, and agents.
+**AIKit** is a **multi-agent template package manager and CLI**: install and publish `aikit.toml` packages from GitHub or a local directory, scaffold projects, and run supported coding-agent CLIs. **aikit-sdk** (Rust) and **aikit-py** (Python) provide the same **programmatic gateway** (catalog, paths, deploy, MCP merge, detection, run/events). This site covers installation, commands, packages, agents, and MCP registration.
 
 ## Getting Started
 
@@ -20,13 +20,20 @@ description: "AIKit: multi-agent template package manager, CLI, and Rust/Python 
 
 ## Core Documentation
 
-<Columns cols={3}>
+<Columns cols={2}>
   <Card
     title="CLI Commands"
     icon="terminal"
     href="/cli-commands"
   >
     Complete reference for all AIKit command-line operations, with syntax, options, and examples.
+  </Card>
+  <Card
+    title="MCP registration"
+    icon="plug"
+    href="/mcp"
+  >
+    Merge MCP servers into Cursor, Claude, Gemini, VS Code, OpenCode, and Codex configs via CLI, Rust, or Python.
   </Card>
   <Card
     title="Configuration"
@@ -89,13 +96,14 @@ AIKit helps you:
 - **Ship template packages** (`aikit.toml`) that install into many coding-assistant layouts
 - **Install packages** from **GitHub (owner/repo)** or a **local directory**
 - **Scaffold projects** with `aikit init` and **run** supported agent CLIs with `aikit run`
-- **Automate** the same behavior via **aikit-sdk** / **aikit-py** (catalog, deploy, detection, run, event stream)
+- **Automate** the same behavior via **aikit-sdk** / **aikit-py** (catalog, deploy, MCP merge, detection, run, event stream)
 
 ### Key features
 
 - **Multi-agent layouts** - One package definition, many target agents (18 in the catalog)
 - **CLI + libraries** - `aikit` for day-to-day use; Rust/Python bindings for tools and CI
 - **Runnable agents** - `aikit run` supports `codex`, `claude`, `gemini`, `opencode`, `agent`
+- **MCP registration** - `aikit mcp` plus matching APIs in **aikit-sdk** and **aikit-py** for six assistants
 - **GitHub-oriented publish flow** - `aikit package publish` / `aikit release` for releases and assets
 
 ### Quick example
@@ -119,7 +127,7 @@ This documentation is organized to support your AIKit journey:
 
 1. **Getting Started** - Installation and basic usage
 2. **Core Concepts** - Understanding AIKit's architecture and package system
-3. **Reference Guides** - Detailed documentation for commands, configuration, and agents
+3. **Reference Guides** - Commands, MCP, configuration, and agents
 4. **Examples** - Practical workflows and use cases
 5. **Troubleshooting** - Solutions for common issues
 

--- a/webdocs/llms-txt.mdx
+++ b/webdocs/llms-txt.mdx
@@ -37,6 +37,7 @@ AIKit organizes documentation into logical sections that mirror our user journey
 
 ## Core Documentation
 - [CLI Commands](cli-commands.mdx): Complete reference for all AIKit command-line interface commands with examples and options
+- [MCP registration](mcp.mdx): Merge MCP servers into agent configs via CLI, aikit-sdk, or aikit-py
 - [Configuration](configuration.mdx): Complete guide to configuring AIKit including AikConfig structure, file locations, and agent-specific settings
 - [Package Management](packages.mdx): Guide to creating, publishing, and managing AIKit packages for sharing AI agent extensions
 - [AI Agent Integration](agents.mdx): Complete guide to integrating AIKit with 18 AI coding assistants including setup, configuration, and capability comparison

--- a/webdocs/llms.txt
+++ b/webdocs/llms.txt
@@ -6,6 +6,7 @@
 
 ## Core Documentation
 - [CLI Commands](cli-commands.mdx): Complete reference for all AIKit command-line interface commands with examples and options
+- [MCP registration](mcp.mdx): Merge MCP servers into agent configs via CLI, aikit-sdk, or aikit-py
 - [Configuration](configuration.mdx): Complete guide to configuring AIKit including AikConfig structure, file locations, and agent-specific settings
 - [Package Management](packages.mdx): Guide to creating, publishing, and managing AIKit packages for sharing AI agent extensions
 - [AI Agent Integration](agents.mdx): Complete guide to integrating AIKit with 18 AI coding assistants including setup, configuration, and capability comparison

--- a/webdocs/mcp.mdx
+++ b/webdocs/mcp.mdx
@@ -1,0 +1,57 @@
+---
+title: "MCP server registration"
+description: "Merge MCP server definitions into Cursor, Claude, Gemini, VS Code Copilot, OpenCode, and Codex config files via the CLI, aikit-sdk, or aikit-py."
+---
+
+# MCP server registration
+
+AIKit can **merge** one MCP server entry at a time into the JSON or TOML file each assistant already uses. This matches product-specific shapes (`mcpServers`, VS Code `servers`, OpenCode `mcp`, Codex `[mcp_servers.*]`).
+
+## Supported agents
+
+| Catalog key | Also accepted | Notes |
+| --- | --- | --- |
+| `cursor-agent` | `cursor` | `.cursor/mcp.json` |
+| `claude` | | `.mcp.json` / `~/.claude.json` |
+| `gemini` | | `.gemini/settings.json` |
+| `copilot` | `vscode` | `.vscode/mcp.json` or VS Code user `mcp.json` |
+| `opencode` | | `opencode.json` |
+| `codex` | | `.codex/config.toml` |
+
+Run `aikit mcp list` for paths and aliases. Six keys are implemented; the full agent catalog is larger.
+
+## CLI
+
+```bash
+# Table of agents, project vs global paths
+aikit mcp list
+
+# Stdio MCP under project .mcp.json (repeat --arg for each argv token)
+aikit mcp add --agent claude --scope project --project . --name fs \
+  --command npx \
+  --arg -y \
+  --arg @modelcontextprotocol/server-filesystem \
+  --arg .
+
+# HTTP MCP with optional headers (repeat --header KEY=value)
+aikit mcp add --agent gemini --scope project --project . --name api \
+  --url http://127.0.0.1:8730/mcp \
+  --header Authorization=Bearer\ token
+```
+
+- `--scope project|global` — project paths are under `--project` (default `.`); global uses your home directory.
+- Exactly one of `--url` or `--command` is required.
+- `--overwrite` replaces an existing server with the same `--name`.
+
+## Rust (`aikit-sdk`)
+
+Use `add_mcp_server`, `mcp_config_path`, `McpScope`, `McpServerTransport`, and helpers such as `mcp_supported_agents` and `normalize_mcp_agent_key`. See the [aikit-sdk README](https://github.com/goaikit/aikit/blob/main/aikit-sdk/README.md#mcp-config-merge) in the repository.
+
+## Python (`aikit-py`)
+
+Use `add_mcp_server`, `mcp_config_path`, `mcp_supported_agents`, `mcp_supported_agent_keys`, `normalize_mcp_agent_key`, and `mcp_parse_env_pairs` / `mcp_parse_header_pairs`. Raises `McpDeployError` on merge errors. See [aikit-py README](https://github.com/goaikit/aikit/blob/main/aikit-py/README.md#mcp-server-config-merge) and `aikit-py/examples/mcp_deploy_stdio.py`.
+
+## See also
+
+- [CLI Commands](cli-commands.mdx) — full CLI reference including `mcp`
+- [Examples](examples.mdx) — copy-paste MCP snippets

--- a/webdocs/packages.mdx
+++ b/webdocs/packages.mdx
@@ -511,6 +511,7 @@ ls -ld .aikit/
 ## See Also
 
 - [CLI Commands](cli-commands.mdx) - Command-line interface reference
+- [MCP registration](mcp.mdx) - Merge MCP servers into agent configs
 - [Configuration Guide](configuration.mdx) - Setup and configuration options
 - [Usage Examples](examples.mdx) - Practical examples and tutorials
 - [Troubleshooting](troubleshooting.mdx) - Common issues and solutions


### PR DESCRIPTION
Adds `aikit-sdk::mcp_deploy` and `aikit mcp list` / `aikit mcp add` to merge MCP server entries into product-specific config files.

**Agents:** `cursor-agent` (alias `cursor`), `claude`, `gemini`, `copilot` (alias `vscode`), `opencode`, `codex`.

**Formats:** JSON `mcpServers` (Cursor, Claude, Gemini), VS Code `servers` with `type`, OpenCode root `mcp`, Codex TOML `[mcp_servers.*]`.

**Cross-platform:** Windows uses `APPDATA` for VS Code user MCP with Roaming fallback; OpenCode global falls back when `config_dir` is missing. Tests use `AIKIT_MCP_TEST_HOME` under `cfg(test)` only.

**Deps:** `dirs` and `toml` on `aikit-sdk`.

Docs updated in root README and `aikit-sdk/README.md`.