### PR TITLE
feat: implement 49-aikit-sdk-structured-agent-pipeline

### DIFF
--- a/aikit-sdk/Cargo.toml
+++ b/aikit-sdk/Cargo.toml
@@ -21,6 +21,7 @@ zip = "2.3"
 tempfile = "3.12"
 uuid = { version = "1", features = ["v4"] }
 aikit-agent = { path = "../aikit-agent", version = "0.1.0" }
+jsonschema = "0.46"
 
 [dev-dependencies]
 insta = { version = "1.39", features = ["json"] }

--- a/aikit-sdk/src/agent_runner.rs
+++ b/aikit-sdk/src/agent_runner.rs
@@ -1,0 +1,290 @@
+//! Agent runner builder and agent detection utilities.
+
+use crate::runner::{
+    get_agent_status, run_agent_events, runnable_agents, AgentEvent, AgentEventPayload,
+    MessagePhase, MessageRole, RunError, RunOptions,
+};
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// AgentRunner
+// ---------------------------------------------------------------------------
+
+/// Builder for running an agent with a specific configuration.
+pub struct AgentRunner {
+    agent_key: String,
+    model: Option<String>,
+    working_dir: Option<PathBuf>,
+}
+
+impl AgentRunner {
+    /// Create a new `AgentRunner` with the given agent key.
+    pub fn new(agent_key: impl Into<String>) -> Self {
+        Self {
+            agent_key: agent_key.into(),
+            model: None,
+            working_dir: None,
+        }
+    }
+
+    /// Alias for `new`.
+    pub fn agent(key: impl Into<String>) -> Self {
+        Self::new(key)
+    }
+
+    /// Set the model to use for this agent invocation.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the working directory for the agent child process.
+    pub fn with_working_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.working_dir = Some(path.into());
+        self
+    }
+
+    /// Decompose the runner into its configuration parts.
+    ///
+    /// Returns `(agent_key, model, working_dir)`. Used by `Pipeline::run` to
+    /// reconstruct the runner on each retry attempt.
+    pub fn into_parts(self) -> (String, Option<String>, Option<PathBuf>) {
+        (self.agent_key, self.model, self.working_dir)
+    }
+
+    /// Run the agent with the given prompt, returning the concatenated final
+    /// assistant text, or a `RunError` on failure.
+    ///
+    /// Collects all events, filters to `AgentEventPayload::StreamMessage(msg)`
+    /// where `msg.role == MessageRole::Assistant` and `msg.phase == MessagePhase::Final`,
+    /// sorts by `seq`, and concatenates `msg.text`.
+    pub fn run_prompt(self, prompt: String) -> Result<String, RunError> {
+        let mut options = RunOptions::default();
+        if let Some(model) = self.model {
+            options.model = Some(model);
+        }
+        if let Some(dir) = self.working_dir {
+            options.current_dir = Some(dir);
+        }
+
+        let mut events: Vec<AgentEvent> = Vec::new();
+        run_agent_events(&self.agent_key, &prompt, options, |ev| {
+            events.push(ev);
+        })?;
+
+        // Filter: StreamMessage where role=Assistant and phase=Final
+        let mut final_messages: Vec<(u64, String)> = events
+            .into_iter()
+            .filter_map(|ev| {
+                if let AgentEventPayload::StreamMessage(msg) = ev.payload {
+                    if msg.role == MessageRole::Assistant && msg.phase == MessagePhase::Final {
+                        return Some((ev.seq, msg.text));
+                    }
+                }
+                None
+            })
+            .collect();
+
+        // Sort by seq
+        final_messages.sort_by_key(|(seq, _)| *seq);
+
+        // Concatenate
+        let text: String = final_messages.into_iter().map(|(_, t)| t).collect();
+        Ok(text)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AgentInfo
+// ---------------------------------------------------------------------------
+
+/// Information about a single runnable agent.
+#[derive(Debug, Clone)]
+pub struct AgentInfo {
+    /// The runnable agent key (e.g. `"claude"`, `"agent"`).
+    pub key: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Whether the agent binary is available and ready to use.
+    pub installed: bool,
+    /// Reason the agent is not available (if `installed` is `false`).
+    pub reason: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// AgentDetector
+// ---------------------------------------------------------------------------
+
+/// Detects which agents are installed and available on the system.
+pub struct AgentDetector;
+
+impl AgentDetector {
+    /// Probe all runnable agent keys and return their availability status.
+    ///
+    /// Key name mapping:
+    /// - `"agent"` → catalog key `"cursor-agent"` → name `"Cursor"`
+    /// - `"aikit"` → name `"aikit"` (fallback, not in catalog under that key)
+    /// - all others → `crate::agent(key).name`
+    pub fn detect() -> Vec<AgentInfo> {
+        let status_map = get_agent_status();
+
+        runnable_agents()
+            .iter()
+            .map(|&key| {
+                let name = Self::resolve_name(key);
+                let status = status_map
+                    .get(key)
+                    .cloned()
+                    .unwrap_or_else(crate::runner::AgentStatus::available);
+
+                AgentInfo {
+                    key: key.to_string(),
+                    name,
+                    installed: status.available,
+                    reason: status.reason.map(|r| format!("{:?}", r)),
+                }
+            })
+            .collect()
+    }
+
+    /// Resolve the human-readable name for a runnable key.
+    fn resolve_name(key: &str) -> String {
+        match key {
+            "agent" => "Cursor".to_string(),
+            "aikit" => "aikit".to_string(),
+            other => {
+                // Look up in catalog
+                if let Some(config) = crate::agent(other) {
+                    config.name.to_string()
+                } else {
+                    other.to_string()
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::{
+        AgentEvent, AgentEventPayload, AgentEventStream, MessageKind, StreamMessage,
+    };
+
+    fn make_stream_message_event(
+        seq: u64,
+        role: MessageRole,
+        phase: MessagePhase,
+        text: &str,
+    ) -> AgentEvent {
+        AgentEvent {
+            agent_key: "claude".to_string(),
+            seq,
+            stream: AgentEventStream::Stdout,
+            payload: AgentEventPayload::StreamMessage(StreamMessage {
+                text: text.to_string(),
+                phase,
+                role,
+                kind: MessageKind::Message,
+                source: AgentEventStream::Stdout,
+                raw_line_seq: seq,
+                turn_id: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_filter_and_sort_final_assistant_messages() {
+        // Simulate collecting events from run_agent_events
+        let events: Vec<AgentEvent> = vec![
+            // Delta (should be ignored)
+            make_stream_message_event(1, MessageRole::Assistant, MessagePhase::Delta, "partial"),
+            // User final (should be ignored)
+            make_stream_message_event(2, MessageRole::User, MessagePhase::Final, "user msg"),
+            // Assistant Final (should be included)
+            make_stream_message_event(3, MessageRole::Assistant, MessagePhase::Final, "Hello "),
+            // Tool final (should be ignored)
+            make_stream_message_event(4, MessageRole::Tool, MessagePhase::Final, "tool output"),
+            // Another Assistant Final out of order (should be sorted after seq=3)
+            make_stream_message_event(5, MessageRole::Assistant, MessagePhase::Final, "world"),
+        ];
+
+        // Test the filtering + sorting + concatenation logic directly
+        let mut final_messages: Vec<(u64, String)> = events
+            .into_iter()
+            .filter_map(|ev| {
+                if let AgentEventPayload::StreamMessage(msg) = ev.payload {
+                    if msg.role == MessageRole::Assistant && msg.phase == MessagePhase::Final {
+                        return Some((ev.seq, msg.text));
+                    }
+                }
+                None
+            })
+            .collect();
+
+        final_messages.sort_by_key(|(seq, _)| *seq);
+        let text: String = final_messages.into_iter().map(|(_, t)| t).collect();
+        assert_eq!(text, "Hello world");
+    }
+
+    #[test]
+    fn test_filter_no_final_messages_returns_empty() {
+        let events: Vec<AgentEvent> = vec![
+            make_stream_message_event(1, MessageRole::Assistant, MessagePhase::Delta, "delta"),
+            make_stream_message_event(2, MessageRole::User, MessagePhase::Final, "user"),
+        ];
+
+        let final_messages: Vec<(u64, String)> = events
+            .into_iter()
+            .filter_map(|ev| {
+                if let AgentEventPayload::StreamMessage(msg) = ev.payload {
+                    if msg.role == MessageRole::Assistant && msg.phase == MessagePhase::Final {
+                        return Some((ev.seq, msg.text));
+                    }
+                }
+                None
+            })
+            .collect();
+
+        let text: String = final_messages.into_iter().map(|(_, t)| t).collect();
+        assert_eq!(text, "");
+    }
+
+    #[test]
+    fn test_agent_detector_returns_all_runnable_keys() {
+        // AgentDetector::detect calls real system probes, but we can at minimum
+        // verify the returned keys match runnable_agents()
+        let infos = AgentDetector::detect();
+        let returned_keys: std::collections::HashSet<String> =
+            infos.iter().map(|i| i.key.clone()).collect();
+        for &key in runnable_agents() {
+            assert!(
+                returned_keys.contains(key),
+                "Missing key '{}' in AgentDetector::detect()",
+                key
+            );
+        }
+        assert_eq!(infos.len(), runnable_agents().len());
+    }
+
+    #[test]
+    fn test_agent_detector_name_mapping_agent_key() {
+        let infos = AgentDetector::detect();
+        let agent_info = infos.iter().find(|i| i.key == "agent").unwrap();
+        assert_eq!(agent_info.name, "Cursor");
+    }
+
+    #[test]
+    fn test_agent_detector_name_mapping_aikit_key() {
+        let infos = AgentDetector::detect();
+        let aikit_info = infos.iter().find(|i| i.key == "aikit").unwrap();
+        assert_eq!(aikit_info.name, "aikit");
+    }
+
+    #[test]
+    fn test_run_error_not_runnable_maps_to_pipeline_error() {
+        let run_err = RunError::AgentNotRunnable("fake".to_string());
+        let pipeline_err = crate::pipeline::PipelineError::AgentInvocation { source: run_err };
+        assert!(pipeline_err.to_string().contains("agent invocation failed"));
+    }
+}

--- a/aikit-sdk/src/agent_runner.rs
+++ b/aikit-sdk/src/agent_runner.rs
@@ -1,8 +1,9 @@
 //! Agent runner builder and agent detection utilities.
 
+use crate::pipeline::PipelineError;
 use crate::runner::{
     get_agent_status, run_agent_events, runnable_agents, AgentEvent, AgentEventPayload,
-    MessagePhase, MessageRole, RunError, RunOptions,
+    AgentStatus, MessagePhase, MessageRole, RunOptions,
 };
 use std::path::PathBuf;
 
@@ -18,29 +19,30 @@ pub struct AgentRunner {
 }
 
 impl AgentRunner {
-    /// Create a new `AgentRunner` with the given agent key.
-    pub fn new(agent_key: impl Into<String>) -> Self {
+    /// Create a new `AgentRunner` with no agent key set.
+    pub fn new() -> Self {
         Self {
-            agent_key: agent_key.into(),
+            agent_key: String::new(),
             model: None,
             working_dir: None,
         }
     }
 
-    /// Alias for `new`.
-    pub fn agent(key: impl Into<String>) -> Self {
-        Self::new(key)
+    /// Set the agent key.
+    pub fn agent(mut self, key: &str) -> Self {
+        self.agent_key = key.to_string();
+        self
     }
 
     /// Set the model to use for this agent invocation.
-    pub fn with_model(mut self, model: impl Into<String>) -> Self {
-        self.model = Some(model.into());
+    pub fn model(mut self, model: &str) -> Self {
+        self.model = Some(model.to_string());
         self
     }
 
     /// Set the working directory for the agent child process.
-    pub fn with_working_dir(mut self, path: impl Into<PathBuf>) -> Self {
-        self.working_dir = Some(path.into());
+    pub fn working_dir(mut self, path: &str) -> Self {
+        self.working_dir = Some(PathBuf::from(path));
         self
     }
 
@@ -52,13 +54,10 @@ impl AgentRunner {
         (self.agent_key, self.model, self.working_dir)
     }
 
-    /// Run the agent with the given prompt, returning the concatenated final
-    /// assistant text, or a `RunError` on failure.
+    /// Invoke the agent with `prompt`; assemble assistant text from the event stream.
     ///
-    /// Collects all events, filters to `AgentEventPayload::StreamMessage(msg)`
-    /// where `msg.role == MessageRole::Assistant` and `msg.phase == MessagePhase::Final`,
-    /// sorts by `seq`, and concatenates `msg.text`.
-    pub fn run_prompt(self, prompt: String) -> Result<String, RunError> {
+    /// Blocking. Returns `PipelineError::AgentInvocation` on any RunError.
+    pub fn run(self, prompt: &str) -> Result<String, PipelineError> {
         let mut options = RunOptions::default();
         if let Some(model) = self.model {
             options.model = Some(model);
@@ -68,9 +67,10 @@ impl AgentRunner {
         }
 
         let mut events: Vec<AgentEvent> = Vec::new();
-        run_agent_events(&self.agent_key, &prompt, options, |ev| {
+        run_agent_events(&self.agent_key, prompt, options, |ev| {
             events.push(ev);
-        })?;
+        })
+        .map_err(|source| PipelineError::AgentInvocation { source })?;
 
         // Filter: StreamMessage where role=Assistant and phase=Final
         let mut final_messages: Vec<(u64, String)> = events
@@ -91,6 +91,12 @@ impl AgentRunner {
         // Concatenate
         let text: String = final_messages.into_iter().map(|(_, t)| t).collect();
         Ok(text)
+    }
+}
+
+impl Default for AgentRunner {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -132,10 +138,10 @@ impl AgentDetector {
             .iter()
             .map(|&key| {
                 let name = Self::resolve_name(key);
-                let status = status_map
-                    .get(key)
-                    .cloned()
-                    .unwrap_or_else(crate::runner::AgentStatus::available);
+                let status = status_map.get(key).cloned().unwrap_or(AgentStatus {
+                    available: false,
+                    reason: None,
+                });
 
                 AgentInfo {
                     key: key.to_string(),
@@ -150,10 +156,14 @@ impl AgentDetector {
     /// Resolve the human-readable name for a runnable key.
     fn resolve_name(key: &str) -> String {
         match key {
-            "agent" => "Cursor".to_string(),
+            "agent" => {
+                // "agent" maps to catalog key "cursor-agent"
+                crate::agent("cursor-agent")
+                    .map(|c| c.name.to_string())
+                    .unwrap_or_else(|| "Cursor".to_string())
+            }
             "aikit" => "aikit".to_string(),
             other => {
-                // Look up in catalog
                 if let Some(config) = crate::agent(other) {
                     config.name.to_string()
                 } else {
@@ -195,7 +205,6 @@ mod tests {
 
     #[test]
     fn test_filter_and_sort_final_assistant_messages() {
-        // Simulate collecting events from run_agent_events
         let events: Vec<AgentEvent> = vec![
             // Delta (should be ignored)
             make_stream_message_event(1, MessageRole::Assistant, MessagePhase::Delta, "partial"),
@@ -209,7 +218,6 @@ mod tests {
             make_stream_message_event(5, MessageRole::Assistant, MessagePhase::Final, "world"),
         ];
 
-        // Test the filtering + sorting + concatenation logic directly
         let mut final_messages: Vec<(u64, String)> = events
             .into_iter()
             .filter_map(|ev| {
@@ -252,8 +260,6 @@ mod tests {
 
     #[test]
     fn test_agent_detector_returns_all_runnable_keys() {
-        // AgentDetector::detect calls real system probes, but we can at minimum
-        // verify the returned keys match runnable_agents()
         let infos = AgentDetector::detect();
         let returned_keys: std::collections::HashSet<String> =
             infos.iter().map(|i| i.key.clone()).collect();
@@ -283,6 +289,7 @@ mod tests {
 
     #[test]
     fn test_run_error_not_runnable_maps_to_pipeline_error() {
+        use crate::runner::RunError;
         let run_err = RunError::AgentNotRunnable("fake".to_string());
         let pipeline_err = crate::pipeline::PipelineError::AgentInvocation { source: run_err };
         assert!(pipeline_err.to_string().contains("agent invocation failed"));

--- a/aikit-sdk/src/agent_runner.rs
+++ b/aikit-sdk/src/agent_runner.rs
@@ -7,6 +7,13 @@ use crate::runner::{
 };
 use std::path::PathBuf;
 
+#[cfg(test)]
+type MockQueue = std::sync::Arc<
+    std::sync::Mutex<std::collections::VecDeque<Result<String, crate::pipeline::PipelineError>>>,
+>;
+#[cfg(test)]
+type CapturedPrompts = std::sync::Arc<std::sync::Mutex<Vec<String>>>;
+
 // ---------------------------------------------------------------------------
 // AgentRunner
 // ---------------------------------------------------------------------------
@@ -16,6 +23,10 @@ pub struct AgentRunner {
     agent_key: String,
     model: Option<String>,
     working_dir: Option<PathBuf>,
+    #[cfg(test)]
+    mock_responses: Option<MockQueue>,
+    #[cfg(test)]
+    captured_prompts: Option<CapturedPrompts>,
 }
 
 impl AgentRunner {
@@ -25,7 +36,32 @@ impl AgentRunner {
             agent_key: String::new(),
             model: None,
             working_dir: None,
+            #[cfg(test)]
+            mock_responses: None,
+            #[cfg(test)]
+            captured_prompts: None,
         }
+    }
+
+    /// Create a mock `AgentRunner` for testing.
+    ///
+    /// Returns the runner and a shared prompt capture buffer.
+    /// Each call to `run()` pops the next response from `responses`.
+    #[cfg(test)]
+    pub(crate) fn with_mock(
+        responses: Vec<Result<String, crate::pipeline::PipelineError>>,
+    ) -> (Self, CapturedPrompts) {
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+        let captured: CapturedPrompts = Arc::new(Mutex::new(Vec::new()));
+        let runner = Self {
+            agent_key: String::new(),
+            model: None,
+            working_dir: None,
+            mock_responses: Some(Arc::new(Mutex::new(VecDeque::from(responses)))),
+            captured_prompts: Some(captured.clone()),
+        };
+        (runner, captured)
     }
 
     /// Set the agent key.
@@ -46,24 +82,28 @@ impl AgentRunner {
         self
     }
 
-    /// Decompose the runner into its configuration parts.
-    ///
-    /// Returns `(agent_key, model, working_dir)`. Used by `Pipeline::run` to
-    /// reconstruct the runner on each retry attempt.
-    pub fn into_parts(self) -> (String, Option<String>, Option<PathBuf>) {
-        (self.agent_key, self.model, self.working_dir)
-    }
-
     /// Invoke the agent with `prompt`; assemble assistant text from the event stream.
     ///
     /// Blocking. Returns `PipelineError::AgentInvocation` on any RunError.
-    pub fn run(self, prompt: &str) -> Result<String, PipelineError> {
-        let mut options = RunOptions::default();
-        if let Some(model) = self.model {
-            options.model = Some(model);
+    pub fn run(&self, prompt: &str) -> Result<String, PipelineError> {
+        // In tests: use mock response queue if populated.
+        #[cfg(test)]
+        if let Some(ref responses) = self.mock_responses {
+            let mut queue = responses.lock().unwrap();
+            if !queue.is_empty() {
+                if let Some(ref captured) = self.captured_prompts {
+                    captured.lock().unwrap().push(prompt.to_string());
+                }
+                return queue.pop_front().unwrap();
+            }
         }
-        if let Some(dir) = self.working_dir {
-            options.current_dir = Some(dir);
+
+        let mut options = RunOptions::default();
+        if let Some(ref model) = self.model {
+            options.model = Some(model.clone());
+        }
+        if let Some(ref dir) = self.working_dir {
+            options.current_dir = Some(dir.clone());
         }
 
         let mut events: Vec<AgentEvent> = Vec::new();
@@ -287,11 +327,29 @@ mod tests {
         assert_eq!(aikit_info.name, "aikit");
     }
 
+    /// AC8: Verify that AgentRunner::run() maps RunError to PipelineError::AgentInvocation.
+    ///
+    /// An unknown agent key causes run_agent_events to return RunError::AgentNotRunnable,
+    /// which must be mapped to PipelineError::AgentInvocation by the .map_err() call.
     #[test]
-    fn test_run_error_not_runnable_maps_to_pipeline_error() {
-        use crate::runner::RunError;
-        let run_err = RunError::AgentNotRunnable("fake".to_string());
-        let pipeline_err = crate::pipeline::PipelineError::AgentInvocation { source: run_err };
-        assert!(pipeline_err.to_string().contains("agent invocation failed"));
+    fn test_agent_runner_run_maps_run_error_to_agent_invocation() {
+        let runner = AgentRunner::new().agent("_not_a_real_agent_key_for_testing_xyz_");
+        let result = runner.run("test prompt");
+        assert!(
+            matches!(result, Err(PipelineError::AgentInvocation { .. })),
+            "expected AgentInvocation, got {:?}",
+            result
+        );
+    }
+
+    /// Integration test: verify AgentDetector::detect() works on a live system.
+    /// Requires at least one agent binary to be installed.
+    #[test]
+    #[ignore]
+    fn integration_test_agent_detector_detect_on_live_system() {
+        let infos = AgentDetector::detect();
+        assert!(!infos.is_empty(), "expected at least one agent entry");
+        let has_installed = infos.iter().any(|i| i.installed);
+        assert!(has_installed, "expected at least one installed agent");
     }
 }

--- a/aikit-sdk/src/agent_runner.rs
+++ b/aikit-sdk/src/agent_runner.rs
@@ -327,6 +327,14 @@ mod tests {
         assert_eq!(aikit_info.name, "aikit");
     }
 
+    /// AC30: The entry with key == "claude" MUST have name == "Claude Code".
+    #[test]
+    fn test_agent_detector_name_mapping_claude_key() {
+        let infos = AgentDetector::detect();
+        let claude_info = infos.iter().find(|i| i.key == "claude").unwrap();
+        assert_eq!(claude_info.name, "Claude Code");
+    }
+
     /// AC8: Verify that AgentRunner::run() maps RunError to PipelineError::AgentInvocation.
     ///
     /// An unknown agent key causes run_agent_events to return RunError::AgentNotRunnable,

--- a/aikit-sdk/src/lib.rs
+++ b/aikit-sdk/src/lib.rs
@@ -441,6 +441,18 @@ pub mod install;
 pub mod manifest;
 pub mod mcp_deploy;
 
+pub mod agent_runner;
+pub mod pipeline;
+pub mod report;
+pub mod template;
+pub mod validation;
+
+pub use agent_runner::{AgentDetector, AgentInfo, AgentRunner};
+pub use pipeline::{OutputFormat, Pipeline, PipelineError, PipelineResult};
+pub use report::ReportRenderer;
+pub use template::TemplateRenderer;
+pub use validation::{ResponseValidator, ValidatedResponse};
+
 pub use fetch::TemplateSource;
 pub use install::{
     copy_artifacts, install_template_from_source, install_template_to_path, installed_package_root,

--- a/aikit-sdk/src/pipeline.rs
+++ b/aikit-sdk/src/pipeline.rs
@@ -6,7 +6,6 @@ use crate::report::ReportRenderer;
 use crate::runner::RunError;
 use crate::template::TemplateRenderer;
 use crate::validation::ResponseValidator;
-use std::collections::HashMap;
 use std::fmt;
 
 // ---------------------------------------------------------------------------
@@ -83,8 +82,8 @@ pub enum OutputFormat {
 /// The successful result of a `Pipeline::run` call.
 #[derive(Debug)]
 pub struct PipelineResult {
-    /// The rendered output (JSON or Markdown depending on `OutputFormat`).
-    pub output: String,
+    /// The rendered report (JSON or Markdown depending on `OutputFormat`).
+    pub report: String,
     /// The parsed JSON data from the validated agent response.
     pub data: serde_json::Value,
     /// Number of attempts used (1 = no retries needed).
@@ -137,19 +136,19 @@ impl Pipeline {
     }
 
     /// Set the optional report template for Markdown output.
-    pub fn with_report_template(mut self, tmpl: impl Into<String>) -> Self {
-        self.report_template = Some(tmpl.into());
+    pub fn report_template(mut self, t: impl Into<String>) -> Self {
+        self.report_template = Some(t.into());
         self
     }
 
     /// Set the maximum number of retry attempts.
-    pub fn with_max_retries(mut self, n: u32) -> Self {
+    pub fn max_retries(mut self, n: u32) -> Self {
         self.max_retries = n;
         self
     }
 
     /// Set the output format.
-    pub fn with_output_format(mut self, fmt: OutputFormat) -> Self {
+    pub fn output_format(mut self, fmt: OutputFormat) -> Self {
         self.output_format = fmt;
         self
     }
@@ -158,12 +157,13 @@ impl Pipeline {
     ///
     /// # Arguments
     /// * `slots` - Values for template placeholders.
-    /// * `runner` - An `AgentRunner` (consumed; takes `self`). Its configuration
-    ///   is extracted before the retry loop so the agent key/model/dir can be
-    ///   reused across attempts.
+    /// * `runner` - An `AgentRunner` (consumed). Its configuration is extracted
+    ///   before the retry loop so the agent key/model/dir can be reused across attempts.
+    ///
+    /// Blocking. Callers needing concurrency MUST use spawn_blocking.
     pub fn run(
         &self,
-        slots: &HashMap<String, String>,
+        slots: &[(&str, &str)],
         runner: AgentRunner,
     ) -> Result<PipelineResult, PipelineError> {
         // Step 1: render the template — fatal if a slot is missing
@@ -177,24 +177,22 @@ impl Pipeline {
 
         loop {
             // Rebuild runner for this attempt
-            let mut attempt_runner = AgentRunner::new(agent_key.clone());
+            let mut attempt_runner = AgentRunner::new().agent(&agent_key);
             if let Some(ref m) = model {
-                attempt_runner = attempt_runner.with_model(m.clone());
+                attempt_runner = attempt_runner.model(m);
             }
             if let Some(ref d) = working_dir {
-                attempt_runner = attempt_runner.with_working_dir(d.clone());
+                attempt_runner = attempt_runner.working_dir(d.to_str().unwrap_or(""));
             }
 
-            // Step 2: call the agent
-            let raw_text = attempt_runner
-                .run_prompt(current_prompt.clone())
-                .map_err(|source| PipelineError::AgentInvocation { source })?;
+            // Step 2: call the agent — fatal on RunError (no retry)
+            let raw_text = attempt_runner.run(&current_prompt)?;
 
             // Step 3: validate
             match ResponseValidator::validate(&raw_text, &self.schema) {
                 Ok(validated) => {
                     // Validation passed — render output
-                    let output = match &self.output_format {
+                    let report = match &self.output_format {
                         OutputFormat::Json => ReportRenderer::render_json(&validated.data)?,
                         OutputFormat::Markdown => {
                             let tmpl = self.report_template.as_deref().unwrap_or("");
@@ -202,7 +200,7 @@ impl Pipeline {
                         }
                     };
                     return Ok(PipelineResult {
-                        output,
+                        report,
                         data: validated.data,
                         attempts: attempt,
                     });
@@ -288,8 +286,7 @@ mod tests {
 
     #[test]
     fn test_template_render_missing_slot_is_fatal() {
-        // TemplateRenderer errors flow through Pipeline's slot rendering step
-        let result = TemplateRenderer::render("Hello {{missing}}", &HashMap::new());
+        let result = TemplateRenderer::render("Hello {{missing}}", &[]);
         assert!(result.is_err());
     }
 
@@ -322,6 +319,7 @@ mod tests {
 
     #[test]
     fn test_pipeline_error_source_agent_invocation() {
+        use crate::runner::RunError;
         use std::error::Error;
         let run_err = RunError::AgentNotRunnable("fake".to_string());
         let err = PipelineError::AgentInvocation { source: run_err };

--- a/aikit-sdk/src/pipeline.rs
+++ b/aikit-sdk/src/pipeline.rs
@@ -1,0 +1,339 @@
+//! Structured agent pipeline: template rendering → agent invocation → JSON validation
+//! → optional report generation.
+
+use crate::agent_runner::AgentRunner;
+use crate::report::ReportRenderer;
+use crate::runner::RunError;
+use crate::template::TemplateRenderer;
+use crate::validation::ResponseValidator;
+use std::collections::HashMap;
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// PipelineError
+// ---------------------------------------------------------------------------
+
+/// All errors that can occur during pipeline execution.
+#[derive(Debug)]
+pub enum PipelineError {
+    /// A `{{slot}}` referenced in the template was not found in the provided slots map.
+    TemplateSlotMissing { slot: String },
+    /// The agent invocation failed.
+    AgentInvocation { source: RunError },
+    /// The agent response did not pass JSON schema validation.
+    ValidationFailed {
+        raw_output: String,
+        errors: Vec<String>,
+    },
+    /// Validation still failed after `max_retries` retry attempts.
+    MaxRetriesExceeded { last_error: Box<PipelineError> },
+    /// A `{{slot}}` referenced in the report template was not found.
+    ReportRender { slot: String },
+}
+
+impl fmt::Display for PipelineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PipelineError::TemplateSlotMissing { slot } => {
+                write!(f, "template slot missing: '{}'", slot)
+            }
+            PipelineError::AgentInvocation { source } => {
+                write!(f, "agent invocation failed: {}", source)
+            }
+            PipelineError::ValidationFailed { errors, .. } => {
+                write!(f, "validation failed: {}", errors.join("; "))
+            }
+            PipelineError::MaxRetriesExceeded { last_error } => {
+                write!(f, "max retries exceeded; last error: {}", last_error)
+            }
+            PipelineError::ReportRender { slot } => {
+                write!(f, "report template slot missing: '{}'", slot)
+            }
+        }
+    }
+}
+
+impl std::error::Error for PipelineError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            PipelineError::AgentInvocation { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OutputFormat
+// ---------------------------------------------------------------------------
+
+/// How the pipeline formats its final output.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    /// Pretty-printed JSON (default).
+    #[default]
+    Json,
+    /// Markdown rendered from a report template.
+    Markdown,
+}
+
+// ---------------------------------------------------------------------------
+// PipelineResult
+// ---------------------------------------------------------------------------
+
+/// The successful result of a `Pipeline::run` call.
+#[derive(Debug)]
+pub struct PipelineResult {
+    /// The rendered output (JSON or Markdown depending on `OutputFormat`).
+    pub output: String,
+    /// The parsed JSON data from the validated agent response.
+    pub data: serde_json::Value,
+    /// Number of attempts used (1 = no retries needed).
+    pub attempts: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
+/// A structured agent pipeline that:
+/// 1. Renders a prompt template with slots.
+/// 2. Calls an agent runner.
+/// 3. Validates the JSON response against a schema.
+/// 4. Retries on failure up to `max_retries` times.
+/// 5. Renders the output according to `output_format`.
+pub struct Pipeline {
+    /// Prompt template with `{{slot}}` placeholders.
+    pub template: String,
+    /// JSON Schema (as a JSON string) for validating the agent response.
+    pub schema: String,
+    /// Optional report template for Markdown output.
+    pub report_template: Option<String>,
+    /// Maximum number of retries after initial failure (0 = no retries).
+    pub max_retries: u32,
+    /// How to format the final output.
+    pub output_format: OutputFormat,
+}
+
+impl Default for Pipeline {
+    fn default() -> Self {
+        Self {
+            template: String::new(),
+            schema: String::new(),
+            report_template: None,
+            max_retries: 0,
+            output_format: OutputFormat::Json,
+        }
+    }
+}
+
+impl Pipeline {
+    /// Create a new `Pipeline` with the given template and schema.
+    pub fn new(template: impl Into<String>, schema: impl Into<String>) -> Self {
+        Self {
+            template: template.into(),
+            schema: schema.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set the optional report template for Markdown output.
+    pub fn with_report_template(mut self, tmpl: impl Into<String>) -> Self {
+        self.report_template = Some(tmpl.into());
+        self
+    }
+
+    /// Set the maximum number of retry attempts.
+    pub fn with_max_retries(mut self, n: u32) -> Self {
+        self.max_retries = n;
+        self
+    }
+
+    /// Set the output format.
+    pub fn with_output_format(mut self, fmt: OutputFormat) -> Self {
+        self.output_format = fmt;
+        self
+    }
+
+    /// Run the pipeline.
+    ///
+    /// # Arguments
+    /// * `slots` - Values for template placeholders.
+    /// * `runner` - An `AgentRunner` (consumed; takes `self`). Its configuration
+    ///   is extracted before the retry loop so the agent key/model/dir can be
+    ///   reused across attempts.
+    pub fn run(
+        &self,
+        slots: &HashMap<String, String>,
+        runner: AgentRunner,
+    ) -> Result<PipelineResult, PipelineError> {
+        // Step 1: render the template — fatal if a slot is missing
+        let original_prompt = TemplateRenderer::render(&self.template, slots)?;
+
+        // Decompose runner into config so we can rebuild per attempt
+        let (agent_key, model, working_dir) = runner.into_parts();
+
+        let mut attempt = 1u32;
+        let mut current_prompt = original_prompt.clone();
+
+        loop {
+            // Rebuild runner for this attempt
+            let mut attempt_runner = AgentRunner::new(agent_key.clone());
+            if let Some(ref m) = model {
+                attempt_runner = attempt_runner.with_model(m.clone());
+            }
+            if let Some(ref d) = working_dir {
+                attempt_runner = attempt_runner.with_working_dir(d.clone());
+            }
+
+            // Step 2: call the agent
+            let raw_text = attempt_runner
+                .run_prompt(current_prompt.clone())
+                .map_err(|source| PipelineError::AgentInvocation { source })?;
+
+            // Step 3: validate
+            match ResponseValidator::validate(&raw_text, &self.schema) {
+                Ok(validated) => {
+                    // Validation passed — render output
+                    let output = match &self.output_format {
+                        OutputFormat::Json => ReportRenderer::render_json(&validated.data)?,
+                        OutputFormat::Markdown => {
+                            let tmpl = self.report_template.as_deref().unwrap_or("");
+                            ReportRenderer::render_markdown(tmpl, &validated.data)?
+                        }
+                    };
+                    return Ok(PipelineResult {
+                        output,
+                        data: validated.data,
+                        attempts: attempt,
+                    });
+                }
+                Err(PipelineError::ValidationFailed { raw_output, errors }) => {
+                    // Check retry budget
+                    if attempt > self.max_retries {
+                        if self.max_retries == 0 {
+                            return Err(PipelineError::ValidationFailed { raw_output, errors });
+                        } else {
+                            return Err(PipelineError::MaxRetriesExceeded {
+                                last_error: Box::new(PipelineError::ValidationFailed {
+                                    raw_output,
+                                    errors,
+                                }),
+                            });
+                        }
+                    }
+
+                    // Build augmented retry prompt
+                    let mut retry_prompt = original_prompt.clone();
+                    retry_prompt.push_str("\n\n## Previous response\n");
+                    retry_prompt.push_str(&raw_output);
+                    retry_prompt.push_str("\n\n## Validation errors\n");
+                    for err_msg in &errors {
+                        retry_prompt.push_str("- ");
+                        retry_prompt.push_str(err_msg);
+                        retry_prompt.push('\n');
+                    }
+                    retry_prompt.push_str(
+                        "\n\nPlease respond again. Your response MUST contain a single ```json block matching the schema.",
+                    );
+
+                    current_prompt = retry_prompt;
+                    attempt += 1;
+                }
+                Err(other) => return Err(other),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pipeline_error_display_template_slot_missing() {
+        let err = PipelineError::TemplateSlotMissing {
+            slot: "foo".to_string(),
+        };
+        assert!(err.to_string().contains("foo"));
+    }
+
+    #[test]
+    fn test_pipeline_error_display_validation_failed() {
+        let err = PipelineError::ValidationFailed {
+            raw_output: "bad".to_string(),
+            errors: vec!["missing field".to_string()],
+        };
+        assert!(err.to_string().contains("missing field"));
+    }
+
+    #[test]
+    fn test_pipeline_error_display_max_retries_exceeded() {
+        let inner = PipelineError::ValidationFailed {
+            raw_output: "x".to_string(),
+            errors: vec!["err".to_string()],
+        };
+        let err = PipelineError::MaxRetriesExceeded {
+            last_error: Box::new(inner),
+        };
+        assert!(err.to_string().contains("max retries exceeded"));
+    }
+
+    #[test]
+    fn test_pipeline_error_display_report_render() {
+        let err = PipelineError::ReportRender {
+            slot: "body".to_string(),
+        };
+        assert!(err.to_string().contains("body"));
+    }
+
+    #[test]
+    fn test_template_render_missing_slot_is_fatal() {
+        // TemplateRenderer errors flow through Pipeline's slot rendering step
+        let result = TemplateRenderer::render("Hello {{missing}}", &HashMap::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_response_validator_valid_json() {
+        use crate::validation::ResponseValidator;
+
+        let schema =
+            r#"{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}"#;
+        let raw = r#"{"name":"Alice"}"#;
+        let validated = ResponseValidator::validate(raw, schema).unwrap();
+        assert_eq!(validated.data["name"], "Alice");
+    }
+
+    #[test]
+    fn test_response_validator_invalid_json_fails() {
+        use crate::validation::ResponseValidator;
+
+        let schema =
+            r#"{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}"#;
+        let raw = r#"{"age":42}"#;
+        let err = ResponseValidator::validate(raw, schema).unwrap_err();
+        match err {
+            PipelineError::ValidationFailed { errors, .. } => {
+                assert!(!errors.is_empty());
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_pipeline_error_source_agent_invocation() {
+        use std::error::Error;
+        let run_err = RunError::AgentNotRunnable("fake".to_string());
+        let err = PipelineError::AgentInvocation { source: run_err };
+        assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn test_pipeline_error_source_others_none() {
+        use std::error::Error;
+        let err = PipelineError::TemplateSlotMissing {
+            slot: "x".to_string(),
+        };
+        assert!(err.source().is_none());
+    }
+}

--- a/aikit-sdk/src/pipeline.rs
+++ b/aikit-sdk/src/pipeline.rs
@@ -157,8 +157,7 @@ impl Pipeline {
     ///
     /// # Arguments
     /// * `slots` - Values for template placeholders.
-    /// * `runner` - An `AgentRunner` (consumed). Its configuration is extracted
-    ///   before the retry loop so the agent key/model/dir can be reused across attempts.
+    /// * `runner` - An `AgentRunner` whose `run()` is called for each attempt.
     ///
     /// Blocking. Callers needing concurrency MUST use spawn_blocking.
     pub fn run(
@@ -169,24 +168,12 @@ impl Pipeline {
         // Step 1: render the template — fatal if a slot is missing
         let original_prompt = TemplateRenderer::render(&self.template, slots)?;
 
-        // Decompose runner into config so we can rebuild per attempt
-        let (agent_key, model, working_dir) = runner.into_parts();
-
         let mut attempt = 1u32;
         let mut current_prompt = original_prompt.clone();
 
         loop {
-            // Rebuild runner for this attempt
-            let mut attempt_runner = AgentRunner::new().agent(&agent_key);
-            if let Some(ref m) = model {
-                attempt_runner = attempt_runner.model(m);
-            }
-            if let Some(ref d) = working_dir {
-                attempt_runner = attempt_runner.working_dir(d.to_str().unwrap_or(""));
-            }
-
             // Step 2: call the agent — fatal on RunError (no retry)
-            let raw_text = attempt_runner.run(&current_prompt)?;
+            let raw_text = runner.run(&current_prompt)?;
 
             // Step 3: validate
             match ResponseValidator::validate(&raw_text, &self.schema) {
@@ -220,7 +207,7 @@ impl Pipeline {
                         }
                     }
 
-                    // Build augmented retry prompt
+                    // Build augmented retry prompt (§4.6)
                     let mut retry_prompt = original_prompt.clone();
                     retry_prompt.push_str("\n\n## Previous response\n");
                     retry_prompt.push_str(&raw_output);
@@ -246,6 +233,11 @@ impl Pipeline {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_runner::AgentRunner;
+
+    // -----------------------------------------------------------------------
+    // Error display / std::error::Error tests
+    // -----------------------------------------------------------------------
 
     #[test]
     fn test_pipeline_error_display_template_slot_missing() {
@@ -285,10 +277,36 @@ mod tests {
     }
 
     #[test]
+    fn test_pipeline_error_source_agent_invocation() {
+        use crate::runner::RunError;
+        use std::error::Error;
+        let run_err = RunError::AgentNotRunnable("fake".to_string());
+        let err = PipelineError::AgentInvocation { source: run_err };
+        assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn test_pipeline_error_source_others_none() {
+        use std::error::Error;
+        let err = PipelineError::TemplateSlotMissing {
+            slot: "x".to_string(),
+        };
+        assert!(err.source().is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Template integration
+    // -----------------------------------------------------------------------
+
+    #[test]
     fn test_template_render_missing_slot_is_fatal() {
         let result = TemplateRenderer::render("Hello {{missing}}", &[]);
         assert!(result.is_err());
     }
+
+    // -----------------------------------------------------------------------
+    // Validation integration
+    // -----------------------------------------------------------------------
 
     #[test]
     fn test_response_validator_valid_json() {
@@ -317,21 +335,212 @@ mod tests {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // AC14: max_retries(0) → ValidationFailed returned directly (not MaxRetriesExceeded)
+    // -----------------------------------------------------------------------
+
     #[test]
-    fn test_pipeline_error_source_agent_invocation() {
+    fn test_pipeline_max_retries_0_returns_validation_failed_directly() {
+        let schema =
+            r#"{"type":"object","properties":{"score":{"type":"integer"}},"required":["score"]}"#;
+        let (mock_runner, _) = AgentRunner::with_mock(vec![Ok("not valid json".to_string())]);
+
+        let result = Pipeline::new("test prompt", schema)
+            .max_retries(0)
+            .run(&[], mock_runner);
+
+        assert!(
+            matches!(result, Err(PipelineError::ValidationFailed { .. })),
+            "expected ValidationFailed, got {:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC15: max_retries(1), both attempts fail → MaxRetriesExceeded boxing ValidationFailed
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pipeline_max_retries_1_both_fail_returns_max_retries_exceeded() {
+        let schema =
+            r#"{"type":"object","properties":{"score":{"type":"integer"}},"required":["score"]}"#;
+        let (mock_runner, _) = AgentRunner::with_mock(vec![
+            Ok("bad output 1".to_string()),
+            Ok("bad output 2".to_string()),
+        ]);
+
+        let result = Pipeline::new("test prompt", schema)
+            .max_retries(1)
+            .run(&[], mock_runner);
+
+        match result {
+            Err(PipelineError::MaxRetriesExceeded { last_error }) => {
+                assert!(
+                    matches!(*last_error, PipelineError::ValidationFailed { .. }),
+                    "last_error should be ValidationFailed, got {:?}",
+                    last_error
+                );
+            }
+            other => panic!("expected MaxRetriesExceeded, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AC16: max_retries(1), second attempt succeeds → attempts == 2
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pipeline_max_retries_1_second_attempt_succeeds_attempts_equals_2() {
+        let schema =
+            r#"{"type":"object","properties":{"score":{"type":"integer"}},"required":["score"]}"#;
+        let valid_response = "```json\n{\"score\": 7}\n```".to_string();
+        let (mock_runner, _) = AgentRunner::with_mock(vec![
+            Ok("not valid json at all".to_string()),
+            Ok(valid_response),
+        ]);
+
+        let result = Pipeline::new("test prompt", schema)
+            .max_retries(1)
+            .run(&[], mock_runner)
+            .expect("should succeed on second attempt");
+
+        assert_eq!(result.attempts, 2, "attempts should be 2 after one retry");
+    }
+
+    // -----------------------------------------------------------------------
+    // AC17: RunError from agent bypasses retry loop regardless of max_retries
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pipeline_agent_run_error_is_not_retried() {
         use crate::runner::RunError;
-        use std::error::Error;
-        let run_err = RunError::AgentNotRunnable("fake".to_string());
-        let err = PipelineError::AgentInvocation { source: run_err };
-        assert!(err.source().is_some());
+
+        let schema = r#"{"type":"object"}"#;
+        let (mock_runner, _) = AgentRunner::with_mock(vec![Err(PipelineError::AgentInvocation {
+            source: RunError::AgentNotRunnable("fake-agent".to_string()),
+        })]);
+
+        // Even with max_retries=5, a fatal RunError must surface immediately
+        let result = Pipeline::new("test prompt", schema)
+            .max_retries(5)
+            .run(&[], mock_runner);
+
+        assert!(
+            matches!(result, Err(PipelineError::AgentInvocation { .. })),
+            "expected AgentInvocation (fatal, no retry), got {:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC18: Augmented retry prompt contains required content
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pipeline_retry_prompt_contains_required_content() {
+        let schema =
+            r#"{"type":"object","properties":{"score":{"type":"integer"}},"required":["score"]}"#;
+        let first_bad_output = "this is definitely not json";
+        let valid_response = "```json\n{\"score\": 1}\n```".to_string();
+
+        let (mock_runner, captured) =
+            AgentRunner::with_mock(vec![Ok(first_bad_output.to_string()), Ok(valid_response)]);
+
+        let _ = Pipeline::new("Original prompt text", schema)
+            .max_retries(1)
+            .run(&[], mock_runner)
+            .expect("should succeed on second attempt");
+
+        let prompts = captured.lock().unwrap();
+        assert_eq!(prompts.len(), 2, "expected 2 prompts (initial + retry)");
+
+        let retry_prompt = &prompts[1];
+        assert!(
+            retry_prompt.contains("Original prompt text"),
+            "retry prompt must contain the original prompt"
+        );
+        assert!(
+            retry_prompt.contains("## Previous response"),
+            "retry prompt must contain '## Previous response' header"
+        );
+        assert!(
+            retry_prompt.contains(first_bad_output),
+            "retry prompt must contain the previous raw output"
+        );
+        assert!(
+            retry_prompt.contains("## Validation errors"),
+            "retry prompt must contain '## Validation errors' header"
+        );
+        assert!(
+            retry_prompt.contains("Please respond again"),
+            "retry prompt must contain the instruction line"
+        );
+        assert!(
+            retry_prompt.contains("```json block"),
+            "retry prompt must mention the required json block format"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC24–AC26: Pipeline::run() happy path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pipeline_run_success_json_format() {
+        let schema =
+            r#"{"type":"object","properties":{"score":{"type":"integer"}},"required":["score"]}"#;
+        let valid_response = "```json\n{\"score\": 42}\n```".to_string();
+        let (mock_runner, _) = AgentRunner::with_mock(vec![Ok(valid_response)]);
+
+        let result = Pipeline::new("test prompt", schema)
+            .max_retries(0)
+            .output_format(OutputFormat::Json)
+            .run(&[], mock_runner)
+            .expect("pipeline should succeed");
+
+        assert_eq!(result.attempts, 1);
+        assert!(result.report.contains("42"));
+        assert_eq!(result.data["score"], 42);
     }
 
     #[test]
-    fn test_pipeline_error_source_others_none() {
-        use std::error::Error;
-        let err = PipelineError::TemplateSlotMissing {
-            slot: "x".to_string(),
-        };
-        assert!(err.source().is_none());
+    fn test_pipeline_run_success_markdown_format() {
+        let schema =
+            r#"{"type":"object","properties":{"score":{"type":"integer"}},"required":["score"]}"#;
+        let valid_response = "```json\n{\"score\": 5}\n```".to_string();
+        let (mock_runner, _) = AgentRunner::with_mock(vec![Ok(valid_response)]);
+
+        let result = Pipeline::new("test prompt", schema)
+            .output_format(OutputFormat::Markdown)
+            .report_template("Score: {{score}}")
+            .run(&[], mock_runner)
+            .expect("pipeline should succeed");
+
+        assert_eq!(result.report, "Score: 5");
+    }
+
+    /// Integration test stub: full end-to-end pipeline with a real agent.
+    /// Requires a Claude agent binary installed. Run with: cargo test --ignored
+    #[test]
+    #[ignore]
+    fn integration_test_pipeline_run_end_to_end() {
+        let schema = r#"{
+            "type": "object",
+            "properties": { "greeting": { "type": "string" } },
+            "required": ["greeting"]
+        }"#;
+        let result = Pipeline::new(
+            "Reply with a JSON object containing a single key 'greeting' with value 'hello'.",
+            schema,
+        )
+        .max_retries(1)
+        .output_format(OutputFormat::Json)
+        .run(&[], AgentRunner::new().agent("claude"));
+
+        assert!(
+            result.is_ok(),
+            "integration pipeline should succeed: {:?}",
+            result.err()
+        );
     }
 }

--- a/aikit-sdk/src/report.rs
+++ b/aikit-sdk/src/report.rs
@@ -2,7 +2,6 @@
 
 use crate::pipeline::PipelineError;
 use crate::template::TemplateRenderer;
-use std::collections::HashMap;
 
 /// Renders agent results into Markdown or JSON reports.
 pub struct ReportRenderer;
@@ -20,7 +19,7 @@ impl ReportRenderer {
         template: &str,
         data: &serde_json::Value,
     ) -> Result<String, PipelineError> {
-        let mut slots: HashMap<String, String> = HashMap::new();
+        let mut slot_entries: Vec<(String, String)> = Vec::new();
 
         // Build slots from top-level keys
         if let Some(obj) = data.as_object() {
@@ -33,16 +32,22 @@ impl ReportRenderer {
                     // Arrays and objects → compact JSON
                     _ => serde_json::to_string(val).unwrap_or_else(|_| val.to_string()),
                 };
-                slots.insert(key.clone(), slot_value);
+                slot_entries.push((key.clone(), slot_value));
             }
         }
 
         // Always inject `report_body` as pretty-printed JSON
         let pretty = serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string());
-        slots.insert("report_body".to_string(), pretty);
+        slot_entries.push(("report_body".to_string(), pretty));
+
+        // Build &[(&str, &str)] from owned entries
+        let slots_ref: Vec<(&str, &str)> = slot_entries
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
 
         // Render and map TemplateSlotMissing → ReportRender
-        TemplateRenderer::render(template, &slots).map_err(|e| match e {
+        TemplateRenderer::render(template, &slots_ref).map_err(|e| match e {
             PipelineError::TemplateSlotMissing { slot } => PipelineError::ReportRender { slot },
             other => other,
         })
@@ -63,7 +68,6 @@ mod tests {
     fn test_render_json_basic() {
         let data = json!({"name": "Alice", "score": 42});
         let result = ReportRenderer::render_json(&data).unwrap();
-        // Pretty-printed JSON should contain the key-value pairs
         assert!(result.contains("\"name\""));
         assert!(result.contains("\"Alice\""));
     }
@@ -81,7 +85,6 @@ mod tests {
         let data = json!({"x": 1});
         let tmpl = "{{report_body}}";
         let result = ReportRenderer::render_markdown(tmpl, &data).unwrap();
-        // Should be pretty-printed JSON
         assert!(result.contains("\"x\""));
         assert!(result.contains("1"));
     }
@@ -91,7 +94,6 @@ mod tests {
         let data = json!({"tags": ["a", "b"]});
         let tmpl = "Tags: {{tags}}";
         let result = ReportRenderer::render_markdown(tmpl, &data).unwrap();
-        // Non-scalar → compact JSON
         assert!(result.contains("[\"a\",\"b\"]") || result.contains("[\"a\", \"b\"]"));
     }
 

--- a/aikit-sdk/src/report.rs
+++ b/aikit-sdk/src/report.rs
@@ -1,0 +1,118 @@
+//! Report rendering: Markdown and JSON output from validated agent data.
+
+use crate::pipeline::PipelineError;
+use crate::template::TemplateRenderer;
+use std::collections::HashMap;
+
+/// Renders agent results into Markdown or JSON reports.
+pub struct ReportRenderer;
+
+impl ReportRenderer {
+    /// Render `data` into a Markdown report using `template`.
+    ///
+    /// Slot values are built from top-level keys of `data`:
+    /// - Scalar values (string, number, bool, null) → their string representation
+    /// - Non-scalar values (arrays, objects) → compact JSON
+    /// - `report_body` is always injected as a pretty-printed JSON of `data`
+    ///
+    /// Returns `PipelineError::ReportRender { slot }` if a referenced slot is missing.
+    pub fn render_markdown(
+        template: &str,
+        data: &serde_json::Value,
+    ) -> Result<String, PipelineError> {
+        let mut slots: HashMap<String, String> = HashMap::new();
+
+        // Build slots from top-level keys
+        if let Some(obj) = data.as_object() {
+            for (key, val) in obj {
+                let slot_value = match val {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    serde_json::Value::Null => "null".to_string(),
+                    // Arrays and objects → compact JSON
+                    _ => serde_json::to_string(val).unwrap_or_else(|_| val.to_string()),
+                };
+                slots.insert(key.clone(), slot_value);
+            }
+        }
+
+        // Always inject `report_body` as pretty-printed JSON
+        let pretty = serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string());
+        slots.insert("report_body".to_string(), pretty);
+
+        // Render and map TemplateSlotMissing → ReportRender
+        TemplateRenderer::render(template, &slots).map_err(|e| match e {
+            PipelineError::TemplateSlotMissing { slot } => PipelineError::ReportRender { slot },
+            other => other,
+        })
+    }
+
+    /// Render `data` as pretty-printed JSON.
+    pub fn render_json(data: &serde_json::Value) -> Result<String, PipelineError> {
+        Ok(serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_render_json_basic() {
+        let data = json!({"name": "Alice", "score": 42});
+        let result = ReportRenderer::render_json(&data).unwrap();
+        // Pretty-printed JSON should contain the key-value pairs
+        assert!(result.contains("\"name\""));
+        assert!(result.contains("\"Alice\""));
+    }
+
+    #[test]
+    fn test_render_markdown_scalar_slots() {
+        let data = json!({"name": "Alice", "score": 42, "active": true});
+        let tmpl = "Name: {{name}}, Score: {{score}}, Active: {{active}}";
+        let result = ReportRenderer::render_markdown(tmpl, &data).unwrap();
+        assert_eq!(result, "Name: Alice, Score: 42, Active: true");
+    }
+
+    #[test]
+    fn test_render_markdown_report_body_injected() {
+        let data = json!({"x": 1});
+        let tmpl = "{{report_body}}";
+        let result = ReportRenderer::render_markdown(tmpl, &data).unwrap();
+        // Should be pretty-printed JSON
+        assert!(result.contains("\"x\""));
+        assert!(result.contains("1"));
+    }
+
+    #[test]
+    fn test_render_markdown_non_scalar_compact_json() {
+        let data = json!({"tags": ["a", "b"]});
+        let tmpl = "Tags: {{tags}}";
+        let result = ReportRenderer::render_markdown(tmpl, &data).unwrap();
+        // Non-scalar → compact JSON
+        assert!(result.contains("[\"a\",\"b\"]") || result.contains("[\"a\", \"b\"]"));
+    }
+
+    #[test]
+    fn test_render_markdown_missing_slot_returns_report_render_error() {
+        let data = json!({"name": "Alice"});
+        let tmpl = "Name: {{name}}, Missing: {{does_not_exist}}";
+        let err = ReportRenderer::render_markdown(tmpl, &data).unwrap_err();
+        match err {
+            PipelineError::ReportRender { slot } => {
+                assert_eq!(slot, "does_not_exist");
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_render_markdown_null_value() {
+        let data = json!({"val": null});
+        let tmpl = "Value: {{val}}";
+        let result = ReportRenderer::render_markdown(tmpl, &data).unwrap();
+        assert_eq!(result, "Value: null");
+    }
+}

--- a/aikit-sdk/src/template.rs
+++ b/aikit-sdk/src/template.rs
@@ -9,7 +9,6 @@
 //! - Unused slots are silently ignored.
 
 use crate::pipeline::PipelineError;
-use std::collections::HashMap;
 
 /// Renders `{{slot}}` templates with a single-pass algorithm.
 pub struct TemplateRenderer;
@@ -19,10 +18,7 @@ impl TemplateRenderer {
     ///
     /// Returns the rendered string, or `PipelineError::TemplateSlotMissing`
     /// if a referenced slot is not present in `slots`.
-    pub fn render(
-        template: &str,
-        slots: &HashMap<String, String>,
-    ) -> Result<String, PipelineError> {
+    pub fn render(template: &str, slots: &[(&str, &str)]) -> Result<String, PipelineError> {
         let mut output = String::with_capacity(template.len());
         let bytes = template.as_bytes();
         let len = bytes.len();
@@ -57,13 +53,15 @@ impl TemplateRenderer {
                     j += 1;
                 }
                 if found_close {
-                    let slot_name = template[start..j].trim().to_string();
-                    match slots.get(&slot_name) {
-                        Some(value) => {
+                    let slot_name = template[start..j].trim();
+                    match slots.iter().find(|(k, _)| *k == slot_name) {
+                        Some((_, value)) => {
                             output.push_str(value);
                         }
                         None => {
-                            return Err(PipelineError::TemplateSlotMissing { slot: slot_name });
+                            return Err(PipelineError::TemplateSlotMissing {
+                                slot: slot_name.to_string(),
+                            });
                         }
                     }
                     i = j + 2;
@@ -107,17 +105,9 @@ fn utf8_char_len(b: u8) -> usize {
 mod tests {
     use super::*;
 
-    fn slots(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-        pairs
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect()
-    }
-
     #[test]
     fn test_basic_substitution() {
-        let result =
-            TemplateRenderer::render("Hello, {{name}}!", &slots(&[("name", "world")])).unwrap();
+        let result = TemplateRenderer::render("Hello, {{name}}!", &[("name", "world")]).unwrap();
         assert_eq!(result, "Hello, world!");
     }
 
@@ -125,7 +115,7 @@ mod tests {
     fn test_multiple_slots() {
         let result = TemplateRenderer::render(
             "{{greeting}}, {{name}}!",
-            &slots(&[("greeting", "Hi"), ("name", "Alice")]),
+            &[("greeting", "Hi"), ("name", "Alice")],
         )
         .unwrap();
         assert_eq!(result, "Hi, Alice!");
@@ -133,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_missing_slot_returns_error() {
-        let err = TemplateRenderer::render("Hello, {{name}}!", &slots(&[])).unwrap_err();
+        let err = TemplateRenderer::render("Hello, {{name}}!", &[]).unwrap_err();
         match err {
             PipelineError::TemplateSlotMissing { slot } => assert_eq!(slot, "name"),
             other => panic!("unexpected error: {:?}", other),
@@ -144,7 +134,7 @@ mod tests {
     fn test_unused_slot_ignored() {
         let result = TemplateRenderer::render(
             "Hello, {{name}}!",
-            &slots(&[("name", "world"), ("unused", "ignored")]),
+            &[("name", "world"), ("unused", "ignored")],
         )
         .unwrap();
         assert_eq!(result, "Hello, world!");
@@ -152,20 +142,20 @@ mod tests {
 
     #[test]
     fn test_escape_open_brace() {
-        let result = TemplateRenderer::render("literal \\{{ brace", &slots(&[])).unwrap();
+        let result = TemplateRenderer::render("literal \\{{ brace", &[]).unwrap();
         assert_eq!(result, "literal {{ brace");
     }
 
     #[test]
     fn test_escape_close_brace() {
-        let result = TemplateRenderer::render("literal \\}} brace", &slots(&[])).unwrap();
+        let result = TemplateRenderer::render("literal \\}} brace", &[]).unwrap();
         assert_eq!(result, "literal }} brace");
     }
 
     #[test]
     fn test_escape_sequences_not_interpolated() {
         // \{{ should not start an interpolation
-        let result = TemplateRenderer::render("\\{{name}}", &slots(&[("name", "world")])).unwrap();
+        let result = TemplateRenderer::render("\\{{name}}", &[("name", "world")]).unwrap();
         // \{{ emits {{ then "name}}" is literal
         assert_eq!(result, "{{name}}");
     }
@@ -173,24 +163,21 @@ mod tests {
     #[test]
     fn test_single_pass_invariant_value_not_rescanned() {
         // If a slot value itself contains `{{other}}`, it must NOT be processed.
-        let result = TemplateRenderer::render(
-            "{{a}}",
-            &slots(&[("a", "{{b}}"), ("b", "should-not-appear")]),
-        )
-        .unwrap();
+        let result =
+            TemplateRenderer::render("{{a}}", &[("a", "{{b}}"), ("b", "should-not-appear")])
+                .unwrap();
         assert_eq!(result, "{{b}}");
     }
 
     #[test]
     fn test_no_slots_in_template() {
-        let result = TemplateRenderer::render("plain text", &slots(&[])).unwrap();
+        let result = TemplateRenderer::render("plain text", &[]).unwrap();
         assert_eq!(result, "plain text");
     }
 
     #[test]
     fn test_slot_with_whitespace_trimmed() {
-        let result =
-            TemplateRenderer::render("{{ name }}", &slots(&[("name", "trimmed")])).unwrap();
+        let result = TemplateRenderer::render("{{ name }}", &[("name", "trimmed")]).unwrap();
         assert_eq!(result, "trimmed");
     }
 }

--- a/aikit-sdk/src/template.rs
+++ b/aikit-sdk/src/template.rs
@@ -1,0 +1,196 @@
+//! Single-pass `{{slot}}` template renderer.
+//!
+//! Scan rules (left-to-right, single pass):
+//! - `\{{` → emit literal `{{`
+//! - `\}}` → emit literal `}}`
+//! - `{{` → scan forward for matching `}}`, trim slot name, look up in slots
+//!   - found: emit value verbatim (no rescan)
+//!   - not found: return `Err(PipelineError::TemplateSlotMissing { slot })`
+//! - Unused slots are silently ignored.
+
+use crate::pipeline::PipelineError;
+use std::collections::HashMap;
+
+/// Renders `{{slot}}` templates with a single-pass algorithm.
+pub struct TemplateRenderer;
+
+impl TemplateRenderer {
+    /// Render `template` by substituting all `{{slot}}` occurrences.
+    ///
+    /// Returns the rendered string, or `PipelineError::TemplateSlotMissing`
+    /// if a referenced slot is not present in `slots`.
+    pub fn render(
+        template: &str,
+        slots: &HashMap<String, String>,
+    ) -> Result<String, PipelineError> {
+        let mut output = String::with_capacity(template.len());
+        let bytes = template.as_bytes();
+        let len = bytes.len();
+        let mut i = 0;
+
+        while i < len {
+            // Check for escape sequences \{{ and \}}
+            if i + 2 < len && bytes[i] == b'\\' {
+                if bytes[i + 1] == b'{' && bytes[i + 2] == b'{' {
+                    output.push_str("{{");
+                    i += 3;
+                    continue;
+                }
+                if bytes[i + 1] == b'}' && bytes[i + 2] == b'}' {
+                    output.push_str("}}");
+                    i += 3;
+                    continue;
+                }
+            }
+
+            // Check for `{{`
+            if i + 1 < len && bytes[i] == b'{' && bytes[i + 1] == b'{' {
+                // Search for matching `}}`
+                let start = i + 2;
+                let mut j = start;
+                let mut found_close = false;
+                while j + 1 < len {
+                    if bytes[j] == b'}' && bytes[j + 1] == b'}' {
+                        found_close = true;
+                        break;
+                    }
+                    j += 1;
+                }
+                if found_close {
+                    let slot_name = template[start..j].trim().to_string();
+                    match slots.get(&slot_name) {
+                        Some(value) => {
+                            output.push_str(value);
+                        }
+                        None => {
+                            return Err(PipelineError::TemplateSlotMissing { slot: slot_name });
+                        }
+                    }
+                    i = j + 2;
+                } else {
+                    // No closing `}}` found — treat as literal
+                    output.push(bytes[i] as char);
+                    i += 1;
+                }
+                continue;
+            }
+
+            // Regular character — push as UTF-8 char boundary safe slice
+            let ch_len = utf8_char_len(bytes[i]);
+            if i + ch_len <= len {
+                output.push_str(&template[i..i + ch_len]);
+                i += ch_len;
+            } else {
+                output.push(bytes[i] as char);
+                i += 1;
+            }
+        }
+
+        Ok(output)
+    }
+}
+
+/// Returns the byte-length of a UTF-8 character given its leading byte.
+fn utf8_char_len(b: u8) -> usize {
+    if b & 0x80 == 0 {
+        1
+    } else if b & 0xE0 == 0xC0 {
+        2
+    } else if b & 0xF0 == 0xE0 {
+        3
+    } else {
+        4
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slots(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_basic_substitution() {
+        let result =
+            TemplateRenderer::render("Hello, {{name}}!", &slots(&[("name", "world")])).unwrap();
+        assert_eq!(result, "Hello, world!");
+    }
+
+    #[test]
+    fn test_multiple_slots() {
+        let result = TemplateRenderer::render(
+            "{{greeting}}, {{name}}!",
+            &slots(&[("greeting", "Hi"), ("name", "Alice")]),
+        )
+        .unwrap();
+        assert_eq!(result, "Hi, Alice!");
+    }
+
+    #[test]
+    fn test_missing_slot_returns_error() {
+        let err = TemplateRenderer::render("Hello, {{name}}!", &slots(&[])).unwrap_err();
+        match err {
+            PipelineError::TemplateSlotMissing { slot } => assert_eq!(slot, "name"),
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_unused_slot_ignored() {
+        let result = TemplateRenderer::render(
+            "Hello, {{name}}!",
+            &slots(&[("name", "world"), ("unused", "ignored")]),
+        )
+        .unwrap();
+        assert_eq!(result, "Hello, world!");
+    }
+
+    #[test]
+    fn test_escape_open_brace() {
+        let result = TemplateRenderer::render("literal \\{{ brace", &slots(&[])).unwrap();
+        assert_eq!(result, "literal {{ brace");
+    }
+
+    #[test]
+    fn test_escape_close_brace() {
+        let result = TemplateRenderer::render("literal \\}} brace", &slots(&[])).unwrap();
+        assert_eq!(result, "literal }} brace");
+    }
+
+    #[test]
+    fn test_escape_sequences_not_interpolated() {
+        // \{{ should not start an interpolation
+        let result = TemplateRenderer::render("\\{{name}}", &slots(&[("name", "world")])).unwrap();
+        // \{{ emits {{ then "name}}" is literal
+        assert_eq!(result, "{{name}}");
+    }
+
+    #[test]
+    fn test_single_pass_invariant_value_not_rescanned() {
+        // If a slot value itself contains `{{other}}`, it must NOT be processed.
+        let result = TemplateRenderer::render(
+            "{{a}}",
+            &slots(&[("a", "{{b}}"), ("b", "should-not-appear")]),
+        )
+        .unwrap();
+        assert_eq!(result, "{{b}}");
+    }
+
+    #[test]
+    fn test_no_slots_in_template() {
+        let result = TemplateRenderer::render("plain text", &slots(&[])).unwrap();
+        assert_eq!(result, "plain text");
+    }
+
+    #[test]
+    fn test_slot_with_whitespace_trimmed() {
+        let result =
+            TemplateRenderer::render("{{ name }}", &slots(&[("name", "trimmed")])).unwrap();
+        assert_eq!(result, "trimmed");
+    }
+}

--- a/aikit-sdk/src/validation.rs
+++ b/aikit-sdk/src/validation.rs
@@ -1,0 +1,190 @@
+//! JSON response validation using jsonschema.
+//!
+//! Extracts the first ```json block from a response (falling back to bare JSON),
+//! then validates it against a JSON Schema.
+
+use crate::pipeline::PipelineError;
+
+/// A successfully validated agent response.
+#[derive(Debug)]
+pub struct ValidatedResponse {
+    /// The parsed JSON data.
+    pub data: serde_json::Value,
+    /// The raw string that was parsed (the extracted JSON text).
+    pub raw: String,
+}
+
+/// Validates agent text responses against a JSON Schema.
+pub struct ResponseValidator;
+
+impl ResponseValidator {
+    /// Extract and validate `text` against `schema_str`.
+    ///
+    /// Extraction: searches for a ` ```json ` fenced block (newline after fence
+    /// is permitted). Falls back to treating the entire string as bare JSON.
+    ///
+    /// Validation: uses `jsonschema::validator_for` to build a validator from
+    /// `schema_str`, then collects all validation errors.
+    pub fn validate(text: &str, schema_str: &str) -> Result<ValidatedResponse, PipelineError> {
+        // --- Extract JSON text ---
+        let json_text = Self::extract_json(text);
+
+        // --- Parse JSON ---
+        let data: serde_json::Value =
+            serde_json::from_str(&json_text).map_err(|e| PipelineError::ValidationFailed {
+                raw_output: text.to_string(),
+                errors: vec![format!("JSON parse error: {}", e)],
+            })?;
+
+        // --- Parse schema ---
+        let schema_value: serde_json::Value =
+            serde_json::from_str(schema_str).map_err(|e| PipelineError::ValidationFailed {
+                raw_output: text.to_string(),
+                errors: vec![format!("Schema parse error: {}", e)],
+            })?;
+
+        let validator = jsonschema::validator_for(&schema_value).map_err(|e| {
+            PipelineError::ValidationFailed {
+                raw_output: text.to_string(),
+                errors: vec![format!("Schema compilation error: {}", e)],
+            }
+        })?;
+
+        // --- Validate ---
+        let error_messages: Vec<String> = validator
+            .iter_errors(&data)
+            .map(|e| e.to_string())
+            .collect();
+
+        if error_messages.is_empty() {
+            Ok(ValidatedResponse {
+                data,
+                raw: json_text,
+            })
+        } else {
+            Err(PipelineError::ValidationFailed {
+                raw_output: text.to_string(),
+                errors: error_messages,
+            })
+        }
+    }
+
+    /// Extract the first ```json block from `text`, or return `text` as-is.
+    fn extract_json(text: &str) -> String {
+        // Look for ```json (optionally followed by a newline)
+        if let Some(start_idx) = find_json_fence_start(text) {
+            // Find the closing ```
+            let after_open = &text[start_idx..];
+            if let Some(close_offset) = after_open.find("```") {
+                let json_content = &after_open[..close_offset];
+                return json_content.trim().to_string();
+            }
+        }
+        // Fallback: bare JSON
+        text.trim().to_string()
+    }
+}
+
+/// Find the start of the content inside the first ```json fence.
+///
+/// Returns the byte index within `text` where the JSON content begins
+/// (i.e., right after the opening fence line).
+fn find_json_fence_start(text: &str) -> Option<usize> {
+    // Search for "```json" optionally preceded by whitespace on a new segment
+    let marker = "```json";
+    if let Some(pos) = text.find(marker) {
+        let after_marker = pos + marker.len();
+        // Skip optional newline (LF or CRLF) after the fence
+        let content_start = if text[after_marker..].starts_with("\r\n") {
+            after_marker + 2
+        } else if text[after_marker..].starts_with('\n') {
+            after_marker + 1
+        } else {
+            after_marker
+        };
+        return Some(content_start);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SCHEMA_NAME_REQUIRED: &str = r#"{
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+    }"#;
+
+    #[test]
+    fn test_valid_bare_json() {
+        let result = ResponseValidator::validate(r#"{"name":"Alice"}"#, SCHEMA_NAME_REQUIRED);
+        assert!(result.is_ok());
+        let v = result.unwrap();
+        assert_eq!(v.data["name"], "Alice");
+    }
+
+    #[test]
+    fn test_valid_json_in_fence() {
+        let text = "Here is the result:\n```json\n{\"name\":\"Bob\"}\n```\n";
+        let result = ResponseValidator::validate(text, SCHEMA_NAME_REQUIRED);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().data["name"], "Bob");
+    }
+
+    #[test]
+    fn test_valid_json_fence_no_newline() {
+        let text = "```json{\"name\":\"Carol\"}```";
+        let result = ResponseValidator::validate(text, SCHEMA_NAME_REQUIRED);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().data["name"], "Carol");
+    }
+
+    #[test]
+    fn test_missing_required_field_fails() {
+        let raw = r#"{"age": 42}"#;
+        let err = ResponseValidator::validate(raw, SCHEMA_NAME_REQUIRED).unwrap_err();
+        match err {
+            PipelineError::ValidationFailed { errors, .. } => {
+                assert!(!errors.is_empty());
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_invalid_json_parse_error() {
+        let raw = "not json at all";
+        let err = ResponseValidator::validate(raw, SCHEMA_NAME_REQUIRED).unwrap_err();
+        match err {
+            PipelineError::ValidationFailed { errors, .. } => {
+                assert!(errors[0].contains("JSON parse error") || !errors.is_empty());
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_fence_content_returned_in_raw() {
+        let text = "```json\n{\"name\":\"Dave\"}\n```";
+        let v = ResponseValidator::validate(text, SCHEMA_NAME_REQUIRED).unwrap();
+        assert_eq!(v.raw.trim(), r#"{"name":"Dave"}"#);
+    }
+
+    #[test]
+    fn test_wrong_type_fails_validation() {
+        let schema =
+            r#"{"type":"object","properties":{"count":{"type":"integer"}},"required":["count"]}"#;
+        let raw = r#"{"count": "not-an-integer"}"#;
+        let err = ResponseValidator::validate(raw, schema).unwrap_err();
+        assert!(matches!(err, PipelineError::ValidationFailed { .. }));
+    }
+
+    #[test]
+    fn test_first_fence_used_when_multiple() {
+        let text = "```json\n{\"name\":\"First\"}\n```\n```json\n{\"name\":\"Second\"}\n```";
+        let v = ResponseValidator::validate(text, SCHEMA_NAME_REQUIRED).unwrap();
+        assert_eq!(v.data["name"], "First");
+    }
+}

--- a/aikit-sdk/src/validation.rs
+++ b/aikit-sdk/src/validation.rs
@@ -59,7 +59,7 @@ impl ResponseValidator {
         if error_messages.is_empty() {
             Ok(ValidatedResponse {
                 data,
-                raw: json_text,
+                raw: text.to_string(),
             })
         } else {
             Err(PipelineError::ValidationFailed {
@@ -166,10 +166,28 @@ mod tests {
     }
 
     #[test]
-    fn test_fence_content_returned_in_raw() {
+    fn test_full_output_returned_in_raw() {
         let text = "```json\n{\"name\":\"Dave\"}\n```";
         let v = ResponseValidator::validate(text, SCHEMA_NAME_REQUIRED).unwrap();
-        assert_eq!(v.raw.trim(), r#"{"name":"Dave"}"#);
+        // raw must be the full assembled agent output, not just the extracted JSON
+        assert_eq!(v.raw, text);
+    }
+
+    #[test]
+    fn test_invalid_schema_string_returns_validation_failed() {
+        // AC13: invalid schema string must return ValidationFailed with non-empty errors
+        let valid_json = r#"{"name": "Alice"}"#;
+        let invalid_schema = "not-valid-json-schema";
+        let err = ResponseValidator::validate(valid_json, invalid_schema).unwrap_err();
+        match err {
+            PipelineError::ValidationFailed { errors, .. } => {
+                assert!(
+                    !errors.is_empty(),
+                    "expected non-empty errors for invalid schema"
+                );
+            }
+            other => panic!("expected ValidationFailed, got {:?}", other),
+        }
     }
 
     #[test]

--- a/aikit-sdk/src/validation.rs
+++ b/aikit-sdk/src/validation.rs
@@ -6,7 +6,7 @@
 use crate::pipeline::PipelineError;
 
 /// A successfully validated agent response.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValidatedResponse {
     /// The parsed JSON data.
     pub data: serde_json::Value,


### PR DESCRIPTION
## Summary
Implements spec #49: structured agent pipeline in `aikit-sdk` (template render, agent runner, JSON schema validation, retry loop, report rendering, and pipeline composition).

## Test plan
- [x] `./scripts/run-tests.sh` passed in develop workflow
- [x] Spec validation returned VALID against `tmp/49-aikit-sdk-structured-agent-pipeline.md`

Merge with squash.