### PR TITLE
fix(sdk): map opencode events to MessagePhase::Final

### DIFF
--- a/aikit-sdk/src/runner/normalize.rs
+++ b/aikit-sdk/src/runner/normalize.rs
@@ -281,7 +281,7 @@ pub(super) fn normalize_opencode(
         {
             results.push(StreamMessage {
                 text: text.to_string(),
-                phase: MessagePhase::Delta,
+                phase: MessagePhase::Final,
                 role: MessageRole::Assistant,
                 kind: MessageKind::Message,
                 source: stream,
@@ -321,7 +321,7 @@ pub(super) fn normalize_opencode(
             };
             results.push(StreamMessage {
                 text: content.to_string(),
-                phase: MessagePhase::Delta,
+                phase: MessagePhase::Final,
                 role,
                 kind: MessageKind::Message,
                 source: stream,


### PR DESCRIPTION
## Summary

- `normalize_opencode` emitted `MessagePhase::Delta` for `text` and `message` events, but `AgentRunner::run()` only collects `Final`-phase assistant messages
- This caused the assembled response to always be empty, producing `JSON parse error: EOF while parsing a value at line 1 column 0` in `dk review` pipelines when using the opencode agent
- Changed both `text` and `message` event handlers in `normalize_opencode` to emit `MessagePhase::Final`, consistent with how codex, claude, and gemini normalizers work

## Root Cause

`dk review --template maintainability` → `AgentRunner::run()` → filters for `role == Assistant && phase == Final` → opencode normalizer only emitted `Delta` → empty assembled text → JSON parse error.

Opencode emits discrete `text` events (complete utterances, not streaming chunks), so `Final` is the correct phase mapping — matching how codex maps `item.text` to `Final`.

## Test Plan

- [x] All 381 existing tests pass (including `test_stub_opencode_streaming`, `test_fixture_opencode_produces_stream_messages`)
- [x] Live opencode integration test (`test_run_agent_opencode_basic` with `--ignored`) passes
- [x] Simulated `AgentRunner::run()` with live opencode event stream: JSON successfully extracted and parsed