### PR TITLE
feat(aikit-sdk): Codex app-server sessions (vendor aikit-agent-codex + bridge)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "aikit-sdk",
     "aikit-py",
     "aikit-agent",
+    "aikit-agent-codex",
     "aikit-evals",
     "aikit-magictool",
     "aikit-textgrad",

--- a/aikit-agent-codex/.gitignore
+++ b/aikit-agent-codex/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+*.log
+*.tmp
+.env*

--- a/aikit-agent-codex/Cargo.toml
+++ b/aikit-agent-codex/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "aikit-agent-codex"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Async Rust client for OpenAI Codex app-server JSON-RPC (stdio). Drives threads, turns, approvals, and streaming notifications."
+repository = "https://github.com/goaikit/aikit"
+keywords = ["openai", "codex", "app-server", "agent", "json-rpc"]
+categories = ["api-bindings", "asynchronous"]
+
+[lib]
+name = "aikit_agent_codex"
+path = "src/lib.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "rt-multi-thread", "sync", "time"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["full"] }
+which = "8"
+
+[[example]]
+name = "chat"
+path = "examples/chat.rs"
+
+[[test]]
+name = "smoke"
+path = "tests/smoke.rs"

--- a/aikit-agent-codex/README.md
+++ b/aikit-agent-codex/README.md
@@ -1,0 +1,177 @@
+# aikit-agent-codex
+
+Async Rust client for the OpenAI Codex `app-server` JSON-RPC protocol.
+
+Spawn `codex app-server`, complete the `initialize`/`initialized` handshake, open
+threads, send turns, stream agent output, and answer approval prompts — all from
+a Rust process. The wire format is newline-delimited JSON-RPC 2.0 over stdio
+(the `"jsonrpc":"2.0"` header is omitted on the wire, per the app-server spec).
+
+## Install
+
+Add the crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+aikit-agent-codex = { path = "../aikit-agent-codex" }
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+```
+
+You also need the `codex` binary on `PATH` (it ships with the Codex CLI).
+
+## Quick start
+
+```rust
+use aikit_agent_codex::{CodexClient, ServerMessage, ServerNotificationKind};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cwd = std::env::current_dir()?;
+
+    let (client, mut events) = CodexClient::spawn().await?;
+    client.initialize("my_app", "My App", "0.1.0").await?;
+
+    let thread_id = client
+        .thread_start_simple(&cwd, /*approvalPolicy*/ "never", /*sandbox*/ "workspace-write")
+        .await?;
+
+    let turn_id = client.turn_start(&thread_id, "Summarize this repo.").await?;
+
+    while let Some(ev) = events.recv().await {
+        match ev {
+            ServerMessage::Notification(n) => match n.kind() {
+                ServerNotificationKind::AgentMessageDelta => {
+                    if let Some(delta) = n.params.get("delta").and_then(|d| d.as_str()) {
+                        print!("{delta}");
+                    }
+                }
+                ServerNotificationKind::TurnCompleted => break,
+                _ => {}
+            },
+            ServerMessage::ServerRequest(req) => {
+                // Auto-approve any tool call.
+                client.reply_server_request(req.id, json!({ "outcome": "approved" })).await?;
+            }
+        }
+    }
+
+    client.shutdown().await
+}
+```
+
+Run the bundled end-to-end demo:
+
+```bash
+cargo run --example chat -- "Explain the project layout"
+```
+
+## Multi-turn replies
+
+Keep the same `thread_id` and call `turn_start` again for each user reply after
+the previous turn completes. `turn_steer` is for adding input to an in-flight
+turn, not for a normal follow-up message.
+
+```rust
+use aikit_agent_codex::{CodexClient, ServerMessage, ServerNotificationKind};
+use serde_json::json;
+use std::io::{self, Write};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cwd = std::env::current_dir()?;
+
+    let (client, mut events) = CodexClient::spawn().await?;
+    client.initialize("my_app", "My App", "0.1.0").await?;
+
+    let thread_id = client
+        .thread_start_simple(&cwd, "never", "workspace-write")
+        .await?;
+
+    loop {
+        print!("you> ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let input = input.trim();
+        if input.is_empty() || input == "exit" || input == "quit" {
+            break;
+        }
+
+        let turn_id = client.turn_start(&thread_id, input).await?;
+
+        while let Some(ev) = events.recv().await {
+            match ev {
+                ServerMessage::Notification(n) => match n.kind() {
+                    ServerNotificationKind::AgentMessageDelta => {
+                        if let Some(delta) = n.params.get("delta").and_then(|d| d.as_str()) {
+                            print!("{delta}");
+                        }
+                    }
+                    ServerNotificationKind::TurnCompleted => {
+                        println!("\n[turn {turn_id} completed]");
+                        break;
+                    }
+                    _ => {}
+                },
+                ServerMessage::ServerRequest(req) => {
+                    client.reply_server_request(req.id, json!({ "outcome": "approved" })).await?;
+                }
+            }
+        }
+    }
+
+    client.shutdown().await
+}
+```
+
+## Steering an active turn
+
+Use `turn_steer` only while a turn is still running. It appends steering input
+to the active turn and returns the `TurnId` that accepted the input. For a
+normal reply after `TurnCompleted`, call `turn_start` again instead.
+
+```rust
+let turn_id = client.turn_start(&thread_id, "Draft a migration plan.").await?;
+
+let same_turn_id = client
+    .turn_steer(&thread_id, "Focus on rollback steps and operational risk.")
+    .await?;
+
+assert_eq!(same_turn_id, turn_id);
+```
+
+## What's implemented
+
+| Method | Helper |
+|---|---|
+| `initialize` + `initialized` | `CodexClient::initialize` |
+| `thread/start` | `thread_start`, `thread_start_simple` |
+| `thread/resume` | `thread_resume` |
+| `turn/start` | `turn_start` |
+| `turn/steer` | `turn_steer` |
+| `turn/interrupt` | `turn_interrupt` |
+| any method | `request`, `request_with_timeout`, `notify` |
+| server-side approval requests | `reply_server_request`, `reply_server_request_error` |
+
+For methods without a typed helper (e.g. `thread/fork`, `thread/compact/start`,
+`fs/readFile`, `model/list`), call `client.request("method", params_json).await`.
+
+## Transports
+
+Stdio is the only transport wired in. To connect to a running
+`codex app-server --listen unix://` or `ws://` endpoint, spawn that server
+separately and adapt the reader/writer halves; the JSON-RPC layer above is
+transport-agnostic.
+
+## References
+
+- Protocol: <https://developers.openai.com/codex/cli>
+- App-server README: `tmp/codex/codex-rs/app-server/README.md`
+- Generate a typed schema with `codex app-server generate-json-schema --out schema/`
+
+## License
+
+Apache-2.0

--- a/aikit-agent-codex/examples/chat.rs
+++ b/aikit-agent-codex/examples/chat.rs
@@ -1,0 +1,70 @@
+//! End-to-end demo: spawn `codex app-server`, send one turn, print streamed
+//! agent output, then exit on turn completion.
+//!
+//! Usage:
+//!     cargo run --example chat -- "your prompt here"
+
+use aikit_agent_codex::{CodexClient, ServerMessage, ServerNotificationKind, SpawnOptions};
+use serde_json::json;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let prompt = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "List the files in this repo and describe its layout.".to_string());
+
+    let cwd = std::env::current_dir()?;
+
+    let opts = SpawnOptions {
+        default_request_timeout: Duration::from_secs(30),
+        ..Default::default()
+    };
+    let (client, mut events) = CodexClient::spawn_with(opts).await?;
+    client
+        .initialize(
+            "aikit_agent_codex_example",
+            "aikit-agent-codex example",
+            env!("CARGO_PKG_VERSION"),
+        )
+        .await?;
+
+    let thread_id = client
+        .thread_start_simple(&cwd, "never", "workspace-write")
+        .await?;
+    eprintln!("[thread {} started in {}]", thread_id, cwd.display());
+
+    let turn_id = client.turn_start(&thread_id, &prompt).await?;
+    eprintln!("[turn {} started]\n", turn_id);
+
+    while let Some(ev) = events.recv().await {
+        match ev {
+            ServerMessage::Notification(n) => match n.kind() {
+                ServerNotificationKind::AgentMessageDelta => {
+                    if let Some(delta) = n.params.get("delta").and_then(|d| d.as_str()) {
+                        print!("{delta}");
+                    }
+                }
+                ServerNotificationKind::TurnCompleted => {
+                    println!("\n\n[turn {} completed]", turn_id);
+                    break;
+                }
+                _ => {
+                    eprintln!("[{}] {}", n.method, n.params);
+                }
+            },
+            ServerMessage::ServerRequest(req) => {
+                eprintln!(
+                    "[server request {} (id={}) -> auto-approving]",
+                    req.method, req.id
+                );
+                client
+                    .reply_server_request(req.id, json!({ "outcome": "approved" }))
+                    .await?;
+            }
+        }
+    }
+
+    client.shutdown().await?;
+    Ok(())
+}

--- a/aikit-agent-codex/rustfmt.toml
+++ b/aikit-agent-codex/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+max_width = 100
+tab_spaces = 4
+newline_style = "Unix"

--- a/aikit-agent-codex/src/client.rs
+++ b/aikit-agent-codex/src/client.rs
@@ -1,0 +1,495 @@
+use crate::error::{CodexError, Result};
+use crate::events::{ServerMessage, ServerNotification, ServerRequest};
+use crate::protocol::RequestId;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex};
+use tokio::time::timeout;
+
+type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<std::result::Result<Value, CodexError>>>>>;
+
+/// Options for spawning `codex app-server`.
+#[derive(Debug, Clone)]
+pub struct SpawnOptions {
+    /// Binary name or path used to locate `codex`. Defaults to `"codex"`.
+    pub codex_bin: String,
+
+    /// Extra args appended after `app-server` (e.g. `["--listen", "stdio://"]`).
+    pub extra_args: Vec<String>,
+
+    /// Working directory for the spawned process. Defaults to inherited.
+    pub cwd: Option<std::path::PathBuf>,
+
+    /// Per-request timeout applied by `request()`. Defaults to 60s.
+    pub default_request_timeout: Duration,
+}
+
+impl Default for SpawnOptions {
+    fn default() -> Self {
+        Self {
+            codex_bin: "codex".to_string(),
+            extra_args: Vec::new(),
+            cwd: None,
+            default_request_timeout: Duration::from_secs(60),
+        }
+    }
+}
+
+/// Async client for the Codex `app-server` JSON-RPC protocol over stdio.
+///
+/// Wire format: newline-delimited JSON-RPC 2.0 with the `"jsonrpc":"2.0"`
+/// header omitted (per the app-server spec). The client spawns the server as
+/// a child process, owns its stdin/stdout, routes request/response pairs by
+/// id, and forwards notifications and server-initiated requests to a channel.
+pub struct CodexClient {
+    next_id: AtomicU64,
+    pending: PendingMap,
+    stdin: AsyncMutex<ChildStdin>,
+    child: AsyncMutex<Option<Child>>,
+    initialized: AtomicBool,
+    default_request_timeout: Duration,
+}
+
+impl CodexClient {
+    /// Spawn `codex app-server` with default options.
+    ///
+    /// Returns the client plus a receiver of inbound server messages
+    /// (notifications and server-initiated requests).
+    pub async fn spawn() -> Result<(Self, mpsc::Receiver<ServerMessage>)> {
+        Self::spawn_with(SpawnOptions::default()).await
+    }
+
+    /// Spawn `codex app-server` with custom options.
+    pub async fn spawn_with(opts: SpawnOptions) -> Result<(Self, mpsc::Receiver<ServerMessage>)> {
+        let default_request_timeout = opts.default_request_timeout;
+
+        let mut cmd = Command::new(&opts.codex_bin);
+        cmd.arg("app-server");
+        for arg in &opts.extra_args {
+            cmd.arg(arg);
+        }
+        if let Some(cwd) = &opts.cwd {
+            cmd.current_dir(cwd);
+        }
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            // Safety net: never leak a child if the caller forgets shutdown().
+            .kill_on_drop(true);
+
+        let mut child = cmd.spawn()?;
+        let stdin = child.stdin.take().expect("stdin was piped");
+        let stdout = child.stdout.take().expect("stdout was piped");
+
+        let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
+        let (event_tx, event_rx) = mpsc::channel::<ServerMessage>(256);
+
+        tokio::spawn(reader_loop(stdout, Arc::clone(&pending), event_tx));
+
+        Ok((
+            Self {
+                next_id: AtomicU64::new(1),
+                pending,
+                stdin: AsyncMutex::new(stdin),
+                child: AsyncMutex::new(Some(child)),
+                initialized: AtomicBool::new(false),
+                default_request_timeout,
+            },
+            event_rx,
+        ))
+    }
+
+    /// Perform the required `initialize` + `initialized` handshake.
+    ///
+    /// Must be the first call on a fresh connection; subsequent requests are
+    /// rejected by the server until this completes.
+    pub async fn initialize(
+        &self,
+        client_name: &str,
+        client_title: &str,
+        version: &str,
+    ) -> Result<Value> {
+        if self.initialized.swap(true, Ordering::SeqCst) {
+            return Err(CodexError::AlreadyInitialized);
+        }
+        let result = self
+            .request(
+                "initialize",
+                json!({
+                    "clientInfo": {
+                        "name": client_name,
+                        "title": client_title,
+                        "version": version,
+                    }
+                }),
+            )
+            .await?;
+        self.notify("initialized", json!({})).await?;
+        Ok(result)
+    }
+
+    /// Create a new thread (conversation). Returns the full response object.
+    ///
+    /// Callers build the params object per the app-server spec; common fields
+    /// are `cwd`, `approvalPolicy`, `sandbox`, `model`, etc.
+    pub async fn thread_start(&self, params: Value) -> Result<Value> {
+        self.request("thread/start", params).await
+    }
+
+    /// Convenience: start a thread with `cwd`, approval policy, and sandbox
+    /// shorthand. Returns the new [`ThreadId`].
+    pub async fn thread_start_simple(
+        &self,
+        cwd: impl AsRef<std::path::Path>,
+        approval_policy: &str,
+        sandbox: &str,
+    ) -> Result<crate::ThreadId> {
+        let params = thread_start_simple_params(cwd.as_ref(), approval_policy, sandbox)?;
+        let res = self.thread_start(params).await?;
+        let id = thread_id_from_response(&res, "thread/start")?;
+        Ok(crate::ThreadId(id))
+    }
+
+    /// Resume an existing stored thread by id.
+    pub async fn thread_resume(&self, thread_id: &crate::ThreadId) -> Result<Value> {
+        self.request("thread/resume", json!({ "threadId": thread_id.0 }))
+            .await
+    }
+
+    /// Send a text turn and return the new [`TurnId`].
+    ///
+    /// Streaming output for the turn arrives as notifications on the receiver
+    /// returned from [`spawn`](Self::spawn); drain until
+    /// [`ServerNotificationKind::TurnCompleted`] to collect the full response.
+    pub async fn turn_start(
+        &self,
+        thread_id: &crate::ThreadId,
+        text: &str,
+    ) -> Result<crate::TurnId> {
+        let res = self
+            .request(
+                "turn/start",
+                json!({
+                    "threadId": thread_id.0,
+                    "input": [ { "type": "text", "text": text } ],
+                }),
+            )
+            .await?;
+        let id = turn_id_from_response(&res)?;
+        Ok(crate::TurnId(id))
+    }
+
+    /// Append text to an already in-flight turn (steering).
+    ///
+    /// Returns the active [`TurnId`] that accepted the input.
+    pub async fn turn_steer(
+        &self,
+        thread_id: &crate::ThreadId,
+        text: &str,
+    ) -> Result<crate::TurnId> {
+        let res = self
+            .request(
+                "turn/steer",
+                json!({
+                    "threadId": thread_id.0,
+                    "input": [ { "type": "text", "text": text } ],
+                }),
+            )
+            .await?;
+        let id = res
+            .get("turnId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| CodexError::Send("missing turnId in turn/steer response".into()))?
+            .to_string();
+        Ok(crate::TurnId(id))
+    }
+
+    /// Request cancellation of an in-flight turn.
+    pub async fn turn_interrupt(
+        &self,
+        thread_id: &crate::ThreadId,
+        turn_id: &crate::TurnId,
+    ) -> Result<()> {
+        let _ = self
+            .request(
+                "turn/interrupt",
+                json!({ "threadId": thread_id.0, "turnId": turn_id.0 }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Reply to a [`ServerRequest`] (e.g. an approval) with a `result` payload.
+    pub async fn reply_server_request(&self, id: RequestId, result: Value) -> Result<()> {
+        self.write_raw(&json!({ "id": id, "result": result })).await
+    }
+
+    /// Reject a [`ServerRequest`] with a JSON-RPC error.
+    pub async fn reply_server_request_error(
+        &self,
+        id: RequestId,
+        code: i64,
+        message: &str,
+    ) -> Result<()> {
+        self.write_raw(&json!({ "id": id, "error": { "code": code, "message": message } }))
+            .await
+    }
+
+    /// Send a JSON-RPC request and await its `result` using the default timeout.
+    pub async fn request(&self, method: &str, params: Value) -> Result<Value> {
+        self.request_with_timeout(method, params, self.default_request_timeout)
+            .await
+    }
+
+    /// Send a JSON-RPC request with an explicit timeout.
+    ///
+    /// On timeout the pending entry is removed and
+    /// [`CodexError::RequestTimeout`] is returned.
+    pub async fn request_with_timeout(
+        &self,
+        method: &str,
+        params: Value,
+        deadline: Duration,
+    ) -> Result<Value> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().unwrap().insert(id, tx);
+
+        self.write_raw(&json!({ "method": method, "id": id, "params": params }))
+            .await?;
+
+        let method_owned = method.to_string();
+        match timeout(deadline, rx).await {
+            Ok(Ok(Ok(v))) => Ok(v),
+            Ok(Ok(Err(e))) => match e {
+                CodexError::ServerError {
+                    code,
+                    message,
+                    data,
+                    ..
+                } => Err(CodexError::ServerError {
+                    method: method_owned,
+                    code,
+                    message,
+                    data,
+                }),
+                other => Err(other),
+            },
+            Ok(Err(_)) => Err(CodexError::Closed {
+                method: method_owned,
+            }),
+            Err(_) => {
+                self.pending.lock().unwrap().remove(&id);
+                Err(CodexError::RequestTimeout {
+                    method: method_owned,
+                    timeout_secs: deadline.as_secs(),
+                })
+            }
+        }
+    }
+
+    /// Fire-and-forget JSON-RPC notification (no id, no response expected).
+    pub async fn notify(&self, method: &str, params: Value) -> Result<()> {
+        self.write_raw(&json!({ "method": method, "params": params }))
+            .await
+    }
+
+    async fn write_raw(&self, value: &Value) -> Result<()> {
+        let mut bytes = serde_json::to_vec(value)?;
+        bytes.push(b'\n');
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(&bytes)
+            .await
+            .map_err(|e| CodexError::Send(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Close stdin (causing the server to exit cleanly) and reap the child.
+    ///
+    /// Force-kills after a 5-second grace period. Safe to call multiple times.
+    pub async fn shutdown(&self) -> Result<()> {
+        // Drop the stdin guard so the server sees EOF.
+        {
+            let _guard = self.stdin.lock().await;
+        }
+        if let Some(mut child) = self.child.lock().await.take() {
+            let _ = timeout(Duration::from_secs(5), child.wait()).await;
+            let _ = child.kill().await;
+        }
+        Ok(())
+    }
+}
+
+fn thread_id_from_response(res: &Value, method: &str) -> Result<String> {
+    res.get("thread")
+        .and_then(|t| t.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| CodexError::Send(format!("missing thread.id in {method} response")))
+}
+
+fn turn_id_from_response(res: &Value) -> Result<String> {
+    res.get("turn")
+        .and_then(|t| t.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| CodexError::Send("missing turn.id in turn/start response".into()))
+}
+
+fn thread_start_simple_params(
+    cwd: &std::path::Path,
+    approval_policy: &str,
+    sandbox: &str,
+) -> Result<Value> {
+    Ok(json!({
+        "cwd": cwd.to_string_lossy(),
+        "approvalPolicy": approval_policy,
+        "sandbox": normalize_sandbox_mode(sandbox)?,
+    }))
+}
+
+fn normalize_sandbox_mode(sandbox: &str) -> Result<&'static str> {
+    match sandbox {
+        "read-only" => Ok("read-only"),
+        "workspace-write" | "workspaceWrite" => Ok("workspace-write"),
+        "danger-full-access" | "dangerFullAccess" => Ok("danger-full-access"),
+        other => Err(CodexError::InvalidParameter {
+            name: "sandbox".to_string(),
+            message: format!(
+                "unknown value '{other}', expected one of 'read-only', 'workspace-write', 'danger-full-access'"
+            ),
+        }),
+    }
+}
+
+async fn reader_loop(
+    stdout: ChildStdout,
+    pending: PendingMap,
+    event_tx: mpsc::Sender<ServerMessage>,
+) {
+    let mut lines = BufReader::new(stdout).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        let Ok(v) = serde_json::from_str::<Value>(&line) else {
+            tracing::debug!(line = %line, "skipping non-JSON line from server");
+            continue;
+        };
+        let Some(obj) = v.as_object() else {
+            continue;
+        };
+
+        // 1. Response to one of our requests: { id, result | error }
+        if obj.contains_key("result") || obj.contains_key("error") {
+            let Some(id) = obj.get("id").and_then(Value::as_u64) else {
+                continue;
+            };
+            let Some(sender) = pending.lock().unwrap().remove(&id) else {
+                continue;
+            };
+            if let Some(err) = obj.get("error") {
+                let _ = sender.send(Err(CodexError::ServerError {
+                    method: String::new(),
+                    code: err.get("code").and_then(Value::as_i64).unwrap_or(-1),
+                    message: err
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown error")
+                        .to_string(),
+                    data: err.get("data").cloned(),
+                }));
+            } else {
+                let _ = sender.send(Ok(obj.get("result").cloned().unwrap_or(Value::Null)));
+            }
+            continue;
+        }
+
+        // 2. Notification or server-initiated request: { method, params[, id] }
+        let Some(method) = obj.get("method").and_then(Value::as_str) else {
+            continue;
+        };
+        let method = method.to_string();
+        let params = obj.get("params").cloned().unwrap_or(Value::Null);
+
+        let message = match obj.get("id") {
+            Some(id_value) => {
+                let id = match id_value {
+                    Value::Number(n) if n.as_u64().is_some() => {
+                        RequestId::Num(n.as_u64().expect("checked above"))
+                    }
+                    Value::String(s) => RequestId::Str(s.clone()),
+                    _ => continue,
+                };
+                ServerMessage::ServerRequest(ServerRequest { id, method, params })
+            }
+            None => ServerMessage::Notification(ServerNotification { method, params }),
+        };
+
+        if event_tx.send(message).await.is_err() {
+            break; // caller dropped the receiver
+        }
+    }
+
+    // Transport closed: drop all pending senders so waiting requests see Closed.
+    pending.lock().unwrap().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_sandbox_mode, thread_start_simple_params};
+    use crate::CodexError;
+    use std::path::Path;
+
+    #[test]
+    fn sandbox_modes_are_serialized_as_protocol_kebab_case() {
+        assert_eq!(normalize_sandbox_mode("read-only").unwrap(), "read-only");
+        assert_eq!(
+            normalize_sandbox_mode("workspace-write").unwrap(),
+            "workspace-write"
+        );
+        assert_eq!(
+            normalize_sandbox_mode("danger-full-access").unwrap(),
+            "danger-full-access"
+        );
+    }
+
+    #[test]
+    fn legacy_camel_case_sandbox_modes_are_normalized() {
+        assert_eq!(
+            normalize_sandbox_mode("workspaceWrite").unwrap(),
+            "workspace-write"
+        );
+        assert_eq!(
+            normalize_sandbox_mode("dangerFullAccess").unwrap(),
+            "danger-full-access"
+        );
+    }
+
+    #[test]
+    fn thread_start_simple_params_normalizes_workspace_write() {
+        let params =
+            thread_start_simple_params(Path::new("/tmp/repo"), "never", "workspaceWrite").unwrap();
+
+        assert_eq!(params["cwd"], "/tmp/repo");
+        assert_eq!(params["approvalPolicy"], "never");
+        assert_eq!(params["sandbox"], "workspace-write");
+    }
+
+    #[test]
+    fn unknown_sandbox_mode_is_rejected_locally() {
+        let err = normalize_sandbox_mode("workspace_write").unwrap_err();
+
+        assert!(matches!(
+            err,
+            CodexError::InvalidParameter { ref name, .. } if name == "sandbox"
+        ));
+        assert!(err
+            .to_string()
+            .contains("expected one of 'read-only', 'workspace-write', 'danger-full-access'"));
+    }
+}

--- a/aikit-agent-codex/src/error.rs
+++ b/aikit-agent-codex/src/error.rs
@@ -1,0 +1,45 @@
+use serde_json::Value;
+
+/// Errors returned by [`crate::CodexClient`].
+#[derive(Debug, thiserror::Error)]
+pub enum CodexError {
+    /// `codex app-server` failed to spawn.
+    #[error("failed to spawn codex: {0}")]
+    Spawn(#[from] std::io::Error),
+
+    /// A JSON (de)serialization failure on the wire.
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The server replied with a JSON-RPC `error` object for a request.
+    #[error("server returned error for '{method}' (code {code}): {message}")]
+    ServerError {
+        method: String,
+        code: i64,
+        message: String,
+        data: Option<Value>,
+    },
+
+    /// The transport closed before the server replied to `method`.
+    #[error("connection closed before '{method}' replied")]
+    Closed { method: String },
+
+    /// Writing a framed message to the server's stdin failed.
+    #[error("transport write failed: {0}")]
+    Send(String),
+
+    /// `initialize` was called more than once on the same connection.
+    #[error("already initialized; initialize() can only be called once per connection")]
+    AlreadyInitialized,
+
+    /// A helper received a parameter value the Codex protocol does not accept.
+    #[error("invalid parameter '{name}': {message}")]
+    InvalidParameter { name: String, message: String },
+
+    /// `request_with_timeout` exceeded its deadline.
+    #[error("timed out waiting for '{method}' reply after {timeout_secs}s")]
+    RequestTimeout { method: String, timeout_secs: u64 },
+}
+
+/// Convenience `Result` alias.
+pub type Result<T, E = CodexError> = std::result::Result<T, E>;

--- a/aikit-agent-codex/src/events.rs
+++ b/aikit-agent-codex/src/events.rs
@@ -1,0 +1,77 @@
+use crate::protocol::RequestId;
+use serde_json::Value;
+
+/// Inbound server message routed to the caller via the events channel.
+#[derive(Debug, Clone)]
+pub enum ServerMessage {
+    /// JSON-RPC notification (no id). Examples: `turn/started`, `item/*`,
+    /// `turn/completed`.
+    Notification(ServerNotification),
+
+    /// JSON-RPC request initiated by the server (e.g. an approval prompt).
+    /// Reply with [`crate::CodexClient::reply_server_request`].
+    ServerRequest(ServerRequest),
+}
+
+/// A JSON-RPC notification from the server.
+#[derive(Debug, Clone)]
+pub struct ServerNotification {
+    /// Method name, e.g. `turn/completed`.
+    pub method: String,
+    /// Raw `params` payload.
+    pub params: Value,
+}
+
+impl ServerNotification {
+    /// Classify the method into a known kind for ergonomic matching.
+    pub fn kind(&self) -> ServerNotificationKind {
+        ServerNotificationKind::from_method(&self.method)
+    }
+}
+
+/// Typed classification of common app-server notification methods.
+///
+/// Unknown methods map to [`ServerNotificationKind::Other`]; inspect
+/// `ServerNotification::method` and `params` for those.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerNotificationKind {
+    ThreadStarted,
+    ThreadStatusChanged,
+    ThreadClosed,
+    TurnStarted,
+    TurnCompleted,
+    ItemStarted,
+    ItemCompleted,
+    AgentMessageDelta,
+    CommandExecutionOutputDelta,
+    Other,
+}
+
+impl ServerNotificationKind {
+    /// Map a wire method name to a known kind.
+    pub fn from_method(method: &str) -> Self {
+        match method {
+            "thread/started" => Self::ThreadStarted,
+            "thread/status/changed" => Self::ThreadStatusChanged,
+            "thread/closed" => Self::ThreadClosed,
+            "turn/started" => Self::TurnStarted,
+            "turn/completed" => Self::TurnCompleted,
+            "item/started" => Self::ItemStarted,
+            "item/completed" => Self::ItemCompleted,
+            "item/agentMessage/delta" => Self::AgentMessageDelta,
+            "item/commandExecution/outputDelta" => Self::CommandExecutionOutputDelta,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// A JSON-RPC request initiated by the server (e.g. `thread/approveCommand`).
+#[derive(Debug, Clone)]
+pub struct ServerRequest {
+    /// Id to echo back in the reply.
+    pub id: RequestId,
+    /// Method name.
+    pub method: String,
+    /// Raw `params` payload.
+    pub params: Value,
+}

--- a/aikit-agent-codex/src/lib.rs
+++ b/aikit-agent-codex/src/lib.rs
@@ -1,0 +1,18 @@
+//! Async Rust client for the OpenAI Codex `app-server` JSON-RPC protocol.
+//!
+//! Drives a Codex session over stdio: spawn `codex app-server`, complete the
+//! `initialize` handshake, create threads, send turns, and stream agent output
+//! as JSON-RPC notifications. See `examples/chat.rs` for an end-to-end demo
+//! and [`CodexClient`] for the entry point.
+
+pub mod client;
+pub mod error;
+pub mod events;
+pub mod protocol;
+
+pub use client::{CodexClient, SpawnOptions};
+pub use error::CodexError;
+pub use events::{ServerMessage, ServerNotification, ServerNotificationKind, ServerRequest};
+pub use protocol::{RequestId, ThreadId, TurnId};
+
+pub use error::Result;

--- a/aikit-agent-codex/src/protocol.rs
+++ b/aikit-agent-codex/src/protocol.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// JSON-RPC request id.
+///
+/// The client always emits integer ids; the server may use integers or
+/// strings for server-initiated requests (e.g. approval prompts). Both are
+/// preserved here.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RequestId {
+    /// Numeric id (what the client emits).
+    Num(u64),
+    /// String id (some server-originated requests use these).
+    Str(String),
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RequestId::Num(n) => write!(f, "{n}"),
+            RequestId::Str(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// Opaque thread identifier returned by `thread/start`, `thread/resume`, etc.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ThreadId(pub String);
+
+impl fmt::Display for ThreadId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for ThreadId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for ThreadId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Opaque turn identifier returned by `turn/start`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TurnId(pub String);
+
+impl fmt::Display for TurnId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for TurnId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}

--- a/aikit-agent-codex/tests/smoke.rs
+++ b/aikit-agent-codex/tests/smoke.rs
@@ -1,0 +1,50 @@
+//! Integration smoke test. Skips automatically when `codex` is not on PATH,
+//! so this is safe to run in CI environments that don't have Codex installed.
+
+use aikit_agent_codex::{CodexClient, SpawnOptions};
+
+#[tokio::test]
+async fn initialize_handshake_round_trip() {
+    if which::which("codex").is_err() {
+        eprintln!("skipping: 'codex' not on PATH");
+        return;
+    }
+    let (client, _events) = CodexClient::spawn().await.expect("spawn");
+    let result = client
+        .initialize("aikit_agent_codex_test", "aikit-agent-codex test", "0.0.0")
+        .await
+        .expect("initialize");
+    assert!(
+        result.get("codexHome").is_some() || result.get("userAgent").is_some(),
+        "expected codexHome or userAgent in initialize response, got: {result}"
+    );
+    client.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn spawn_with_missing_binary_returns_spawn_error() {
+    let opts = SpawnOptions {
+        codex_bin: "definitely-not-a-real-codex-binary-xyz".into(),
+        ..Default::default()
+    };
+    let result = CodexClient::spawn_with(opts).await;
+    assert!(result.is_err(), "expected spawn to fail for missing binary");
+}
+
+#[tokio::test]
+async fn double_initialize_is_rejected() {
+    if which::which("codex").is_err() {
+        eprintln!("skipping: 'codex' not on PATH");
+        return;
+    }
+    let (client, _events) = CodexClient::spawn().await.expect("spawn");
+    client
+        .initialize("aikit_agent_codex_test", "aikit-agent-codex test", "0.0.0")
+        .await
+        .expect("first initialize");
+    let second = client
+        .initialize("aikit_agent_codex_test", "aikit-agent-codex test", "0.0.0")
+        .await;
+    assert!(second.is_err(), "second initialize should fail");
+    client.shutdown().await.expect("shutdown");
+}

--- a/aikit-sdk/Cargo.toml
+++ b/aikit-sdk/Cargo.toml
@@ -17,6 +17,9 @@ claude-sdk = ["dep:claude-agent-sdk"]
 # Bidirectional Claude sessions (B2): drive `claude-agent-sdk`'s client over a
 # tokio bridge with a Control handle (interrupt / permission mode / model).
 claude-control = ["claude-sdk", "dep:tokio"]
+# Bidirectional Codex sessions: drive `aikit-agent-codex`'s app-server client
+# (JSON-RPC over stdio) over a tokio bridge with a Control handle.
+codex-app-server = ["dep:aikit-agent-codex", "dep:tokio"]
 
 [dependencies]
 tracing = "0.1"
@@ -32,6 +35,7 @@ tempfile = "3.12"
 uuid = { version = "1", features = ["v4"] }
 aikit-agent = { path = "../aikit-agent", version = "0.1.0" }
 claude-agent-sdk = { git = "https://github.com/aroff/claude-agent-sdk-rust", rev = "717eacf", optional = true }
+aikit-agent-codex = { path = "../aikit-agent-codex", version = "0.1.0", optional = true }
 tokio = { version = "1", features = ["rt", "sync", "macros"], optional = true }
 jsonschema = "0.46"
 

--- a/aikit-sdk/src/runner/codex_session.rs
+++ b/aikit-sdk/src/runner/codex_session.rs
@@ -1,0 +1,584 @@
+//! Codex app-server sessions over a tokio bridge.
+//!
+//! The Codex analogue of [`claude_session`](super::claude_session): a dedicated
+//! thread runs a current-thread tokio runtime driving `aikit-agent-codex`'s
+//! [`CodexClient`] (JSON-RPC over `codex app-server` stdio) — spawn →
+//! `initialize` → `thread/start` → `turn/start` — forwarding server
+//! notifications as canonical [`AgentEvent`]s, while a [`CodexControlHandle`]
+//! issues interrupt / steer / disconnect.
+//!
+//! `CodexClient::spawn` already hands back the inbound notification receiver
+//! separately from the control client, so a single-task `tokio::select!`
+//! multiplexes the two without a second task. Server→client approval requests
+//! are auto-approved for now (a permission-callback seam, like the Claude
+//! session's, is a follow-up). See spec 007.
+
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+
+use aikit_agent_codex::{
+    CodexClient, ServerMessage, ServerNotificationKind, SpawnOptions, ThreadId, TurnId,
+};
+use serde_json::{json, Value};
+
+use crate::runner::backend::Decoded;
+use crate::runner::types::{
+    AgentEvent, AgentEventPayload, AgentEventStream, MessageKind, MessagePhase, MessageRole,
+    StreamMessage,
+};
+
+/// Options for opening a Codex session.
+#[derive(Debug, Clone)]
+pub struct CodexSessionOptions {
+    /// Working directory for the thread (and the spawned `codex` process).
+    pub cwd: PathBuf,
+    /// Approval policy: `never` (auto), `on-request`, `on-failure`, `untrusted`.
+    pub approval_policy: String,
+    /// Sandbox mode: e.g. `read-only`, `workspace-write`, `danger-full-access`.
+    pub sandbox: String,
+}
+
+impl Default for CodexSessionOptions {
+    fn default() -> Self {
+        Self {
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            // Default to non-interactive auto-approval (matches how aikit runs
+            // codex via `--yolo` today); approvals never block the stream.
+            approval_policy: "never".to_string(),
+            sandbox: "workspace-write".to_string(),
+        }
+    }
+}
+
+/// Errors opening or driving a Codex session.
+#[derive(Debug)]
+pub enum CodexSessionError {
+    /// The tokio runtime could not be created.
+    Runtime(String),
+    /// Spawning / handshaking with `codex app-server` failed.
+    Connect(String),
+    /// The control channel is closed (the session ended).
+    Closed,
+}
+
+impl std::fmt::Display for CodexSessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CodexSessionError::Runtime(e) => write!(f, "codex session runtime error: {e}"),
+            CodexSessionError::Connect(e) => write!(f, "codex session connect error: {e}"),
+            CodexSessionError::Closed => write!(f, "codex session control channel closed"),
+        }
+    }
+}
+
+impl std::error::Error for CodexSessionError {}
+
+/// Commands forwarded from a [`CodexControlHandle`] to the session bridge.
+enum ControlCmd {
+    Interrupt,
+    Steer(String),
+    Disconnect,
+}
+
+/// A sync handle to drive a live Codex session.
+pub struct CodexControlHandle {
+    tx: tokio::sync::mpsc::UnboundedSender<ControlCmd>,
+}
+
+impl CodexControlHandle {
+    fn send(&self, cmd: ControlCmd) -> Result<(), CodexSessionError> {
+        self.tx.send(cmd).map_err(|_| CodexSessionError::Closed)
+    }
+
+    /// Interrupt the in-flight turn.
+    pub fn interrupt(&self) -> Result<(), CodexSessionError> {
+        self.send(ControlCmd::Interrupt)
+    }
+
+    /// Steer the in-flight turn by appending input.
+    pub fn steer(&self, text: impl Into<String>) -> Result<(), CodexSessionError> {
+        self.send(ControlCmd::Steer(text.into()))
+    }
+
+    /// End the session.
+    pub fn disconnect(&self) -> Result<(), CodexSessionError> {
+        self.send(ControlCmd::Disconnect)
+    }
+}
+
+/// A live Codex session: a [`CodexControlHandle`] and the canonical event
+/// stream. The event channel closes when the session ends; the bridge thread is
+/// joined on drop.
+pub struct CodexSession {
+    pub control: CodexControlHandle,
+    pub events: mpsc::Receiver<AgentEvent>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for CodexSession {
+    fn drop(&mut self) {
+        let _ = self.control.disconnect();
+        if let Some(j) = self.join.take() {
+            let _ = j.join();
+        }
+    }
+}
+
+/// Open a Codex session, sending `prompt` as the first turn.
+///
+/// Blocks until connected and the first turn is started, so spawn/handshake
+/// failures return [`CodexSessionError::Connect`] rather than only closing the
+/// event stream.
+pub fn open_codex_session(
+    prompt: impl Into<String>,
+    options: CodexSessionOptions,
+) -> Result<CodexSession, CodexSessionError> {
+    let prompt = prompt.into();
+    let (event_tx, event_rx) = mpsc::channel::<AgentEvent>();
+    let (control_tx, control_rx) = tokio::sync::mpsc::unbounded_channel::<ControlCmd>();
+    let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
+
+    let join = thread::Builder::new()
+        .name("aikit-codex-session".into())
+        .spawn(move || {
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    let _ = ready_tx.send(Err(format!("failed to build runtime: {e}")));
+                    return;
+                }
+            };
+            rt.block_on(run_session(prompt, options, event_tx, control_rx, ready_tx));
+        })
+        .map_err(|e| CodexSessionError::Runtime(e.to_string()))?;
+
+    match ready_rx.recv() {
+        Ok(Ok(())) => Ok(CodexSession {
+            control: CodexControlHandle { tx: control_tx },
+            events: event_rx,
+            join: Some(join),
+        }),
+        Ok(Err(msg)) => {
+            let _ = join.join();
+            Err(CodexSessionError::Connect(msg))
+        }
+        Err(_) => {
+            let _ = join.join();
+            Err(CodexSessionError::Connect(
+                "session thread terminated before ready".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_session(
+    prompt: String,
+    options: CodexSessionOptions,
+    event_tx: mpsc::Sender<AgentEvent>,
+    mut control_rx: tokio::sync::mpsc::UnboundedReceiver<ControlCmd>,
+    ready_tx: mpsc::Sender<Result<(), String>>,
+) {
+    let spawn_opts = SpawnOptions {
+        cwd: Some(options.cwd.clone()),
+        ..SpawnOptions::default()
+    };
+    let (client, mut events) = match CodexClient::spawn_with(spawn_opts).await {
+        Ok(pair) => pair,
+        Err(e) => {
+            let _ = ready_tx.send(Err(format!("spawn failed: {e}")));
+            return;
+        }
+    };
+
+    if let Err(e) = client
+        .initialize("aikit", "aikit", env!("CARGO_PKG_VERSION"))
+        .await
+    {
+        let _ = ready_tx.send(Err(format!("initialize failed: {e}")));
+        return;
+    }
+
+    let thread_id: ThreadId = match client
+        .thread_start_simple(&options.cwd, &options.approval_policy, &options.sandbox)
+        .await
+    {
+        Ok(id) => id,
+        Err(e) => {
+            let _ = ready_tx.send(Err(format!("thread/start failed: {e}")));
+            return;
+        }
+    };
+
+    let mut turn_id: TurnId = match client.turn_start(&thread_id, &prompt).await {
+        Ok(id) => id,
+        Err(e) => {
+            let _ = ready_tx.send(Err(format!("turn/start failed: {e}")));
+            return;
+        }
+    };
+
+    let _ = ready_tx.send(Ok(()));
+
+    let mut seq: u64 = 0;
+    let mut closed = false;
+    loop {
+        tokio::select! {
+            msg = events.recv() => {
+                match msg {
+                    Some(ServerMessage::Notification(n)) => {
+                        for frame in map_notification(&n.method, &n.params, seq) {
+                            if event_tx
+                                .send(AgentEvent {
+                                    agent_key: "codex".to_string(),
+                                    seq,
+                                    stream: AgentEventStream::Stdout,
+                                    payload: decoded_to_payload(frame),
+                                })
+                                .is_err()
+                            {
+                                closed = true;
+                                break;
+                            }
+                            seq += 1;
+                        }
+                    }
+                    // Server→client request (e.g. an approval prompt). Auto-approve
+                    // for now — a permission-callback seam is a follow-up.
+                    Some(ServerMessage::ServerRequest(req)) => {
+                        let _ = client
+                            .reply_server_request(req.id, json!({ "outcome": "approved" }))
+                            .await;
+                    }
+                    None => break, // app-server closed the stream
+                }
+                if closed {
+                    break;
+                }
+            }
+            cmd = control_rx.recv() => {
+                match cmd {
+                    Some(ControlCmd::Interrupt) => {
+                        let _ = client.turn_interrupt(&thread_id, &turn_id).await;
+                    }
+                    Some(ControlCmd::Steer(text)) => {
+                        if let Ok(id) = client.turn_steer(&thread_id, &text).await {
+                            turn_id = id;
+                        }
+                    }
+                    Some(ControlCmd::Disconnect) | None => break,
+                }
+            }
+        }
+    }
+
+    let _ = client.shutdown().await;
+}
+
+/// Map one app-server notification to canonical [`Decoded`] frames.
+fn map_notification(method: &str, params: &Value, raw_line_seq: u64) -> Vec<Decoded> {
+    let mk = |text: String, phase: MessagePhase, role: MessageRole, kind: MessageKind| {
+        Decoded::Stream(StreamMessage {
+            text,
+            phase,
+            role,
+            kind,
+            source: AgentEventStream::Stdout,
+            raw_line_seq,
+            turn_id: None,
+        })
+    };
+
+    match ServerNotificationKind::from_method(method) {
+        ServerNotificationKind::AgentMessageDelta => params
+            .get("delta")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                vec![mk(
+                    s.to_string(),
+                    MessagePhase::Delta,
+                    MessageRole::Assistant,
+                    MessageKind::Message,
+                )]
+            })
+            .unwrap_or_default(),
+        ServerNotificationKind::CommandExecutionOutputDelta => params
+            .get("delta")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                vec![mk(
+                    s.to_string(),
+                    MessagePhase::Delta,
+                    MessageRole::Tool,
+                    MessageKind::ToolOutput,
+                )]
+            })
+            .unwrap_or_default(),
+        ServerNotificationKind::ItemCompleted => {
+            // params may wrap the item under `item`, or carry it inline.
+            let item = params.get("item").unwrap_or(params);
+            map_item(item, raw_line_seq)
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Map a completed `item` (agent_message / reasoning / command_execution /
+/// file_change) to canonical frames. Mirrors the `codex exec` item schema but
+/// emits structured tool frames where the app-server provides them.
+fn map_item(item: &Value, raw_line_seq: u64) -> Vec<Decoded> {
+    let mk = |text: String, phase: MessagePhase, role: MessageRole, kind: MessageKind| {
+        Decoded::Stream(StreamMessage {
+            text,
+            phase,
+            role,
+            kind,
+            source: AgentEventStream::Stdout,
+            raw_line_seq,
+            turn_id: None,
+        })
+    };
+    let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    match item_type {
+        "agent_message" => item
+            .get("text")
+            .and_then(|v| v.as_str())
+            .map(|t| {
+                vec![mk(
+                    t.to_string(),
+                    MessagePhase::Final,
+                    MessageRole::Assistant,
+                    MessageKind::Message,
+                )]
+            })
+            .unwrap_or_default(),
+        "reasoning" => item
+            .get("text")
+            .and_then(|v| v.as_str())
+            .or_else(|| item.get("summary").and_then(|v| v.as_str()))
+            .map(|t| {
+                vec![mk(
+                    t.to_string(),
+                    MessagePhase::Final,
+                    MessageRole::Assistant,
+                    MessageKind::Reasoning,
+                )]
+            })
+            .unwrap_or_default(),
+        "command_execution" => {
+            let mut out = Vec::new();
+            if let Some(cmd) = item.get("command").and_then(|v| v.as_str()) {
+                out.push(Decoded::ToolUse {
+                    call_id: item
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    tool_name: "shell".to_string(),
+                    input: json!({ "command": cmd }),
+                });
+            }
+            if let Some(output) = item.get("aggregated_output").and_then(|v| v.as_str()) {
+                if !output.trim().is_empty() {
+                    out.push(Decoded::ToolResult {
+                        call_id: item
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                        output: json!(output),
+                        is_error: item.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0) != 0,
+                    });
+                }
+            }
+            out
+        }
+        "file_change" => {
+            let summary = item
+                .get("changes")
+                .and_then(|c| c.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|c| {
+                            let path = c.get("path").and_then(|v| v.as_str())?;
+                            let kind = c.get("kind").and_then(|v| v.as_str()).unwrap_or("change");
+                            Some(format!("{kind} {path}"))
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default();
+            if summary.is_empty() {
+                Vec::new()
+            } else {
+                vec![mk(
+                    format!("file_change: {summary}"),
+                    MessagePhase::Final,
+                    MessageRole::Tool,
+                    MessageKind::Message,
+                )]
+            }
+        }
+        // Unknown item: surface any text it carries.
+        _ => item
+            .get("text")
+            .and_then(|v| v.as_str())
+            .map(|t| {
+                vec![mk(
+                    t.to_string(),
+                    MessagePhase::Final,
+                    MessageRole::Assistant,
+                    MessageKind::Message,
+                )]
+            })
+            .unwrap_or_default(),
+    }
+}
+
+fn decoded_to_payload(frame: Decoded) -> AgentEventPayload {
+    match frame {
+        Decoded::Stream(m) => AgentEventPayload::StreamMessage(m),
+        Decoded::ToolUse {
+            call_id,
+            tool_name,
+            input,
+        } => AgentEventPayload::ToolUse {
+            call_id,
+            tool_name,
+            input,
+        },
+        Decoded::ToolResult {
+            call_id,
+            output,
+            is_error,
+        } => AgentEventPayload::ToolResult {
+            call_id,
+            output,
+            is_error,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_agent_message_delta() {
+        let out = map_notification("item/agentMessage/delta", &json!({"delta": "Hel"}), 3);
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            Decoded::Stream(m) => {
+                assert_eq!(m.text, "Hel");
+                assert_eq!(m.phase, MessagePhase::Delta);
+                assert_eq!(m.kind, MessageKind::Message);
+                assert_eq!(m.raw_line_seq, 3);
+            }
+            other => panic!("expected Stream, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_item_completed_reasoning_and_command() {
+        let reasoning = map_notification(
+            "item/completed",
+            &json!({"item": {"type": "reasoning", "text": "thinking"}}),
+            0,
+        );
+        assert!(matches!(
+            &reasoning[0],
+            Decoded::Stream(m) if m.kind == MessageKind::Reasoning && m.text == "thinking"
+        ));
+
+        let cmd = map_notification(
+            "item/completed",
+            &json!({"item": {
+                "id": "i1", "type": "command_execution",
+                "command": "ls -la", "aggregated_output": "file.txt\n", "exit_code": 0
+            }}),
+            0,
+        );
+        assert_eq!(cmd.len(), 2, "tool use + result; got {cmd:?}");
+        assert!(matches!(&cmd[0], Decoded::ToolUse { tool_name, .. } if tool_name == "shell"));
+        assert!(matches!(
+            &cmd[1],
+            Decoded::ToolResult {
+                is_error: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn maps_command_failure_as_error_result() {
+        let cmd = map_notification(
+            "item/completed",
+            &json!({"item": {
+                "id": "i2", "type": "command_execution",
+                "command": "false", "aggregated_output": "boom", "exit_code": 1
+            }}),
+            0,
+        );
+        assert!(matches!(
+            cmd.last().unwrap(),
+            Decoded::ToolResult { is_error: true, .. }
+        ));
+    }
+
+    #[test]
+    fn lifecycle_and_unknown_notifications_yield_nothing() {
+        assert!(map_notification("turn/started", &json!({}), 0).is_empty());
+        assert!(map_notification("turn/completed", &json!({}), 0).is_empty());
+        assert!(map_notification("thread/started", &json!({}), 0).is_empty());
+    }
+
+    #[test]
+    fn control_handle_send_after_close_errors() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<ControlCmd>();
+        let h = CodexControlHandle { tx };
+        drop(rx);
+        assert!(matches!(h.interrupt(), Err(CodexSessionError::Closed)));
+    }
+
+    // Live end-to-end smoke test against a real `codex`. Ignored by default;
+    // run with `cargo test --features codex-app-server -- --ignored live_`.
+    #[test]
+    #[ignore = "requires a real `codex` CLI on PATH and credentials"]
+    fn live_session_streams_and_interrupts() {
+        use std::time::{Duration, Instant};
+
+        let session = open_codex_session(
+            "Say hello in exactly one word.",
+            CodexSessionOptions::default(),
+        )
+        .expect("connect to live codex session");
+
+        let deadline = Instant::now() + Duration::from_secs(60);
+        let mut saw_output = false;
+        let mut interrupted = false;
+        while Instant::now() < deadline {
+            match session.events.recv_timeout(Duration::from_secs(5)) {
+                Ok(ev) => {
+                    eprintln!("LIVE CODEX EVENT seq={} {:?}", ev.seq, ev.payload);
+                    saw_output = true;
+                    if !interrupted {
+                        let _ = session.control.interrupt();
+                        interrupted = true;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) if saw_output => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        assert!(
+            saw_output,
+            "expected at least one event from a live codex session"
+        );
+    }
+}

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -5,6 +5,8 @@ pub mod backends;
 pub mod capabilities;
 #[cfg(feature = "claude-control")]
 pub mod claude_session;
+#[cfg(feature = "codex-app-server")]
+pub mod codex_session;
 pub mod transport;
 pub mod types;
 pub mod usage;
@@ -23,6 +25,10 @@ pub use capabilities::BackendCapabilities;
 pub use claude_session::{
     open_claude_session, ClaudePermissionMode, ClaudeSession, ClaudeSessionError,
     ClaudeSessionOptions, ControlHandle,
+};
+#[cfg(feature = "codex-app-server")]
+pub use codex_session::{
+    open_codex_session, CodexControlHandle, CodexSession, CodexSessionError, CodexSessionOptions,
 };
 pub use usage::aggregate_token_usage;
 


### PR DESCRIPTION
## What

The Codex counterpart to the Claude session work (B1/B2) — **bidirectional Codex sessions** over the `codex app-server` JSON-RPC protocol, completing the two-pronged Phase-B vision (Claude + Codex).

## Vendoring
`aikit-agent-codex` (the async app-server client) was an un-versioned directory *outside* the repo, so CI couldn't build it as a path/git dep. Per the chosen approach, it's **vendored into the workspace** as a member crate (alongside `aikit-agent`, `aikit-evals`, …) — in-tree, CI-safe, versioned with aikit.

## Bridge — `runner/codex_session.rs` (feature `codex-app-server`, off by default)
```rust
let session = open_codex_session(prompt, CodexSessionOptions { cwd, approval_policy, sandbox })?;
// session.events:  mpsc::Receiver<AgentEvent>
// session.control: CodexControlHandle — interrupt() / steer() / disconnect()
```
- A dedicated thread runs a current-thread tokio runtime driving `CodexClient`: **spawn → initialize → thread/start → turn/start**. `CodexClient::spawn` already hands back the notification receiver separately from the control client, so a single-task `tokio::select!` multiplexes inbound notifications and control commands — no second task, no `Arc<Mutex>`.
- Server→client approval requests are **auto-approved** for now (the permission-callback seam, like the Claude session's, is a follow-up).
- Synchronous connect errors via the same readiness-handshake pattern as the Claude session.

## Notification → canonical `Decoded` mapping
- `item/agentMessage/delta` → text delta
- `item/commandExecution/outputDelta` → tool output
- `item/completed` → `agent_message` (text) / `reasoning` / `command_execution` (**structured `ToolUse` + `ToolResult`**, `is_error` on non-zero exit) / `file_change`

These flow through the same `AgentEvent`/serve-SSE path as Claude (incl. #88's tool-frame translation).

## Verification
- **5 unit tests** — delta/item mapping, command-failure → error result, lifecycle-ignored, control-after-close.
- **Live**: the `#[ignore]` test passes against a real `codex` — streamed text + interrupt (`open_codex_session` → `StreamMessage { text: "Hello" }`).
- Default build + `cargo check --workspace` unaffected; clippy clean with the feature on and off. Codex crate's smoke tests guard on `which::which("codex")` (skip in CI).

Spec 007. Follow-up: Codex permission-callback seam (replace auto-approve), turn-completed/usage frames.