### PR TITLE
feat(sdk): expose AgentRunner::with_mock as pub under testing feature (#58)

### DIFF
--- a/aikit-sdk/Cargo.toml
+++ b/aikit-sdk/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/goaikit/aikit"
 keywords = ["ai", "agents", "deploy", "catalog", "capabilities"]
 categories = ["command-line-utilities"]
 
+[features]
+testing = []
+
 [dependencies]
 tracing = "0.1"
 glob = "0.3"

--- a/aikit-sdk/src/agent_runner.rs
+++ b/aikit-sdk/src/agent_runner.rs
@@ -7,12 +7,12 @@ use crate::runner::{
 };
 use std::path::PathBuf;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 type MockQueue = std::sync::Arc<
     std::sync::Mutex<std::collections::VecDeque<Result<String, crate::pipeline::PipelineError>>>,
 >;
-#[cfg(test)]
-type CapturedPrompts = std::sync::Arc<std::sync::Mutex<Vec<String>>>;
+#[cfg(any(test, feature = "testing"))]
+pub type CapturedPrompts = std::sync::Arc<std::sync::Mutex<Vec<String>>>;
 
 // ---------------------------------------------------------------------------
 // AgentRunner
@@ -23,9 +23,9 @@ pub struct AgentRunner {
     agent_key: String,
     model: Option<String>,
     working_dir: Option<PathBuf>,
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     mock_responses: Option<MockQueue>,
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     captured_prompts: Option<CapturedPrompts>,
 }
 
@@ -36,9 +36,9 @@ impl AgentRunner {
             agent_key: String::new(),
             model: None,
             working_dir: None,
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             mock_responses: None,
-            #[cfg(test)]
+            #[cfg(any(test, feature = "testing"))]
             captured_prompts: None,
         }
     }
@@ -47,8 +47,8 @@ impl AgentRunner {
     ///
     /// Returns the runner and a shared prompt capture buffer.
     /// Each call to `run()` pops the next response from `responses`.
-    #[cfg(test)]
-    pub(crate) fn with_mock(
+    #[cfg(any(test, feature = "testing"))]
+    pub fn with_mock(
         responses: Vec<Result<String, crate::pipeline::PipelineError>>,
     ) -> (Self, CapturedPrompts) {
         use std::collections::VecDeque;
@@ -87,7 +87,7 @@ impl AgentRunner {
     /// Blocking. Returns `PipelineError::AgentInvocation` on any RunError.
     pub fn run(&self, prompt: &str) -> Result<String, PipelineError> {
         // In tests: use mock response queue if populated.
-        #[cfg(test)]
+        #[cfg(any(test, feature = "testing"))]
         if let Some(ref responses) = self.mock_responses {
             let mut queue = responses.lock().unwrap();
             if !queue.is_empty() {

--- a/aikit-sdk/src/lib.rs
+++ b/aikit-sdk/src/lib.rs
@@ -447,6 +447,8 @@ pub mod report;
 pub mod template;
 pub mod validation;
 
+#[cfg(any(test, feature = "testing"))]
+pub use agent_runner::CapturedPrompts;
 pub use agent_runner::{AgentDetector, AgentInfo, AgentRunner};
 pub use pipeline::{OutputFormat, Pipeline, PipelineError, PipelineResult};
 pub use report::ReportRenderer;

--- a/aikit-sdk/tests/mock_public_api.rs
+++ b/aikit-sdk/tests/mock_public_api.rs
@@ -1,0 +1,33 @@
+#[cfg(feature = "testing")]
+#[test]
+fn with_mock_returns_queued_response_and_captures_prompt() {
+    let (runner, captured) =
+        aikit_sdk::AgentRunner::with_mock(vec![Ok("mock response".to_string())]);
+    let runner = runner.agent("unused-in-mock");
+    let result = runner.run("test prompt");
+    assert_eq!(result.unwrap(), "mock response");
+    assert_eq!(*captured.lock().unwrap(), vec!["test prompt".to_string()]);
+}
+
+#[cfg(feature = "testing")]
+#[test]
+fn captured_prompts_type_alias_resolves() {
+    let (_runner, captured) = aikit_sdk::AgentRunner::with_mock(vec![Ok("ok".to_string())]);
+    let _typed: aikit_sdk::CapturedPrompts = captured;
+}
+
+#[cfg(feature = "testing")]
+#[test]
+fn with_mock_error_injection_propagates() {
+    use aikit_sdk::PipelineError;
+    let (runner, _) =
+        aikit_sdk::AgentRunner::with_mock(vec![Err(PipelineError::ValidationFailed {
+            raw_output: "bad".to_string(),
+            errors: vec!["e".to_string()],
+        })]);
+    let result = runner.run("any");
+    assert!(matches!(
+        result,
+        Err(PipelineError::ValidationFailed { .. })
+    ));
+}


### PR DESCRIPTION
## Summary

- Adds `[features] testing = []` to `aikit-sdk/Cargo.toml` as a non-default opt-in feature
- Replaces all 8 `#[cfg(test)]` gates on mock infrastructure in `agent_runner.rs` with `#[cfg(any(test, feature = "testing"))]`
- Promotes `CapturedPrompts` to `pub type` and `with_mock` to `pub fn` (previously `pub(crate)`)
- Re-exports `aikit_sdk::CapturedPrompts` from `lib.rs` under the same cfg gate
- Adds `aikit-sdk/tests/mock_public_api.rs` with 3 feature-gated integration tests validating the public mock surface

## Test plan

- [ ] `cargo build -p aikit-sdk` — zero-footprint build without feature succeeds
- [ ] `cargo build -p aikit-sdk --features testing` — succeeds with testing feature
- [ ] `cargo test -p aikit-sdk` — all existing tests pass unmodified
- [ ] `cargo test -p aikit-sdk --features testing` — all 3 new integration tests pass (`with_mock_returns_queued_response_and_captures_prompt`, `captured_prompts_type_alias_resolves`, `with_mock_error_injection_propagates`)
- [ ] Production struct layout unchanged when `testing` feature is absent (3 fields only)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)