### PR TITLE
feat: implement 47-aikit-tools-agent-backed-magic-button-tool-framework

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"38ca64ff-a5b8-490c-b035-c436615039a6","pid":310002,"procStart":"2375066","acquiredAt":1779019822578}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"38ca64ff-a5b8-490c-b035-c436615039a6","pid":310002,"procStart":"2375066","acquiredAt":1779019822578}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "aikit-sdk", "aikit-py", "aikit-agent", "aikit-evals"]
+members = [".", "aikit-sdk", "aikit-py", "aikit-agent", "aikit-evals", "aikit-tools"]
 
 [package]
 name = "aikit-cli"
@@ -88,6 +88,12 @@ urlencoding = "2.1.3"
 regex = "1.10"
 indicatif = "0.18"  # Progress bars
 dialoguer = "0.12"  # Interactive prompts
+
+# Agent-backed tool framework (optional feature)
+aikit-tools = { path = "aikit-tools", version = "0.1.0", optional = true }
+
+[features]
+tools = ["dep:aikit-tools"]
 
 # Vendor OpenSSL only for the musl cross-build. native-tls/openssl-sys is pulled
 # in transitively (anthropic-sdk, cli-framework default features) even though

--- a/aikit-tools/Cargo.toml
+++ b/aikit-tools/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 jsonschema = "0.46"
 thiserror = "2.0"
+async-trait = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"] }
 tracing = "0.1"
 

--- a/aikit-tools/Cargo.toml
+++ b/aikit-tools/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aikit-tools"
+version = "0.1.0"
+edition = "2021"
+description = "Agent-backed magic-button tool framework for aikit serve"
+license = "Apache-2.0"
+repository = "https://github.com/goaikit/aikit"
+
+[dependencies]
+aikit-agent = { path = "../aikit-agent", version = "0.1.0" }
+axum = { version = "0.8", features = ["macros"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+jsonschema = "0.46"
+thiserror = "2.0"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/aikit-tools/src/error.rs
+++ b/aikit-tools/src/error.rs
@@ -1,0 +1,58 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ToolsError {
+    #[error("tool not found: {0}")]
+    ToolNotFound(String),
+
+    #[error("input invalid: {0}")]
+    InputInvalid(String),
+
+    #[error("agent failed: {0}")]
+    AgentFailed(String),
+
+    #[error("agent produced no output")]
+    AgentNoOutput,
+
+    #[error("output invalid: {0}")]
+    OutputInvalid(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl IntoResponse for ToolsError {
+    fn into_response(self) -> Response {
+        let (status, code, message) = match &self {
+            ToolsError::ToolNotFound(msg) => (StatusCode::NOT_FOUND, "tool_not_found", msg.clone()),
+            ToolsError::InputInvalid(msg) => {
+                (StatusCode::BAD_REQUEST, "input_invalid", msg.clone())
+            }
+            ToolsError::AgentFailed(msg) => (StatusCode::BAD_GATEWAY, "agent_failed", msg.clone()),
+            ToolsError::AgentNoOutput => (
+                StatusCode::BAD_GATEWAY,
+                "agent_no_output",
+                "agent produced no output".to_string(),
+            ),
+            ToolsError::OutputInvalid(msg) => {
+                (StatusCode::BAD_GATEWAY, "output_invalid", msg.clone())
+            }
+            ToolsError::Internal(msg) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal", msg.clone())
+            }
+        };
+
+        let body = json!({ "error": { "code": code, "message": message } }).to_string();
+        (
+            status,
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            body,
+        )
+            .into_response()
+    }
+}

--- a/aikit-tools/src/handlers.rs
+++ b/aikit-tools/src/handlers.rs
@@ -1,0 +1,254 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde_json::{json, Value};
+
+use crate::{error::ToolsError, schema, state::ToolsState, tool::AgentTool};
+
+pub async fn list_tools_handler(
+    State(state): State<ToolsState>,
+) -> Result<Json<Value>, ToolsError> {
+    let tools = state.registry.list();
+    Ok(Json(json!({ "tools": tools })))
+}
+
+pub async fn get_schema_handler(
+    State(state): State<ToolsState>,
+    Path((ns, tool)): Path<(String, String)>,
+) -> Result<Json<Value>, ToolsError> {
+    let tool = state
+        .registry
+        .resolve(&ns, &tool)
+        .ok_or_else(|| ToolsError::ToolNotFound(format!("no tool registered at {ns}/{tool}")))?;
+    Ok(Json(tool.schema_doc()))
+}
+
+pub async fn invoke_handler(
+    State(state): State<ToolsState>,
+    Path((ns, tool_name)): Path<(String, String)>,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, ToolsError> {
+    let tool = state.registry.resolve(&ns, &tool_name).ok_or_else(|| {
+        ToolsError::ToolNotFound(format!("no tool registered at {ns}/{tool_name}"))
+    })?;
+
+    // Validate input
+    schema::validate(&tool.input_validator, &body).map_err(ToolsError::InputInvalid)?;
+
+    let system_prompt = tool.system_prompt.clone();
+    let user_prompt = compose_prompt(&tool, &body);
+    let output_schema = tool.output_schema.clone();
+    let runner = state.runner.clone();
+
+    let events = tokio::task::spawn_blocking(move || {
+        runner.run(&system_prompt, &user_prompt, &output_schema)
+    })
+    .await
+    .map_err(|e| ToolsError::Internal(format!("spawn_blocking join error: {e}")))??;
+
+    let draft = crate::runner::capture_output(&events)?;
+
+    // Validate output
+    schema::validate(&tool.output_validator, &draft).map_err(ToolsError::OutputInvalid)?;
+
+    Ok(Json(json!({ "draft": draft })))
+}
+
+fn compose_prompt(tool: &AgentTool, input: &Value) -> String {
+    format!(
+        "You are a {} assistant. Your task: {}\n\nInput data:\n{}\n\nProcess the input and call emit_output exactly once with a conforming result.",
+        tool.name,
+        tool.description,
+        serde_json::to_string_pretty(input).unwrap_or_default()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+        Router,
+    };
+    use http_body_util::BodyExt;
+    use serde_json::{json, Value};
+    use tower::ServiceExt;
+
+    use crate::{
+        reference::draft_contact_tool,
+        registry::ToolRegistry,
+        runner::{AgentRunner, MockRunner},
+        state::ToolsState,
+        AgentInternalEvent,
+    };
+
+    fn make_state(runner: impl AgentRunner + 'static) -> ToolsState {
+        let mut registry = ToolRegistry::new();
+        registry.register(draft_contact_tool());
+        ToolsState {
+            registry: Arc::new(registry),
+            runner: Arc::new(runner),
+        }
+    }
+
+    fn make_app(state: ToolsState) -> Router {
+        crate::router(state)
+    }
+
+    async fn do_request(
+        app: Router,
+        method: Method,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value) {
+        let req = if let Some(b) = body {
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&b).unwrap()))
+                .unwrap()
+        } else {
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap()
+        };
+
+        let response = app.oneshot(req).await.unwrap();
+        let status = response.status();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    fn valid_emit_output() -> AgentInternalEvent {
+        AgentInternalEvent::ToolUse {
+            tool_name: "emit_output".to_string(),
+            tool_input: json!({
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "email": "jane@acme.com",
+                "company": "Acme",
+                "title": "VP Sales",
+                "notes": "Met at conference"
+            }),
+            call_id: "c1".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_tools_returns_draft_contact() {
+        let runner = MockRunner { canned: vec![] };
+        let app = make_app(make_state(runner));
+        let (status, body) = do_request(app, Method::GET, "/aitools", None).await;
+        assert_eq!(status, StatusCode::OK);
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["namespace"], "crm");
+        assert_eq!(tools[0]["name"], "draft_contact");
+        assert!(tools[0]["description"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn get_schema_returns_200() {
+        let runner = MockRunner { canned: vec![] };
+        let app = make_app(make_state(runner));
+        let (status, body) =
+            do_request(app, Method::GET, "/aitools/crm/draft_contact/schema", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.get("inputSchema").is_some());
+        assert!(body.get("outputSchema").is_some());
+        assert!(body.get("description").is_some());
+        assert!(body.get("namespace").is_some());
+        assert!(body.get("name").is_some());
+    }
+
+    #[tokio::test]
+    async fn get_schema_unknown_returns_404() {
+        let runner = MockRunner { canned: vec![] };
+        let app = make_app(make_state(runner));
+        let (status, body) =
+            do_request(app, Method::GET, "/aitools/crm/unknown_tool/schema", None).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["error"]["code"], "tool_not_found");
+    }
+
+    #[tokio::test]
+    async fn invoke_valid_returns_draft() {
+        let runner = MockRunner {
+            canned: vec![valid_emit_output()],
+        };
+        let app = make_app(make_state(runner));
+        let (status, body) = do_request(
+            app,
+            Method::POST,
+            "/aitools/crm/draft_contact",
+            Some(json!({"note": "test", "partial": {}})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["draft"]["first_name"].as_str().is_some());
+        assert!(body["draft"]["last_name"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn invoke_missing_note_returns_400() {
+        let runner = MockRunner { canned: vec![] };
+        let app = make_app(make_state(runner));
+        let (status, body) = do_request(
+            app,
+            Method::POST,
+            "/aitools/crm/draft_contact",
+            Some(json!({"partial": {}})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "input_invalid");
+    }
+
+    #[tokio::test]
+    async fn invoke_output_missing_last_name_returns_502() {
+        let runner = MockRunner {
+            canned: vec![AgentInternalEvent::ToolUse {
+                tool_name: "emit_output".to_string(),
+                tool_input: json!({"first_name": "Jane"}),
+                call_id: "c1".to_string(),
+            }],
+        };
+        let app = make_app(make_state(runner));
+        let (status, body) = do_request(
+            app,
+            Method::POST,
+            "/aitools/crm/draft_contact",
+            Some(json!({"note": "test"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert_eq!(body["error"]["code"], "output_invalid");
+    }
+
+    #[tokio::test]
+    async fn invoke_agent_error_returns_502() {
+        let runner = MockRunner {
+            canned: vec![AgentInternalEvent::Error {
+                code: "err".to_string(),
+                message: "agent failed".to_string(),
+            }],
+        };
+        let app = make_app(make_state(runner));
+        let (status, body) = do_request(
+            app,
+            Method::POST,
+            "/aitools/crm/draft_contact",
+            Some(json!({"note": "test"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert_eq!(body["error"]["code"], "agent_failed");
+    }
+}

--- a/aikit-tools/src/handlers.rs
+++ b/aikit-tools/src/handlers.rs
@@ -251,4 +251,33 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_GATEWAY);
         assert_eq!(body["error"]["code"], "agent_failed");
     }
+
+    struct InternalErrorRunner;
+
+    impl AgentRunner for InternalErrorRunner {
+        fn run(
+            &self,
+            _system_prompt: &str,
+            _user_prompt: &str,
+            _output_schema: &Value,
+        ) -> Result<Vec<AgentInternalEvent>, crate::error::ToolsError> {
+            Err(crate::error::ToolsError::Internal(
+                "test internal error".to_string(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn invoke_runner_internal_error_returns_500() {
+        let app = make_app(make_state(InternalErrorRunner));
+        let (status, body) = do_request(
+            app,
+            Method::POST,
+            "/aitools/crm/draft_contact",
+            Some(json!({"note": "test"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["error"]["code"], "internal");
+    }
 }

--- a/aikit-tools/src/lib.rs
+++ b/aikit-tools/src/lib.rs
@@ -1,0 +1,40 @@
+pub mod error;
+pub mod handlers;
+pub mod reference;
+pub mod registry;
+pub mod runner;
+pub mod schema;
+pub mod state;
+pub mod tool;
+
+pub use aikit_agent::AgentInternalEvent;
+pub use error::ToolsError;
+pub use registry::ToolRegistry;
+pub use runner::{AgentRunner, ProductionAgentRunner};
+pub use state::ToolsState;
+pub use tool::AgentTool;
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+pub fn router(state: ToolsState) -> Router {
+    Router::new()
+        .route("/aitools", get(handlers::list_tools_handler))
+        .route(
+            "/aitools/{ns}/{tool}/schema",
+            get(handlers::get_schema_handler),
+        )
+        .route("/aitools/{ns}/{tool}", post(handlers::invoke_handler))
+        .with_state(state)
+}
+
+pub fn default_registry_state() -> ToolsState {
+    let mut registry = ToolRegistry::new();
+    registry.register(reference::draft_contact_tool());
+    ToolsState {
+        registry: std::sync::Arc::new(registry),
+        runner: std::sync::Arc::new(ProductionAgentRunner),
+    }
+}

--- a/aikit-tools/src/reference.rs
+++ b/aikit-tools/src/reference.rs
@@ -1,0 +1,34 @@
+use serde_json::json;
+
+use crate::tool::AgentTool;
+
+pub fn draft_contact_tool() -> AgentTool {
+    AgentTool::new(
+        "crm",
+        "draft_contact",
+        "CRM contact data-entry assistant",
+        json!({
+            "type": "object",
+            "properties": {
+                "note": { "type": "string" },
+                "partial": { "type": "object" }
+            },
+            "required": ["note"]
+        }),
+        json!({
+            "type": "object",
+            "properties": {
+                "first_name": { "type": "string" },
+                "last_name": { "type": "string" },
+                "email": { "type": "string" },
+                "company": { "type": "string" },
+                "title": { "type": "string" },
+                "notes": { "type": "string" }
+            },
+            "required": ["first_name", "last_name"],
+            "additionalProperties": false
+        }),
+        "You are a CRM contact data-entry assistant. Extract contact information from the provided note and any partial data, then call emit_output exactly once with the structured contact draft.",
+    )
+    .expect("draft_contact_tool schema must be valid")
+}

--- a/aikit-tools/src/registry.rs
+++ b/aikit-tools/src/registry.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::tool::AgentTool;
+
+pub struct ToolRegistry {
+    tools: HashMap<String, Arc<AgentTool>>,
+}
+
+#[derive(Serialize)]
+pub struct ToolListEntry {
+    pub namespace: String,
+    pub name: String,
+    pub description: String,
+}
+
+impl ToolRegistry {
+    pub fn new() -> Self {
+        Self {
+            tools: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, tool: AgentTool) {
+        let key = tool.key();
+        if self.tools.contains_key(&key) {
+            panic!("aikit-tools: duplicate tool registration for key '{key}'");
+        }
+        self.tools.insert(key, Arc::new(tool));
+    }
+
+    pub fn resolve(&self, ns: &str, name: &str) -> Option<Arc<AgentTool>> {
+        let key = format!("{ns}/{name}");
+        self.tools.get(&key).cloned()
+    }
+
+    pub fn list(&self) -> Vec<ToolListEntry> {
+        let mut entries: Vec<ToolListEntry> = self
+            .tools
+            .values()
+            .map(|t| ToolListEntry {
+                namespace: t.namespace.clone(),
+                name: t.name.clone(),
+                description: t.description.clone(),
+            })
+            .collect();
+        entries.sort_by(|a, b| a.namespace.cmp(&b.namespace).then(a.name.cmp(&b.name)));
+        entries
+    }
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_tool(ns: &str, name: &str) -> AgentTool {
+        AgentTool::new(
+            ns,
+            name,
+            "desc",
+            json!({"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]}),
+            json!({"type": "object", "properties": {"y": {"type": "string"}}, "required": ["y"]}),
+            "system prompt",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn register_and_resolve() {
+        let mut registry = ToolRegistry::new();
+        registry.register(make_tool("crm", "draft_contact"));
+        let tool = registry.resolve("crm", "draft_contact");
+        assert!(tool.is_some());
+        assert_eq!(tool.unwrap().key(), "crm/draft_contact");
+    }
+
+    #[test]
+    fn resolve_missing_returns_none() {
+        let registry = ToolRegistry::new();
+        assert!(registry.resolve("crm", "unknown").is_none());
+    }
+
+    #[test]
+    fn list_returns_entries() {
+        let mut registry = ToolRegistry::new();
+        registry.register(make_tool("crm", "draft_contact"));
+        let list = registry.list();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].namespace, "crm");
+        assert_eq!(list[0].name, "draft_contact");
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate tool registration")]
+    fn register_duplicate_panics() {
+        let mut registry = ToolRegistry::new();
+        registry.register(make_tool("crm", "draft_contact"));
+        registry.register(make_tool("crm", "draft_contact"));
+    }
+}

--- a/aikit-tools/src/runner.rs
+++ b/aikit-tools/src/runner.rs
@@ -1,0 +1,230 @@
+use std::env;
+use std::sync::Arc;
+
+use aikit_agent::{
+    AgentConfig, AgentInternalEvent, AgentPersona, HostToolDefinition, HostToolProvider,
+};
+use serde_json::Value;
+
+use crate::error::ToolsError;
+
+pub trait AgentRunner: Send + Sync {
+    fn run(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        output_schema: &Value,
+    ) -> Result<Vec<AgentInternalEvent>, ToolsError>;
+}
+
+struct EmitOutputProvider {
+    output_schema: Value,
+}
+
+impl HostToolProvider for EmitOutputProvider {
+    fn list_tools(&self) -> Vec<HostToolDefinition> {
+        vec![HostToolDefinition {
+            name: "emit_output".to_string(),
+            description: Some(
+                "Submit the final structured Draft. Call exactly once, then stop.".to_string(),
+            ),
+            parameters: self.output_schema.clone(),
+        }]
+    }
+
+    fn call_tool(&self, _name: &str, _arguments: Value) -> Result<String, String> {
+        Ok("OUTPUT_RECORDED. Draft captured. Stop now.".to_string())
+    }
+}
+
+pub struct ProductionAgentRunner;
+
+impl AgentRunner for ProductionAgentRunner {
+    fn run(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        output_schema: &Value,
+    ) -> Result<Vec<AgentInternalEvent>, ToolsError> {
+        let workdir = env::current_dir()
+            .map_err(|e| ToolsError::Internal(format!("cannot determine workdir: {e}")))?;
+
+        let mut config = AgentConfig::from_env(workdir, false, None)
+            .map_err(|e| ToolsError::Internal(format!("agent config error: {e}")))?;
+
+        config.session_persona = Some(AgentPersona {
+            name: "aikit-tools-agent".to_string(),
+            description: "Tool invocation agent".to_string(),
+            prompt: system_prompt.to_string(),
+            tools: None,
+            disallowed_tools: None,
+            model: None,
+        });
+
+        config.host_tool_provider = Some(Arc::new(EmitOutputProvider {
+            output_schema: output_schema.clone(),
+        }));
+
+        let gateway = aikit_agent::llm::openai_compat::OpenAiCompatProvider::new(
+            config.timeout_secs,
+            config.connect_timeout_secs,
+        )
+        .map_err(|e| ToolsError::Internal(format!("gateway error: {e}")))?;
+
+        aikit_agent::run(config, user_prompt, Box::new(gateway))
+            .map_err(|e| ToolsError::AgentFailed(format!("{e}")))
+    }
+}
+
+pub struct MockRunner {
+    pub canned: Vec<AgentInternalEvent>,
+}
+
+impl AgentRunner for MockRunner {
+    fn run(
+        &self,
+        _system_prompt: &str,
+        _user_prompt: &str,
+        _output_schema: &Value,
+    ) -> Result<Vec<AgentInternalEvent>, ToolsError> {
+        Ok(self.canned.clone())
+    }
+}
+
+pub fn capture_output(events: &[AgentInternalEvent]) -> Result<Value, ToolsError> {
+    // Step 1: Error event takes precedence
+    for event in events {
+        if let AgentInternalEvent::Error { message, .. } = event {
+            return Err(ToolsError::AgentFailed(message.clone()));
+        }
+    }
+
+    // Step 2: Last emit_output ToolUse
+    let mut last_emit: Option<&Value> = None;
+    for event in events {
+        if let AgentInternalEvent::ToolUse {
+            tool_name,
+            tool_input,
+            ..
+        } = event
+        {
+            if tool_name == "emit_output" {
+                last_emit = Some(tool_input);
+            }
+        }
+    }
+    if let Some(value) = last_emit {
+        return Ok(value.clone());
+    }
+
+    // Step 3: Last TextFinal parseable as JSON
+    let mut last_text_final: Option<&str> = None;
+    for event in events {
+        if let AgentInternalEvent::TextFinal { content, .. } = event {
+            last_text_final = Some(content.as_str());
+        }
+    }
+    if let Some(text) = last_text_final {
+        let stripped = strip_json_fences(text);
+        if let Ok(value) = serde_json::from_str::<Value>(stripped) {
+            return Ok(value);
+        }
+    }
+
+    // Step 4: No output
+    Err(ToolsError::AgentNoOutput)
+}
+
+fn strip_json_fences(s: &str) -> &str {
+    let s = s.trim();
+    if let Some(inner) = s.strip_prefix("```json") {
+        if let Some(inner2) = inner.strip_suffix("```") {
+            return inner2.trim();
+        }
+    }
+    if let Some(inner) = s.strip_prefix("```") {
+        if let Some(inner2) = inner.strip_suffix("```") {
+            return inner2.trim();
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_error_event() -> AgentInternalEvent {
+        AgentInternalEvent::Error {
+            code: "x".to_string(),
+            message: "y".to_string(),
+        }
+    }
+
+    fn make_emit_output(value: Value) -> AgentInternalEvent {
+        AgentInternalEvent::ToolUse {
+            tool_name: "emit_output".to_string(),
+            tool_input: value,
+            call_id: "c1".to_string(),
+        }
+    }
+
+    fn make_text_final(content: &str) -> AgentInternalEvent {
+        AgentInternalEvent::TextFinal {
+            content: content.to_string(),
+            turn_id: None,
+        }
+    }
+
+    #[test]
+    fn empty_events_returns_no_output() {
+        let result = capture_output(&[]);
+        assert!(matches!(result, Err(ToolsError::AgentNoOutput)));
+    }
+
+    #[test]
+    fn error_event_returns_agent_failed() {
+        let events = vec![make_error_event()];
+        let result = capture_output(&events);
+        assert!(matches!(result, Err(ToolsError::AgentFailed(_))));
+    }
+
+    #[test]
+    fn emit_output_tool_use_returns_value() {
+        let events = vec![make_emit_output(json!({"a": 1}))];
+        let result = capture_output(&events).unwrap();
+        assert_eq!(result, json!({"a": 1}));
+    }
+
+    #[test]
+    fn text_final_json_returns_value() {
+        let events = vec![make_text_final(r#"{"a":1}"#)];
+        let result = capture_output(&events).unwrap();
+        assert_eq!(result, json!({"a": 1}));
+    }
+
+    #[test]
+    fn text_final_with_json_fences_returns_value() {
+        let events = vec![make_text_final("```json\n{\"a\":1}\n```")];
+        let result = capture_output(&events).unwrap();
+        assert_eq!(result, json!({"a": 1}));
+    }
+
+    #[test]
+    fn multiple_emit_outputs_last_wins() {
+        let events = vec![
+            make_emit_output(json!({"a": 1})),
+            make_emit_output(json!({"a": 2})),
+        ];
+        let result = capture_output(&events).unwrap();
+        assert_eq!(result, json!({"a": 2}));
+    }
+
+    #[test]
+    fn error_takes_precedence_over_emit_output() {
+        let events = vec![make_emit_output(json!({"a": 1})), make_error_event()];
+        let result = capture_output(&events);
+        assert!(matches!(result, Err(ToolsError::AgentFailed(_))));
+    }
+}

--- a/aikit-tools/src/schema.rs
+++ b/aikit-tools/src/schema.rs
@@ -1,0 +1,61 @@
+use crate::error::ToolsError;
+use jsonschema::Validator;
+use serde_json::Value;
+
+pub fn compile(schema: &Value) -> Result<Validator, ToolsError> {
+    jsonschema::validator_for(schema)
+        .map_err(|e| ToolsError::Internal(format!("invalid JSON Schema: {e}")))
+}
+
+pub fn validate(validator: &Validator, instance: &Value) -> Result<(), String> {
+    let errors: Vec<String> = validator
+        .iter_errors(instance)
+        .map(|e| e.to_string())
+        .collect();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn compile_valid_schema() {
+        let schema =
+            json!({"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]});
+        assert!(compile(&schema).is_ok());
+    }
+
+    #[test]
+    fn compile_invalid_schema() {
+        let schema = json!({"type": "not-a-real-type-that-errors"});
+        let schema2 = json!({"required": "not-an-array"});
+        let _ = compile(&schema);
+        let _ = compile(&schema2);
+    }
+
+    #[test]
+    fn validate_conforming_instance() {
+        let schema =
+            json!({"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]});
+        let validator = compile(&schema).unwrap();
+        let instance = json!({"x": "hello"});
+        assert!(validate(&validator, &instance).is_ok());
+    }
+
+    #[test]
+    fn validate_non_conforming_instance() {
+        let schema =
+            json!({"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]});
+        let validator = compile(&schema).unwrap();
+        let instance = json!({"y": "hello"});
+        let result = validate(&validator, &instance);
+        assert!(result.is_err());
+        assert!(!result.unwrap_err().is_empty());
+    }
+}

--- a/aikit-tools/src/schema.rs
+++ b/aikit-tools/src/schema.rs
@@ -33,10 +33,8 @@ mod tests {
 
     #[test]
     fn compile_invalid_schema() {
-        let schema = json!({"type": "not-a-real-type-that-errors"});
-        let schema2 = json!({"required": "not-an-array"});
-        let _ = compile(&schema);
-        let _ = compile(&schema2);
+        let schema = json!({"required": "not-an-array"});
+        assert!(compile(&schema).is_err(), "expected Err for invalid schema");
     }
 
     #[test]

--- a/aikit-tools/src/state.rs
+++ b/aikit-tools/src/state.rs
@@ -1,0 +1,10 @@
+use std::sync::Arc;
+
+use crate::registry::ToolRegistry;
+use crate::runner::AgentRunner;
+
+#[derive(Clone)]
+pub struct ToolsState {
+    pub registry: Arc<ToolRegistry>,
+    pub runner: Arc<dyn AgentRunner>,
+}

--- a/aikit-tools/src/tool.rs
+++ b/aikit-tools/src/tool.rs
@@ -1,0 +1,102 @@
+use crate::error::ToolsError;
+use crate::schema;
+use jsonschema::Validator;
+use serde_json::{json, Value};
+
+pub struct AgentTool {
+    pub namespace: String,
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+    pub output_schema: Value,
+    pub system_prompt: String,
+    pub(crate) input_validator: Validator,
+    pub(crate) output_validator: Validator,
+}
+
+impl AgentTool {
+    pub fn new(
+        namespace: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        input_schema: Value,
+        output_schema: Value,
+        system_prompt: impl Into<String>,
+    ) -> Result<Self, ToolsError> {
+        let input_validator = schema::compile(&input_schema)?;
+        let output_validator = schema::compile(&output_schema)?;
+        Ok(Self {
+            namespace: namespace.into(),
+            name: name.into(),
+            description: description.into(),
+            input_schema,
+            output_schema,
+            system_prompt: system_prompt.into(),
+            input_validator,
+            output_validator,
+        })
+    }
+
+    pub fn key(&self) -> String {
+        format!("{}/{}", self.namespace, self.name)
+    }
+
+    pub fn schema_doc(&self) -> Value {
+        json!({
+            "namespace": self.namespace,
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.input_schema,
+            "outputSchema": self.output_schema,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_tool() -> AgentTool {
+        AgentTool::new(
+            "ns",
+            "name",
+            "desc",
+            json!({"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]}),
+            json!({"type": "object", "properties": {"y": {"type": "string"}}, "required": ["y"]}),
+            "system prompt",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn new_bad_schema_returns_err() {
+        let result = AgentTool::new(
+            "ns",
+            "name",
+            "desc",
+            json!({"required": "not-an-array"}),
+            json!({"type": "object"}),
+            "prompt",
+        );
+        let _ = result;
+        assert!(make_tool().key() == "ns/name");
+    }
+
+    #[test]
+    fn key_format() {
+        let tool = make_tool();
+        assert_eq!(tool.key(), "ns/name");
+    }
+
+    #[test]
+    fn schema_doc_contains_expected_keys() {
+        let tool = make_tool();
+        let doc = tool.schema_doc();
+        assert!(doc.get("inputSchema").is_some());
+        assert!(doc.get("outputSchema").is_some());
+        assert!(doc.get("description").is_some());
+        assert!(doc.get("namespace").is_some());
+        assert!(doc.get("name").is_some());
+    }
+}

--- a/aikit-tools/src/tool.rs
+++ b/aikit-tools/src/tool.rs
@@ -79,8 +79,7 @@ mod tests {
             json!({"type": "object"}),
             "prompt",
         );
-        let _ = result;
-        assert!(make_tool().key() == "ns/name");
+        assert!(result.is_err(), "expected Err for invalid input schema");
     }
 
     #[test]

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -928,6 +928,12 @@ fn build_router(state: AppState) -> Router {
         .fallback(not_found_handler)
         .with_state(state.clone());
 
+    #[cfg(feature = "tools")]
+    let router = {
+        let tools_state = aikit_tools::default_registry_state();
+        router.merge(aikit_tools::router(tools_state))
+    };
+
     if state.config.api_key.is_some() {
         router.layer(middleware::from_fn_with_state(state, auth_middleware))
     } else {


### PR DESCRIPTION
## Summary

Implements agent-backed Magic Button tool framework (`aikit-tools` crate): registry, handlers, runner, schema, and serve integration.

## Changes

- New `aikit-tools` workspace crate with tool registry, handlers, runner, and reference types
- Wire tools into `aikit serve`
- Develop workflow snapshot commits on branch `feature/47-aikit-tools-agent-backed-magic-button-tool-framework`

## Test plan

- [ ] `cargo test -p aikit-tools`
- [ ] `cargo test` / workspace checks as applicable
- [ ] Verify serve exposes tool endpoints