### PR TITLE
fix(sdk): inject SessionStore to fix parallel test race condition (#54)

### DIFF
--- a/aikit-sdk/src/aikit_agent_adapter.rs
+++ b/aikit-sdk/src/aikit_agent_adapter.rs
@@ -50,7 +50,14 @@ where
     let gateway = OpenAiCompatProvider::new(config.timeout_secs, config.connect_timeout_secs)
         .map_err(|e| emit_error(prompt, options, &mut on_event, e.to_string()))?;
 
-    run_with_config_and_gateway(prompt, options, config, Box::new(gateway), &mut on_event)
+    run_with_config_and_gateway(
+        prompt,
+        options,
+        config,
+        Box::new(gateway),
+        SessionStore::open(),
+        &mut on_event,
+    )
 }
 
 /// Run the builtin aikit agent with an externally-supplied LLM gateway.
@@ -62,6 +69,7 @@ pub fn run_aikit_agent_with_gateway<F>(
     prompt: &str,
     options: &RunOptions,
     gateway: Box<dyn LlmGateway>,
+    store: Option<SessionStore>,
     mut on_event: F,
 ) -> Result<RunResult, RunError>
 where
@@ -76,7 +84,15 @@ where
 
     apply_session_options(options, &mut config);
 
-    run_with_config_and_gateway(prompt, options, config, gateway, &mut on_event)
+    let resolved_store = store.unwrap_or_else(SessionStore::open);
+    run_with_config_and_gateway(
+        prompt,
+        options,
+        config,
+        gateway,
+        resolved_store,
+        &mut on_event,
+    )
 }
 
 fn apply_session_options(options: &RunOptions, config: &mut AgentConfig) {
@@ -116,12 +132,12 @@ fn run_with_config_and_gateway<F>(
     options: &RunOptions,
     config: AgentConfig,
     gateway: Box<dyn LlmGateway>,
+    store: SessionStore,
     on_event: &mut F,
 ) -> Result<RunResult, RunError>
 where
     F: FnMut(AgentEvent) + Send,
 {
-    let store = SessionStore::open();
     let cwd = options
         .current_dir
         .clone()

--- a/aikit-sdk/tests/builtin_agent_test.rs
+++ b/aikit-sdk/tests/builtin_agent_test.rs
@@ -162,24 +162,17 @@ fn test_embed_wrong_key_error() {
 #[test]
 fn test_resume_missing_session_returns_not_found() {
     let tmp = tempfile::TempDir::new().unwrap();
-    std::env::set_var("AIKIT_SESSIONS_DIR", tmp.path().to_str().unwrap());
     std::env::set_var("AIKIT_API_KEY", "test-key-unused");
+    let store = SessionStore {
+        sessions_dir: tmp.path().to_path_buf(),
+    };
 
     let options = RunOptions::new().with_session_id("nonexistent-session-id-xyz");
-    let mut writer = Vec::new();
-    let mut err_writer = Vec::new();
+    let gw = MockGateway::new(vec![]);
 
-    let result = run_builtin_agent(
-        "aikit",
-        "test prompt",
-        options,
-        OutputMode::Plain,
-        &mut writer,
-        &mut err_writer,
-        None,
-    );
+    let result =
+        run_aikit_agent_with_gateway("test prompt", &options, Box::new(gw), Some(store), |_| {});
 
-    std::env::remove_var("AIKIT_SESSIONS_DIR");
     std::env::remove_var("AIKIT_API_KEY");
 
     match result.unwrap_err() {
@@ -194,28 +187,21 @@ fn test_resume_missing_session_returns_not_found() {
 #[test]
 fn test_resume_corrupt_session_returns_load_failed() {
     let tmp = tempfile::TempDir::new().unwrap();
-    std::env::set_var("AIKIT_SESSIONS_DIR", tmp.path().to_str().unwrap());
     std::env::set_var("AIKIT_API_KEY", "test-key-unused");
+    let store = SessionStore {
+        sessions_dir: tmp.path().to_path_buf(),
+    };
 
     let corrupt_id = "corrupt-session-id-abc";
     let session_path = tmp.path().join(format!("{}.json", corrupt_id));
     std::fs::write(&session_path, "not valid json at all {{{{").unwrap();
 
     let options = RunOptions::new().with_session_id(corrupt_id);
-    let mut writer = Vec::new();
-    let mut err_writer = Vec::new();
+    let gw = MockGateway::new(vec![]);
 
-    let result = run_builtin_agent(
-        "aikit",
-        "test prompt",
-        options,
-        OutputMode::Plain,
-        &mut writer,
-        &mut err_writer,
-        None,
-    );
+    let result =
+        run_aikit_agent_with_gateway("test prompt", &options, Box::new(gw), Some(store), |_| {});
 
-    std::env::remove_var("AIKIT_SESSIONS_DIR");
     std::env::remove_var("AIKIT_API_KEY");
 
     match result.unwrap_err() {
@@ -270,17 +256,19 @@ fn test_session_store_default_is_accessible() {
 #[test]
 fn test_new_session_creates_file_and_prints_to_stderr() {
     let tmp = tempfile::TempDir::new().unwrap();
-    std::env::set_var("AIKIT_SESSIONS_DIR", tmp.path().to_str().unwrap());
     std::env::set_var("AIKIT_API_KEY", "test-key-unused");
+    let store = SessionStore {
+        sessions_dir: tmp.path().to_path_buf(),
+    };
 
     let options = RunOptions::new();
     let gw = MockGateway::new(vec![MockResponse::text("Hello from mock agent!")]);
     let mut on_event_called = false;
-    let result = run_aikit_agent_with_gateway("Say hello", &options, Box::new(gw), |_event| {
-        on_event_called = true;
-    });
+    let result =
+        run_aikit_agent_with_gateway("Say hello", &options, Box::new(gw), Some(store), |_event| {
+            on_event_called = true;
+        });
 
-    std::env::remove_var("AIKIT_SESSIONS_DIR");
     std::env::remove_var("AIKIT_API_KEY");
 
     let result = result.expect("run should succeed");
@@ -335,8 +323,10 @@ fn test_new_session_creates_file_and_prints_to_stderr() {
 #[test]
 fn test_resume_passes_prior_turns_to_llm() {
     let tmp = tempfile::TempDir::new().unwrap();
-    std::env::set_var("AIKIT_SESSIONS_DIR", tmp.path().to_str().unwrap());
     std::env::set_var("AIKIT_API_KEY", "test-key-unused");
+    let store = SessionStore {
+        sessions_dir: tmp.path().to_path_buf(),
+    };
 
     // First, create a session file with prior turns.
     let session_id = "prior-turns-test-session-id-1111";
@@ -358,9 +348,9 @@ fn test_resume_passes_prior_turns_to_llm() {
     let gw = CapturingGateway::new(vec![MockResponse::text("Based on prior context...")]);
     let captured = std::sync::Arc::clone(&gw.captured);
 
-    let result = run_aikit_agent_with_gateway("What is 3+3?", &options, Box::new(gw), |_| {});
+    let result =
+        run_aikit_agent_with_gateway("What is 3+3?", &options, Box::new(gw), Some(store), |_| {});
 
-    std::env::remove_var("AIKIT_SESSIONS_DIR");
     std::env::remove_var("AIKIT_API_KEY");
 
     result.expect("resume should succeed");
@@ -409,13 +399,21 @@ fn test_resume_passes_prior_turns_to_llm() {
 #[test]
 fn test_two_run_integration_with_resume() {
     let tmp = tempfile::TempDir::new().unwrap();
-    std::env::set_var("AIKIT_SESSIONS_DIR", tmp.path().to_str().unwrap());
     std::env::set_var("AIKIT_API_KEY", "test-key-unused");
 
     // --- First run: no session_id, creates a new session ---
     let options1 = RunOptions::new();
     let gw1 = MockGateway::new(vec![MockResponse::text("First run response")]);
-    let result1 = run_aikit_agent_with_gateway("First prompt", &options1, Box::new(gw1), |_| {});
+    let store1 = SessionStore {
+        sessions_dir: tmp.path().to_path_buf(),
+    };
+    let result1 = run_aikit_agent_with_gateway(
+        "First prompt",
+        &options1,
+        Box::new(gw1),
+        Some(store1),
+        |_| {},
+    );
     let result1 = result1.expect("first run should succeed");
 
     // Extract session ID from stderr
@@ -438,10 +436,18 @@ fn test_two_run_integration_with_resume() {
     let options2 = RunOptions::new().with_session_id(&session_id);
     let gw2 = CapturingGateway::new(vec![MockResponse::text("Second run response")]);
     let captured = std::sync::Arc::clone(&gw2.captured);
+    let store2 = SessionStore {
+        sessions_dir: tmp.path().to_path_buf(),
+    };
 
-    let result2 = run_aikit_agent_with_gateway("Second prompt", &options2, Box::new(gw2), |_| {});
+    let result2 = run_aikit_agent_with_gateway(
+        "Second prompt",
+        &options2,
+        Box::new(gw2),
+        Some(store2),
+        |_| {},
+    );
 
-    std::env::remove_var("AIKIT_SESSIONS_DIR");
     std::env::remove_var("AIKIT_API_KEY");
 
     result2.expect("second run should succeed");


### PR DESCRIPTION
## Summary

- Adds `store: SessionStore` parameter to the private `run_with_config_and_gateway` function so each call site supplies its own store
- Adds `store: Option<SessionStore>` to the public `run_aikit_agent_with_gateway` so tests can inject an isolated per-test store
- Removes all `std::env::set_var("AIKIT_SESSIONS_DIR", ...)` calls from the 4 affected integration tests; each test now constructs its own `SessionStore { sessions_dir: tmp.path().to_path_buf() }` and passes `Some(store)`

## Test plan

- [x] `cargo test -p aikit-sdk --test builtin_agent_test` — all 17 tests pass with default parallelism
- [x] All 4 previously-flaky tests now pass: `test_new_session_creates_file_and_prints_to_stderr`, `test_resume_corrupt_session_returns_load_failed`, `test_two_run_integration_with_resume`, `test_resume_passes_prior_turns_to_llm`
- [x] No `set_var("AIKIT_SESSIONS_DIR", ...)` calls remain in `builtin_agent_test.rs`
- [x] Production path unchanged: `run_aikit_agent` still calls `SessionStore::open()` directly

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)