### PR TITLE
feat(aikit-sdk): rich Claude decode via claude-agent-sdk (Phase B1)

### DIFF
--- a/aikit-sdk/Cargo.toml
+++ b/aikit-sdk/Cargo.toml
@@ -9,7 +9,11 @@ keywords = ["ai", "agents", "deploy", "catalog", "capabilities"]
 categories = ["command-line-utilities"]
 
 [features]
+default = ["claude-sdk"]
 testing = []
+# Delegate Claude decode to the typed `claude-agent-sdk` parser (richer
+# tool/thinking frames). When off, a hand-rolled text-only decode is used.
+claude-sdk = ["dep:claude-agent-sdk"]
 
 [dependencies]
 tracing = "0.1"
@@ -24,6 +28,7 @@ zip = "2.3"
 tempfile = "3.12"
 uuid = { version = "1", features = ["v4"] }
 aikit-agent = { path = "../aikit-agent", version = "0.1.0" }
+claude-agent-sdk = { git = "https://github.com/aroff/claude-agent-sdk-rust", rev = "717eacf", optional = true }
 jsonschema = "0.46"
 
 [dev-dependencies]

--- a/aikit-sdk/src/run_progress.rs
+++ b/aikit-sdk/src/run_progress.rs
@@ -129,6 +129,19 @@ impl RunProgress {
                     self.last_assistant_text = Some(text.to_string());
                 }
             }
+            AgentEventPayload::ToolUse { tool_name, .. } => {
+                self.add_row(format!("tool> {}", tool_name));
+            }
+            AgentEventPayload::ToolResult {
+                output, is_error, ..
+            } => {
+                let prefix = if *is_error { "tool error>" } else { "tool>" };
+                self.add_row(format!(
+                    "{} {}",
+                    prefix,
+                    truncate(&output.to_string(), self.config.max_tool_output_chars)
+                ));
+            }
             AgentEventPayload::AikitToolUse { tool_name, .. } => {
                 self.add_row(format!("tool> {}", tool_name));
             }

--- a/aikit-sdk/src/runner/backend.rs
+++ b/aikit-sdk/src/runner/backend.rs
@@ -16,6 +16,30 @@ use super::types::{
     AgentEventPayload, AgentEventStream, QuotaExceededInfo, StreamMessage, TokenUsage, UsageSource,
 };
 
+/// One canonical frame produced by decoding a line of a Backend's Dialect.
+///
+/// Phase A backends emit only [`Decoded::Stream`]. Richer Backends (Claude via
+/// `claude-agent-sdk`) also emit structured tool frames. The run loop maps each
+/// variant to the corresponding [`AgentEventPayload`]; the order within the
+/// returned `Vec` is the emission order.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decoded {
+    /// Canonical text/reasoning/status message.
+    Stream(StreamMessage),
+    /// A structured tool call.
+    ToolUse {
+        call_id: String,
+        tool_name: String,
+        input: serde_json::Value,
+    },
+    /// A structured tool result, correlated to a prior `ToolUse` by `call_id`.
+    ToolResult {
+        call_id: String,
+        output: serde_json::Value,
+        is_error: bool,
+    },
+}
+
 /// A runnable agent. Closed set; parse from a key with [`Backend::from_key`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Backend {
@@ -39,6 +63,11 @@ pub const ALL: &[Backend] = &[
     Backend::Cursor,
     Backend::Aikit,
 ];
+
+/// Wrap a backend's `StreamMessage`s as `Decoded::Stream` frames.
+fn wrap(messages: Vec<StreamMessage>) -> Vec<Decoded> {
+    messages.into_iter().map(Decoded::Stream).collect()
+}
 
 impl Backend {
     /// Parse a key string into a Backend. Returns `None` for unknown keys.
@@ -95,34 +124,37 @@ impl Backend {
         }
     }
 
-    /// Decode one inbound JSON line into canonical [`StreamMessage`]s.
-    /// Empty-text messages are filtered out (an invariant no decoder may break).
+    /// Decode one inbound JSON line into canonical [`Decoded`] frames.
+    ///
+    /// `Decoded::Stream` frames with empty text are filtered out (an invariant
+    /// no decoder may break); structured tool frames always pass through.
     pub fn decode(
         self,
         value: &serde_json::Value,
         stream: AgentEventStream,
         raw_line_seq: u64,
-    ) -> Vec<StreamMessage> {
-        let messages = match self {
+    ) -> Vec<Decoded> {
+        // Claude (with the `claude-sdk` feature) emits rich frames directly;
+        // the other backends emit StreamMessages that we wrap as Decoded::Stream.
+        let decoded: Vec<Decoded> = match self {
             Backend::Claude => claude::decode(value, stream, raw_line_seq),
-            Backend::Codex => codex::decode(value, stream, raw_line_seq),
-            Backend::Gemini => gemini::decode(value, stream, raw_line_seq),
-            Backend::OpenCode => opencode::decode(value, stream, raw_line_seq),
-            Backend::Cursor => cursor::decode(value, stream, raw_line_seq),
-            Backend::Aikit => aikit::decode(value, stream, raw_line_seq),
+            Backend::Codex => wrap(codex::decode(value, stream, raw_line_seq)),
+            Backend::Gemini => wrap(gemini::decode(value, stream, raw_line_seq)),
+            Backend::OpenCode => wrap(opencode::decode(value, stream, raw_line_seq)),
+            Backend::Cursor => wrap(cursor::decode(value, stream, raw_line_seq)),
+            Backend::Aikit => wrap(aikit::decode(value, stream, raw_line_seq)),
         };
-        messages
+        decoded
             .into_iter()
-            .filter(|m| {
-                if m.text.trim().is_empty() {
+            .filter(|d| match d {
+                Decoded::Stream(m) if m.text.trim().is_empty() => {
                     tracing::debug!(
                         target: "aikit_sdk::runner::decode",
                         "E_DECODE_EMPTY_TEXT: matched rule but text is empty"
                     );
                     false
-                } else {
-                    true
                 }
+                _ => true,
             })
             .collect()
     }
@@ -253,11 +285,13 @@ mod tests {
         ];
         for &b in ALL {
             for c in &cases {
-                for m in b.decode(c, AgentEventStream::Stdout, 0) {
-                    assert!(
-                        !m.text.trim().is_empty(),
-                        "{b:?} produced an empty-text StreamMessage"
-                    );
+                for d in b.decode(c, AgentEventStream::Stdout, 0) {
+                    if let Decoded::Stream(m) = d {
+                        assert!(
+                            !m.text.trim().is_empty(),
+                            "{b:?} produced an empty-text StreamMessage"
+                        );
+                    }
                 }
             }
         }

--- a/aikit-sdk/src/runner/backends/claude.rs
+++ b/aikit-sdk/src/runner/backends/claude.rs
@@ -1,11 +1,14 @@
 //! Claude backend: `claude --output-format stream-json` over a subprocess.
 //!
-//! Phase A relocates the existing decode/usage/quota/argv logic verbatim.
-//! Phase B will delegate decode to `claude-agent-sdk-rust::parse_message` and
-//! light up the bidirectional control axis (see spec 006).
+//! Decode delegates to the typed `claude-agent-sdk` parser (`parse_message`)
+//! when the `claude-sdk` feature is enabled (default), emitting structured
+//! tool/thinking frames in addition to text; a hand-rolled text-only decode is
+//! the fallback. Phase B2 will light up the bidirectional control axis via the
+//! SDK client (see spec 006/007).
 
 use std::ffi::OsString;
 
+use crate::runner::backend::Decoded;
 use crate::runner::backends::argv_spec::{ArgvCtx, ArgvSpec, SessionMode};
 use crate::runner::backends::quota_match::{match_quota, JsonPat, RawPat};
 use crate::runner::capabilities::BackendCapabilities;
@@ -34,11 +37,156 @@ const SPEC: ArgvSpec = ArgvSpec {
     session_mode: SessionMode::Flag("--resume"),
 };
 
+/// Build a canonical `StreamMessage` frame.
+fn sm(
+    text: String,
+    phase: MessagePhase,
+    kind: MessageKind,
+    turn_id: Option<String>,
+    stream: AgentEventStream,
+    raw_line_seq: u64,
+) -> StreamMessage {
+    StreamMessage {
+        text,
+        phase,
+        role: MessageRole::Assistant,
+        kind,
+        source: stream,
+        raw_line_seq,
+        turn_id,
+    }
+}
+
 pub(crate) fn decode(
     value: &serde_json::Value,
     stream: AgentEventStream,
     raw_line_seq: u64,
-) -> Vec<StreamMessage> {
+) -> Vec<Decoded> {
+    #[cfg(feature = "claude-sdk")]
+    {
+        sdk_decode(value, stream, raw_line_seq)
+    }
+    #[cfg(not(feature = "claude-sdk"))]
+    {
+        lenient_decode(value, stream, raw_line_seq)
+    }
+}
+
+/// Typed decode via `claude-agent-sdk`. Text/result behaviour matches the
+/// fallback; additionally surfaces thinking (as `Reasoning`) and structured
+/// tool calls/results. Parse errors and unknown message types yield no frames
+/// (same as the legacy decoder).
+#[cfg(feature = "claude-sdk")]
+fn sdk_decode(
+    value: &serde_json::Value,
+    stream: AgentEventStream,
+    raw_line_seq: u64,
+) -> Vec<Decoded> {
+    use claude_agent_sdk::{ContentBlock, Message, UserContent};
+
+    // The SDK parser is strict (requires e.g. `model` on assistant, full
+    // `result` fields). On a parse miss (older/partial CLI output, or an
+    // unrecognized type) fall back to the lenient text extraction so we never
+    // regress below the legacy decoder's floor.
+    let msg = match claude_agent_sdk::parse_message(value) {
+        Ok(Some(m)) => m,
+        _ => return lenient_decode(value, stream, raw_line_seq),
+    };
+
+    let mut out = Vec::new();
+    match msg {
+        Message::Assistant(a) => {
+            for block in a.content {
+                match block {
+                    ContentBlock::Text(t) => out.push(Decoded::Stream(sm(
+                        t.text,
+                        MessagePhase::Delta,
+                        MessageKind::Message,
+                        None,
+                        stream,
+                        raw_line_seq,
+                    ))),
+                    ContentBlock::Thinking(t) => out.push(Decoded::Stream(sm(
+                        t.thinking,
+                        MessagePhase::Delta,
+                        MessageKind::Reasoning,
+                        None,
+                        stream,
+                        raw_line_seq,
+                    ))),
+                    ContentBlock::ToolUse(t) => out.push(Decoded::ToolUse {
+                        call_id: t.id,
+                        tool_name: t.name,
+                        input: serde_json::Value::Object(t.input),
+                    }),
+                    ContentBlock::ToolResult(t) => out.push(Decoded::ToolResult {
+                        call_id: t.tool_use_id,
+                        output: t.content.unwrap_or(serde_json::Value::Null),
+                        is_error: t.is_error.unwrap_or(false),
+                    }),
+                    ContentBlock::ServerToolUse(s) => out.push(Decoded::ToolUse {
+                        call_id: s.id,
+                        tool_name: server_tool_name(&s.name),
+                        input: serde_json::Value::Object(s.input),
+                    }),
+                    ContentBlock::ServerToolResult(s) => out.push(Decoded::ToolResult {
+                        call_id: s.tool_use_id,
+                        output: serde_json::Value::Object(s.content),
+                        is_error: false,
+                    }),
+                }
+            }
+        }
+        // `user` lines carry tool_result blocks paired to prior tool calls.
+        Message::User(u) => {
+            if let UserContent::Blocks(blocks) = u.content {
+                for block in blocks {
+                    if let ContentBlock::ToolResult(t) = block {
+                        out.push(Decoded::ToolResult {
+                            call_id: t.tool_use_id,
+                            output: t.content.unwrap_or(serde_json::Value::Null),
+                            is_error: t.is_error.unwrap_or(false),
+                        });
+                    }
+                }
+            }
+        }
+        Message::Result(r) => {
+            if let Some(text) = r.result {
+                out.push(Decoded::Stream(sm(
+                    text,
+                    MessagePhase::Final,
+                    MessageKind::Message,
+                    Some(r.session_id),
+                    stream,
+                    raw_line_seq,
+                )));
+            }
+        }
+        // System / StreamEvent / RateLimit / Task* / Hook / Mirror carry no
+        // message text in the legacy contract: rate-limit is surfaced by
+        // `extract_quota` and usage by `extract_usage` (both unchanged).
+        _ => {}
+    }
+    out
+}
+
+#[cfg(feature = "claude-sdk")]
+fn server_tool_name(name: &claude_agent_sdk::ServerToolName) -> String {
+    serde_json::to_value(name)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("{name:?}"))
+}
+
+/// Hand-rolled text-only decode. The sole decoder when the `claude-sdk` feature
+/// is off, and the lenient fallback for lines the SDK parser rejects when it is
+/// on. Handles only `assistant` text and `result` — the legacy floor.
+fn lenient_decode(
+    value: &serde_json::Value,
+    stream: AgentEventStream,
+    raw_line_seq: u64,
+) -> Vec<Decoded> {
     let mut results = Vec::new();
     let line_type = value.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
@@ -48,15 +196,14 @@ pub(crate) fn decode(
                 for item in arr {
                     if item.get("type").and_then(|v| v.as_str()) == Some("text") {
                         if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                            results.push(StreamMessage {
-                                text: text.to_string(),
-                                phase: MessagePhase::Delta,
-                                role: MessageRole::Assistant,
-                                kind: MessageKind::Message,
-                                source: stream,
+                            results.push(Decoded::Stream(sm(
+                                text.to_string(),
+                                MessagePhase::Delta,
+                                MessageKind::Message,
+                                None,
+                                stream,
                                 raw_line_seq,
-                                turn_id: None,
-                            });
+                            )));
                         }
                     }
                 }
@@ -70,15 +217,14 @@ pub(crate) fn decode(
                 .get("session_id")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
-            results.push(StreamMessage {
-                text: result_text.to_string(),
-                phase: MessagePhase::Final,
-                role: MessageRole::Assistant,
-                kind: MessageKind::Message,
-                source: stream,
-                raw_line_seq,
+            results.push(Decoded::Stream(sm(
+                result_text.to_string(),
+                MessagePhase::Final,
+                MessageKind::Message,
                 turn_id,
-            });
+                stream,
+                raw_line_seq,
+            )));
         }
     }
 
@@ -189,4 +335,122 @@ pub(crate) fn argv(ctx: ArgvCtx) -> Vec<OsString> {
     }
     SPEC.push_session_flag(&mut argv, ctx.session_id);
     argv
+}
+
+#[cfg(all(test, feature = "claude-sdk"))]
+mod sdk_tests {
+    use super::*;
+    use crate::runner::backend::Decoded;
+
+    fn dec(line: serde_json::Value) -> Vec<Decoded> {
+        decode(&line, AgentEventStream::Stdout, 7)
+    }
+
+    #[test]
+    fn assistant_text_preserved_as_stream_delta() {
+        let out = dec(serde_json::json!({
+            "type": "assistant",
+            "message": {"model": "claude-x", "content": [{"type": "text", "text": "hi"}]}
+        }));
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            Decoded::Stream(m) => {
+                assert_eq!(m.text, "hi");
+                assert_eq!(m.phase, MessagePhase::Delta);
+                assert_eq!(m.kind, MessageKind::Message);
+                assert_eq!(m.raw_line_seq, 7);
+            }
+            other => panic!("expected Stream, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assistant_thinking_becomes_reasoning() {
+        let out = dec(serde_json::json!({
+            "type": "assistant",
+            "message": {"model": "m", "content": [
+                {"type": "thinking", "thinking": "let me think", "signature": "sig"}
+            ]}
+        }));
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            Decoded::Stream(m) => {
+                assert_eq!(m.text, "let me think");
+                assert_eq!(m.kind, MessageKind::Reasoning);
+            }
+            other => panic!("expected Reasoning Stream, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assistant_tool_use_is_structured() {
+        let out = dec(serde_json::json!({
+            "type": "assistant",
+            "message": {"model": "m", "content": [
+                {"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {"command": "ls"}}
+            ]}
+        }));
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            Decoded::ToolUse {
+                call_id,
+                tool_name,
+                input,
+            } => {
+                assert_eq!(call_id, "tu_1");
+                assert_eq!(tool_name, "Bash");
+                assert_eq!(input.get("command").unwrap(), "ls");
+            }
+            other => panic!("expected ToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_tool_result_is_structured() {
+        let out = dec(serde_json::json!({
+            "type": "user",
+            "message": {"content": [
+                {"type": "tool_result", "tool_use_id": "tu_1", "content": "file.txt", "is_error": false}
+            ]}
+        }));
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            Decoded::ToolResult {
+                call_id,
+                output,
+                is_error,
+            } => {
+                assert_eq!(call_id, "tu_1");
+                assert_eq!(output, "file.txt");
+                assert!(!is_error);
+            }
+            other => panic!("expected ToolResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn result_text_is_final_with_turn_id() {
+        let out = dec(serde_json::json!({
+            "type": "result", "subtype": "success", "duration_ms": 1, "duration_api_ms": 1,
+            "is_error": false, "num_turns": 1, "session_id": "sess-9", "result": "done"
+        }));
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            Decoded::Stream(m) => {
+                assert_eq!(m.text, "done");
+                assert_eq!(m.phase, MessagePhase::Final);
+                assert_eq!(m.turn_id.as_deref(), Some("sess-9"));
+            }
+            other => panic!("expected Final Stream, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_and_malformed_yield_nothing() {
+        assert!(
+            dec(serde_json::json!({"type": "stream_event", "event": {"type": "ping"}})).is_empty()
+        );
+        assert!(dec(serde_json::json!({"type": "system", "subtype": "init"})).is_empty());
+        assert!(dec(serde_json::json!({})).is_empty());
+    }
 }

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -15,7 +15,7 @@ pub use types::{
 
 pub use argv::{is_runnable, runnable_agents};
 pub use availability::{get_agent_status, get_installed_agents, is_agent_available};
-pub use backend::Backend;
+pub use backend::{Backend, Decoded};
 pub use capabilities::BackendCapabilities;
 pub use usage::aggregate_token_usage;
 
@@ -35,7 +35,16 @@ pub fn normalize_json_line(
     raw_line_seq: u64,
 ) -> Vec<StreamMessage> {
     match Backend::from_key(agent_key) {
-        Some(backend) => backend.decode(value, stream, raw_line_seq),
+        // The StreamMessage view of decode; structured tool frames (visible via
+        // `run_agent_events`) are not surfaced through this legacy helper.
+        Some(backend) => backend
+            .decode(value, stream, raw_line_seq)
+            .into_iter()
+            .filter_map(|d| match d {
+                backend::Decoded::Stream(m) => Some(m),
+                _ => None,
+            })
+            .collect(),
         None => {
             tracing::warn!(
                 target: "aikit_sdk::runner::decode",
@@ -309,22 +318,45 @@ where
                             }
                         }
 
-                        let messages = backend.decode(json_val, stream, json_line_seq);
-                        if messages.is_empty() {
+                        let decoded = backend.decode(json_val, stream, json_line_seq);
+                        if decoded.is_empty() {
                             json_lines_unmapped += 1;
                         }
-                        for msg_instance in messages {
-                            stream_messages_emitted += 1;
-                            let sm_event = AgentEvent {
+                        for frame in decoded {
+                            let payload = match frame {
+                                backend::Decoded::Stream(m) => {
+                                    stream_messages_emitted += 1;
+                                    AgentEventPayload::StreamMessage(m)
+                                }
+                                backend::Decoded::ToolUse {
+                                    call_id,
+                                    tool_name,
+                                    input,
+                                } => AgentEventPayload::ToolUse {
+                                    call_id,
+                                    tool_name,
+                                    input,
+                                },
+                                backend::Decoded::ToolResult {
+                                    call_id,
+                                    output,
+                                    is_error,
+                                } => AgentEventPayload::ToolResult {
+                                    call_id,
+                                    output,
+                                    is_error,
+                                },
+                            };
+                            let frame_event = AgentEvent {
                                 agent_key: agent_key.to_string(),
                                 seq,
                                 stream,
-                                payload: AgentEventPayload::StreamMessage(msg_instance),
+                                payload,
                             };
                             seq += 1;
                             if callback_panic.is_none() {
                                 let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                                    on_event(sm_event);
+                                    on_event(frame_event);
                                 }));
                                 if let Err(p) = result {
                                     callback_panic = Some(p);
@@ -828,6 +860,8 @@ mod tests {
                 AgentEventPayload::RawLine(_) => "raw",
                 AgentEventPayload::RawBytes(_) => "bytes",
                 AgentEventPayload::StreamMessage(_) => "stream_message",
+                AgentEventPayload::ToolUse { .. } => "tool_use",
+                AgentEventPayload::ToolResult { .. } => "tool_result",
                 AgentEventPayload::TokenUsageLine { .. } => "token_usage",
                 AgentEventPayload::QuotaExceeded { .. } => "quota_exceeded",
                 AgentEventPayload::RawTransportLine { .. } => "raw_transport",

--- a/aikit-sdk/src/runner/types.rs
+++ b/aikit-sdk/src/runner/types.rs
@@ -448,6 +448,21 @@ pub enum AgentEventPayload {
     RawBytes(Vec<u8>),
     /// Canonical text output from an agent, engine-agnostic.
     StreamMessage(StreamMessage),
+    /// A structured tool call decoded from an external Backend's output
+    /// (engine-agnostic; the in-process aikit agent uses `AikitToolUse`).
+    /// Emitted in decode order, in place of the corresponding `StreamMessage`s.
+    ToolUse {
+        call_id: String,
+        tool_name: String,
+        input: serde_json::Value,
+    },
+    /// A structured tool result decoded from an external Backend's output.
+    /// `call_id` correlates to the originating `ToolUse`.
+    ToolResult {
+        call_id: String,
+        output: serde_json::Value,
+        is_error: bool,
+    },
     /// Normalized token usage extracted from the preceding `JsonLine`.
     /// Emitted immediately after the corresponding `JsonLine` event when
     /// `RunOptions::emit_token_usage_events` is `true`.

--- a/docs/adr/0010-decode-emits-typed-frames.md
+++ b/docs/adr/0010-decode-emits-typed-frames.md
@@ -1,0 +1,21 @@
+# Decode emits typed canonical frames, not just StreamMessages
+
+## Status
+
+accepted
+
+## Context
+
+Phase A's `Backend::decode` returned `Vec<StreamMessage>` — a text-only lowest common denominator. To carry structured tool calls (and to let richer backends like Claude surface what they already emit), a single decoded line must be able to yield more than text: a tool call has a `call_id`, `tool_name`, and structured `input` that `StreamMessage { text, phase, role, kind }` cannot represent. This is the producer-side gap that [spec 005](../../specs/005-runner-structured-events/spec.md) identified.
+
+## Decision
+
+`Backend::decode` returns `Vec<Decoded>`, where `Decoded` is a small canonical enum: `Stream(StreamMessage)`, `ToolUse { call_id, tool_name, input }`, `ToolResult { call_id, output, is_error }`. The run loop maps each frame to an `AgentEventPayload`; two new **generic** payload variants — `AgentEventPayload::ToolUse` and `ToolResult` — carry tool frames for *external* backends (distinct from the existing `Aikit*` variants used by the in-process agent). The empty-text filter applies only to `Decoded::Stream`; tool frames always pass through.
+
+The five non-Claude backends are unchanged in behaviour: their `decode` still produces only `StreamMessage`s, which `Backend::decode` wraps as `Decoded::Stream`. The legacy `normalize_json_line` helper keeps its `Vec<StreamMessage>` signature by projecting out `Stream` frames; structured frames are observed via `run_agent_events`.
+
+## Consequences
+
+- Additive on the wire (the Event Streaming Protocol is an open tagged-frame format — [ADR 0005](0005-agent-events-are-the-shared-streaming-protocol.md)); existing consumers that match `StreamMessage` are unaffected. `AgentEventPayload` is `#[non_exhaustive]`, so external matches already tolerate the new variants.
+- `serve`'s SSE translation does not yet special-case the new frames (they fall through its wildcard); surfacing them as richer SSE is a follow-on (spec 005 E1/E3).
+- Unifying token-usage and quota into the same `Decoded` stream was considered and deferred: keeping `extract_usage`/`extract_quota` separate preserves the run loop's event ordering and the `emit_token_usage_events` semantics exactly.

--- a/docs/adr/0011-claude-decode-delegates-to-sdk.md
+++ b/docs/adr/0011-claude-decode-delegates-to-sdk.md
@@ -1,0 +1,21 @@
+# Claude decode delegates to the claude-agent-sdk parser
+
+## Status
+
+accepted
+
+## Context
+
+aikit's hand-rolled Claude decode handled only `assistant` text and `result`, silently dropping thinking, tool calls, tool results, and server (advisor) tools that the `claude` CLI already emits in `stream-json`. A maintained typed parser exists — `claude-agent-sdk` (`/home/sysuser/ws001/aroff/claude-agent-sdk-rust`), whose `parse_message(&Value) -> Result<Option<Message>>` is **sync and pure** and yields the full typed `Message`/`ContentBlock` taxonomy with 1:1 wire compatibility. This is the Transport-seam payoff anticipated in [ADR 0007](0007-backend-transport-seam.md) (Phase B).
+
+## Decision
+
+`backends/claude.rs::decode` delegates to `claude_agent_sdk::parse_message`, then maps the typed `Message` to canonical [`Decoded`](0010-decode-emits-typed-frames.md) frames: Text → `Stream` (Delta), Thinking → `Stream` (Reasoning), tool_use / server_tool_use → `ToolUse`, tool_result / advisor_tool_result and `user` tool-result blocks → `ToolResult`, `result` → `Stream` (Final, turn_id = session_id). System / stream_event / rate_limit / task / hook lines yield no message frames — rate-limit stays in `extract_quota` and usage in `extract_usage`, both unchanged. Parse errors and unknown types yield no frames (matching the legacy decoder's silent skip).
+
+The dependency is gated behind a default-on `claude-sdk` feature; with it off, a hand-rolled text-only fallback decode is used, so aikit-sdk still builds without the Claude-specific dependency.
+
+## Consequences
+
+- Text output is behaviour-preserving; thinking and structured tool calls/results are now surfaced (additive). Claude's declared `structured_tools`/`reasoning` capabilities are now genuinely backed.
+- aikit-sdk gains an optional dependency on `claude-agent-sdk` (which pulls tokio) when the feature is on. Phase B2 will use the same crate's async `ClaudeSDKClient` + control protocol for the bidirectional/interruptible axis; this ADR covers decode only (no async added yet).
+- A `result` line without `session_id` now yields no Final frame (the SDK's `ResultMessage.session_id` is required); in practice the CLI always includes it.


### PR DESCRIPTION
## What

Phase **B1** of the Claude integration: replace aikit's text-only hand-rolled Claude decode with the typed **`claude-agent-sdk`** parser, surfacing the structure the `claude` CLI already emits (tool calls, thinking, tool results) but the old decoder dropped. Follows Phase A's Backend/Transport seam (#84).

## How

- **New decode contract** `Backend::decode -> Vec<Decoded>` where `Decoded = Stream | ToolUse | ToolResult` (ADR 0010). Adds generic `AgentEventPayload::ToolUse`/`ToolResult` for external backends (distinct from the in-process `Aikit*` variants).
- **`backends/claude.rs`** delegates to `claude_agent_sdk::parse_message` and maps `Message`/`ContentBlock`:
  - text → `Stream` (Delta), thinking → `Stream` (Reasoning), tool_use / server_tool_use → `ToolUse`, tool_result / advisor / user tool-results → `ToolResult`, result → `Stream` (Final, turn_id=session_id).
  - system / stream_event / rate_limit / task / hook → no message frames (rate-limit stays in `extract_quota`, usage in `extract_usage` — both unchanged).
- **SDK-enrich with a lenient fallback** — the SDK parser is strict (requires `model`, full `result` fields); on any parse miss we fall back to the old text extraction, so behaviour never regresses below the legacy floor (aikit's "never silently drop a turn" stance).
- Gated behind a **default-on `claude-sdk` feature**; hand-rolled fallback when off. Dependency is a pinned git dep on `aroff/claude-agent-sdk-rust`. **No async/tokio added** — that's B2.
- `normalize_json_line` keeps its `Vec<StreamMessage>` signature (projects `Stream` frames); structured frames are observed via `run_agent_events`.

## Verification

- aikit-sdk: **276 lib** (incl. 6 new `claude::sdk_tests`) **+ 52 parity + 34 streaming + others** — all green.
- `cargo clippy -p aikit-sdk --all-targets` clean with the feature **on and off**; `cargo check --workspace` clean.

## Follow-on

- **B2**: embed `ClaudeSDKClient` as an async `Transport` + tokio bridge for the bidirectional Control axis (interrupt / set_permission_mode / set_model / permission callbacks).
- **B3**: SDK sessions, in-process SDK-MCP tools, hooks, server-tools.
- serve SSE translation of the new tool frames (spec 005 E1/E3).

ADRs: 0010 (typed decode frames), 0011 (SDK delegation). Spec 007 (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)