### PR TITLE
feat(aikit-sdk,serve): codex permission-callback + live-session HTTP surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,8 @@ walkdir = "2"
 which = "8.0"
 
 # aikit SDK (agent catalog and deploy)
-aikit-sdk = { path = "aikit-sdk", version = "0.3.0" }
+# claude-control/codex-app-server enable bidirectional live-session bridges.
+aikit-sdk = { path = "aikit-sdk", version = "0.3.0", features = ["claude-control", "codex-app-server"] }
 
 # Magic-tool layer (optional; enabled by --features tools)
 aikit-magictool = { path = "aikit-magictool", version = "0.1.0", optional = true, features = ["agent"] }

--- a/aikit-sdk/src/lib.rs
+++ b/aikit-sdk/src/lib.rs
@@ -418,6 +418,16 @@ pub mod aikit_agent_adapter;
 pub mod runner;
 pub mod session_store;
 
+#[cfg(feature = "claude-control")]
+pub use runner::{
+    open_claude_session, ClaudePermissionMode, ClaudeSession, ClaudeSessionError,
+    ClaudeSessionOptions, ControlHandle, PermissionCallback, ToolApprovalRequest, ToolDecision,
+};
+#[cfg(feature = "codex-app-server")]
+pub use runner::{
+    open_codex_session, CodexControlHandle, CodexSession, CodexSessionError, CodexSessionOptions,
+};
+
 // Re-export host tool types so cli-framework can depend on aikit-sdk alone.
 pub use aikit_agent::{HostToolDefinition, HostToolProvider};
 

--- a/aikit-sdk/src/runner/approval.rs
+++ b/aikit-sdk/src/runner/approval.rs
@@ -1,0 +1,36 @@
+//! Shared tool-approval types for session bridges.
+//!
+//! Both [`super::claude_session`] and [`super::codex_session`] expose a
+//! synchronous permission callback using these shared types; callers write one
+//! handler and attach it to whichever session they open.
+
+use std::sync::Arc;
+
+/// A request for the caller to approve or deny a tool call mid-session.
+#[derive(Debug, Clone)]
+pub struct ToolApprovalRequest {
+    /// Tool name or server-request method (e.g. `Bash`, `thread/approveCommand`).
+    pub tool_name: String,
+    /// Structured tool input / request params.
+    pub input: serde_json::Value,
+    /// Originating tool-use id, when provided by the backend.
+    pub tool_use_id: Option<String>,
+}
+
+/// The caller's decision on a [`ToolApprovalRequest`].
+#[derive(Debug, Clone)]
+pub enum ToolDecision {
+    /// Allow the call with its original input.
+    Allow,
+    /// Allow the call, substituting `input` for the original.
+    AllowWith { input: serde_json::Value },
+    /// Deny the call with a message shown to the agent.
+    Deny { message: String },
+}
+
+/// Synchronous permission callback, invoked on the bridge thread.
+///
+/// Must be fast and non-blocking — the bridge cannot process further events
+/// until this returns. `Send + Sync` allows the callback to live on the
+/// bridge alongside the session client.
+pub type PermissionCallback = Arc<dyn Fn(ToolApprovalRequest) -> ToolDecision + Send + Sync>;

--- a/aikit-sdk/src/runner/claude_session.rs
+++ b/aikit-sdk/src/runner/claude_session.rs
@@ -27,35 +27,11 @@ use crate::runner::backend::Decoded;
 use crate::runner::backends::claude::map_message;
 use crate::runner::types::{AgentEvent, AgentEventPayload, AgentEventStream};
 
+// Re-export so callers can reach them via `claude_session::` as before.
+pub use crate::runner::approval::{PermissionCallback, ToolApprovalRequest, ToolDecision};
+
 /// The Claude permission mode, re-exported from `claude-agent-sdk`.
 pub use claude_agent_sdk::PermissionMode as ClaudePermissionMode;
-
-/// A request for the caller to approve or deny a tool call mid-session.
-#[derive(Debug, Clone)]
-pub struct ToolApprovalRequest {
-    /// The tool being invoked (e.g. `Bash`, `Edit`).
-    pub tool_name: String,
-    /// The tool's structured input.
-    pub input: serde_json::Value,
-    /// The originating tool-use id, if provided.
-    pub tool_use_id: Option<String>,
-}
-
-/// The caller's decision on a [`ToolApprovalRequest`].
-#[derive(Debug, Clone)]
-pub enum ToolDecision {
-    /// Allow the call with its original input.
-    Allow,
-    /// Allow the call, substituting `input` for the original.
-    AllowWith { input: serde_json::Value },
-    /// Deny the call with a message shown to the agent.
-    Deny { message: String },
-}
-
-/// A synchronous permission callback. Invoked on the bridge thread when the
-/// agent requests a tool it isn't pre-authorised for; must be fast and
-/// non-blocking. `Send + Sync` so it can live on the bridge.
-pub type PermissionCallback = Arc<dyn Fn(ToolApprovalRequest) -> ToolDecision + Send + Sync>;
 
 /// Options for opening a Claude session. A focused subset of the SDK's options;
 /// extend as B2/B3 needs grow.
@@ -183,6 +159,27 @@ impl Drop for ClaudeSession {
         if let Some(j) = self.join.take() {
             let _ = j.join();
         }
+    }
+}
+
+impl ClaudeSession {
+    /// Dissolve the session into its control handle and event receiver.
+    ///
+    /// The bridge thread is detached rather than joined. It exits naturally
+    /// when the returned [`ControlHandle`] is eventually dropped (control
+    /// channel closes → bridge loop breaks → `query.close()` is called).
+    pub fn into_parts(self) -> (ControlHandle, mpsc::Receiver<AgentEvent>) {
+        // Prevent Drop from running (which would disconnect + join synchronously).
+        let this = std::mem::ManuallyDrop::new(self);
+        // SAFETY: ManuallyDrop prevents the destructor from running; we read
+        // every field exactly once and explicitly handle the JoinHandle.
+        let control = unsafe { std::ptr::read(&this.control) };
+        let events = unsafe { std::ptr::read(&this.events) };
+        let join = unsafe { std::ptr::read(&this.join) };
+        if let Some(j) = join {
+            drop(j); // detach — thread exits when control sender is dropped
+        }
+        (control, events)
     }
 }
 

--- a/aikit-sdk/src/runner/codex_session.rs
+++ b/aikit-sdk/src/runner/codex_session.rs
@@ -14,7 +14,7 @@
 //! session's, is a follow-up). See spec 007.
 
 use std::path::PathBuf;
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 use std::thread;
 
 use aikit_agent_codex::{
@@ -28,8 +28,11 @@ use crate::runner::types::{
     StreamMessage,
 };
 
+// Re-export for callers who import approval types via `codex_session::`.
+pub use crate::runner::approval::{PermissionCallback, ToolApprovalRequest, ToolDecision};
+
 /// Options for opening a Codex session.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CodexSessionOptions {
     /// Working directory for the thread (and the spawned `codex` process).
     pub cwd: PathBuf,
@@ -37,6 +40,9 @@ pub struct CodexSessionOptions {
     pub approval_policy: String,
     /// Sandbox mode: e.g. `read-only`, `workspace-write`, `danger-full-access`.
     pub sandbox: String,
+    /// Tool-approval callback. When set, server→client approval requests are
+    /// passed to this callback instead of being auto-approved.
+    pub on_tool_permission: Option<PermissionCallback>,
 }
 
 impl Default for CodexSessionOptions {
@@ -47,7 +53,33 @@ impl Default for CodexSessionOptions {
             // codex via `--yolo` today); approvals never block the stream.
             approval_policy: "never".to_string(),
             sandbox: "workspace-write".to_string(),
+            on_tool_permission: None,
         }
+    }
+}
+
+impl CodexSessionOptions {
+    /// Set the tool-approval callback (builder style).
+    pub fn with_tool_permission<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(ToolApprovalRequest) -> ToolDecision + Send + Sync + 'static,
+    {
+        self.on_tool_permission = Some(Arc::new(callback));
+        self
+    }
+}
+
+impl std::fmt::Debug for CodexSessionOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexSessionOptions")
+            .field("cwd", &self.cwd)
+            .field("approval_policy", &self.approval_policy)
+            .field("sandbox", &self.sandbox)
+            .field(
+                "on_tool_permission",
+                &self.on_tool_permission.as_ref().map(|_| "<callback>"),
+            )
+            .finish()
     }
 }
 
@@ -122,6 +154,26 @@ impl Drop for CodexSession {
         if let Some(j) = self.join.take() {
             let _ = j.join();
         }
+    }
+}
+
+impl CodexSession {
+    /// Dissolve the session into its control handle and event receiver.
+    ///
+    /// The bridge thread is detached and exits naturally when the returned
+    /// [`CodexControlHandle`] is dropped (control channel closes → bridge
+    /// loop breaks → client disconnects).
+    pub fn into_parts(self) -> (CodexControlHandle, mpsc::Receiver<AgentEvent>) {
+        let this = std::mem::ManuallyDrop::new(self);
+        // SAFETY: ManuallyDrop prevents the destructor; we read every field
+        // exactly once and handle the JoinHandle explicitly.
+        let control = unsafe { std::ptr::read(&this.control) };
+        let events = unsafe { std::ptr::read(&this.events) };
+        let join = unsafe { std::ptr::read(&this.join) };
+        if let Some(j) = join {
+            drop(j); // detach
+        }
+        (control, events)
     }
 }
 
@@ -246,12 +298,28 @@ async fn run_session(
                             seq += 1;
                         }
                     }
-                    // Server→client request (e.g. an approval prompt). Auto-approve
-                    // for now — a permission-callback seam is a follow-up.
+                    // Server→client request (e.g. an approval prompt). Route to
+                    // the permission callback when one is set; auto-approve otherwise.
                     Some(ServerMessage::ServerRequest(req)) => {
-                        let _ = client
-                            .reply_server_request(req.id, json!({ "outcome": "approved" }))
-                            .await;
+                        let outcome = if let Some(cb) = &options.on_tool_permission {
+                            let request = ToolApprovalRequest {
+                                tool_name: req.method.clone(),
+                                input: req.params.clone(),
+                                tool_use_id: None,
+                            };
+                            match cb(request) {
+                                ToolDecision::Allow => json!({ "outcome": "approved" }),
+                                ToolDecision::AllowWith { input } => {
+                                    json!({ "outcome": "approved", "input": input })
+                                }
+                                ToolDecision::Deny { message } => {
+                                    json!({ "outcome": "rejected", "reason": message })
+                                }
+                            }
+                        } else {
+                            json!({ "outcome": "approved" })
+                        };
+                        let _ = client.reply_server_request(req.id, outcome).await;
                     }
                     None => break, // app-server closed the stream
                 }
@@ -543,6 +611,61 @@ mod tests {
         let h = CodexControlHandle { tx };
         drop(rx);
         assert!(matches!(h.interrupt(), Err(CodexSessionError::Closed)));
+    }
+
+    #[test]
+    fn with_tool_permission_builder_sets_callback() {
+        let opts = CodexSessionOptions::default().with_tool_permission(|_req| ToolDecision::Allow);
+        assert!(opts.on_tool_permission.is_some());
+    }
+
+    #[test]
+    fn permission_callback_decisions() {
+        let cb: PermissionCallback =
+            Arc::new(|req: ToolApprovalRequest| match req.tool_name.as_str() {
+                "thread/approveCommand" => ToolDecision::Deny {
+                    message: "not allowed".into(),
+                },
+                "thread/approveFileWrite" => ToolDecision::AllowWith {
+                    input: serde_json::json!({ "sanitized": true }),
+                },
+                _ => ToolDecision::Allow,
+            });
+
+        let deny_req = ToolApprovalRequest {
+            tool_name: "thread/approveCommand".into(),
+            input: serde_json::json!({}),
+            tool_use_id: None,
+        };
+        assert!(matches!(cb(deny_req), ToolDecision::Deny { .. }));
+
+        let allow_with_req = ToolApprovalRequest {
+            tool_name: "thread/approveFileWrite".into(),
+            input: serde_json::json!({}),
+            tool_use_id: None,
+        };
+        match cb(allow_with_req) {
+            ToolDecision::AllowWith { input } => assert_eq!(input["sanitized"], true),
+            other => panic!("expected AllowWith, got {other:?}"),
+        }
+
+        let allow_req = ToolApprovalRequest {
+            tool_name: "other".into(),
+            input: serde_json::json!({}),
+            tool_use_id: None,
+        };
+        assert!(matches!(cb(allow_req), ToolDecision::Allow));
+    }
+
+    #[test]
+    fn options_debug_hides_callback() {
+        let plain = CodexSessionOptions::default();
+        let debug = format!("{plain:?}");
+        assert!(debug.contains("on_tool_permission: None"), "got: {debug}");
+
+        let with_cb = CodexSessionOptions::default().with_tool_permission(|_| ToolDecision::Allow);
+        let debug = format!("{with_cb:?}");
+        assert!(debug.contains("on_tool_permission: Some"), "got: {debug}");
     }
 
     // Live end-to-end smoke test against a real `codex`. Ignored by default;

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -1,3 +1,4 @@
+pub mod approval;
 pub mod argv;
 pub mod availability;
 pub mod backend;
@@ -30,6 +31,9 @@ pub use claude_session::{
 pub use codex_session::{
     open_codex_session, CodexControlHandle, CodexSession, CodexSessionError, CodexSessionOptions,
 };
+// Shared approval types; available when at least one session feature is enabled.
+#[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
+pub use approval::{PermissionCallback, ToolApprovalRequest, ToolDecision};
 pub use usage::aggregate_token_usage;
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -51,6 +51,10 @@ use aikit_sdk::{
     get_agent_status, AgentEventPayload, MessageKind, MessagePhase, MessageRole, RunError,
     RunOptions, UsageSource,
 };
+use aikit_sdk::{
+    open_claude_session, open_codex_session, ClaudeSessionError, ClaudeSessionOptions,
+    CodexControlHandle, CodexSessionError, CodexSessionOptions, ControlHandle,
+};
 
 use cli_framework::api::{
     ApiServerBuilder, ApiVersion, ApiVersionName, DefaultVersion, ReadinessReport, Stability,
@@ -162,6 +166,57 @@ pub enum StreamFrame {
     },
 }
 
+// ── live session (bidirectional) ─────────────────────────────────────────────
+
+/// Wraps either a [`ControlHandle`] (Claude) or a [`CodexControlHandle`] (Codex)
+/// so both can be stored in a unified registry.
+enum LiveSessionControl {
+    Claude(ControlHandle),
+    Codex(CodexControlHandle),
+}
+
+impl LiveSessionControl {
+    fn interrupt(&self) {
+        match self {
+            LiveSessionControl::Claude(h) => {
+                let _ = h.interrupt();
+            }
+            LiveSessionControl::Codex(h) => {
+                let _ = h.interrupt();
+            }
+        }
+    }
+
+    fn disconnect(&self) {
+        match self {
+            LiveSessionControl::Claude(h) => {
+                let _ = h.disconnect();
+            }
+            LiveSessionControl::Codex(h) => {
+                let _ = h.disconnect();
+            }
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum LiveSessionStatus {
+    Active,
+    Closed,
+}
+
+struct LiveSessionRecord {
+    session_id: String,
+    agent_key: String,
+    control: LiveSessionControl,
+    status: LiveSessionStatus,
+    created_at: DateTime<Utc>,
+}
+
+/// Registry of open bidirectional sessions, keyed by session_id.
+type LiveSessions = Arc<Mutex<HashMap<String, LiveSessionRecord>>>;
+
 // ── run function type (injectable for tests) ──────────────────────────────────
 
 pub struct RunFnOutcome {
@@ -206,6 +261,7 @@ type AuthCache = Arc<Mutex<Option<(Instant, HashMap<String, AuthStatus>)>>>;
 #[derive(Clone)]
 struct AppState {
     runs: Arc<Mutex<HashMap<String, RunRecord>>>,
+    live_sessions: LiveSessions,
     config: ServeConfig,
     run_fn: RunFn,
     auth_cache: AuthCache,
@@ -257,6 +313,50 @@ struct SendMessageRequest {
     model: Option<String>,
     #[serde(default)]
     yolo: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateLiveSessionRequest {
+    agent: String,
+    prompt: String,
+    #[serde(default)]
+    model: Option<String>,
+    /// Codex approval policy: `never`, `on-failure`, `on-request`, `untrusted`.
+    #[serde(default)]
+    approval_policy: Option<String>,
+    /// Codex sandbox mode: `read-only`, `workspace-write`, `danger-full-access`.
+    #[serde(default)]
+    sandbox: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LiveSessionControlRequest {
+    /// Action to perform: `interrupt`, `set_model`, `disconnect`.
+    action: String,
+    /// Model to switch to; required when `action = "set_model"`.
+    #[serde(default)]
+    model: Option<String>,
+}
+
+#[derive(Serialize)]
+struct LiveSessionSummary {
+    session_id: String,
+    agent: String,
+    status: LiveSessionStatus,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+struct ListLiveSessionsResponse {
+    sessions: Vec<LiveSessionSummary>,
+}
+
+#[derive(Serialize)]
+struct DeleteLiveSessionResponse {
+    session_id: String,
+    status: LiveSessionStatus,
 }
 
 /// Response representation negotiated from the request's `Accept` header.
@@ -1365,6 +1465,303 @@ async fn sync_response(
         .into_response()
 }
 
+// ── live session handlers ─────────────────────────────────────────────────────
+
+/// `POST /api/v1/live-sessions` — create a bidirectional Claude or Codex
+/// session and stream its events as SSE.
+///
+/// The `X-Session-Id` response header carries the session_id before the first
+/// SSE frame so clients can associate it even before reading the stream.
+/// The first SSE frame is also `event: session` with `{"session_id": ...}`.
+async fn create_live_session_handler(
+    State(state): State<AppState>,
+    Json(body): Json<CreateLiveSessionRequest>,
+) -> Response {
+    if body.agent.trim().is_empty() {
+        return error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_request",
+            "agent field is required",
+        );
+    }
+    if body.prompt.is_empty() {
+        return error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_request",
+            "prompt must not be empty",
+        );
+    }
+
+    let session_id = Uuid::new_v4().to_string();
+
+    // Open the session synchronously — connect/handshake errors surface here.
+    let (control, events_rx) = match body.agent.as_str() {
+        "claude" => {
+            let opts = ClaudeSessionOptions {
+                model: body.model.clone(),
+                ..ClaudeSessionOptions::default()
+            };
+            match open_claude_session(&body.prompt, opts) {
+                Ok(s) => {
+                    let (ctrl, evts) = s.into_parts();
+                    (LiveSessionControl::Claude(ctrl), evts)
+                }
+                Err(ClaudeSessionError::Connect(msg)) => {
+                    return error_response(
+                        StatusCode::BAD_GATEWAY,
+                        "session_connect_failed",
+                        &format!("Failed to connect to claude: {msg}"),
+                    );
+                }
+                Err(e) => {
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "session_error",
+                        &e.to_string(),
+                    );
+                }
+            }
+        }
+        "codex" => {
+            let default_opts = CodexSessionOptions::default();
+            let opts = CodexSessionOptions {
+                approval_policy: body
+                    .approval_policy
+                    .clone()
+                    .unwrap_or(default_opts.approval_policy),
+                sandbox: body.sandbox.clone().unwrap_or(default_opts.sandbox),
+                ..default_opts
+            };
+            match open_codex_session(&body.prompt, opts) {
+                Ok(s) => {
+                    let (ctrl, evts) = s.into_parts();
+                    (LiveSessionControl::Codex(ctrl), evts)
+                }
+                Err(CodexSessionError::Connect(msg)) => {
+                    return error_response(
+                        StatusCode::BAD_GATEWAY,
+                        "session_connect_failed",
+                        &format!("Failed to connect to codex: {msg}"),
+                    );
+                }
+                Err(e) => {
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "session_error",
+                        &e.to_string(),
+                    );
+                }
+            }
+        }
+        other => {
+            return error_response(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "agent_not_supported",
+                &format!("Live sessions require agent 'claude' or 'codex', got '{other}'"),
+            );
+        }
+    };
+
+    // Register the session in the live registry.
+    {
+        let mut live = state.live_sessions.lock().unwrap();
+        live.insert(
+            session_id.clone(),
+            LiveSessionRecord {
+                session_id: session_id.clone(),
+                agent_key: body.agent.clone(),
+                control,
+                status: LiveSessionStatus::Active,
+                created_at: Utc::now(),
+            },
+        );
+    }
+
+    // Spawn a blocking forwarder: sync mpsc → tokio mpsc → SSE.
+    let (frame_tx, frame_rx) = tokio::sync::mpsc::channel::<StreamFrame>(64);
+    let agent_key = body.agent.clone();
+    let live_ref = Arc::clone(&state.live_sessions);
+    let sid_for_cleanup = session_id.clone();
+    let sid_for_frame = session_id.clone();
+    tokio::task::spawn_blocking(move || {
+        // First frame: announce the session_id.
+        if frame_tx
+            .blocking_send(StreamFrame::Session {
+                session_id: sid_for_frame,
+            })
+            .is_err()
+        {
+            return;
+        }
+        // Forward agent events until the session closes or the client disconnects.
+        while let Ok(event) = events_rx.recv() {
+            if let Some(frame) = agent_event_to_frame(&event, &agent_key) {
+                if frame_tx.blocking_send(frame).is_err() {
+                    break; // client disconnected
+                }
+            }
+        }
+        // Mark session closed in the registry.
+        if let Ok(mut live) = live_ref.lock() {
+            if let Some(r) = live.get_mut(&sid_for_cleanup) {
+                r.status = LiveSessionStatus::Closed;
+            }
+        }
+    });
+
+    // Build the SSE response with the session_id header.
+    let sid_header = session_id.clone();
+    let (out_tx, out_rx) = tokio::sync::mpsc::channel::<Result<Event, Infallible>>(64);
+    let mut frame_rx = frame_rx;
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                maybe = frame_rx.recv() => {
+                    match maybe {
+                        Some(frame) => {
+                            if out_tx.send(Ok(frame_to_sse(&frame))).await.is_err() {
+                                return;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                _ = out_tx.closed() => return,
+            }
+        }
+        let data = serde_json::json!({ "exit_code": 0 }).to_string();
+        let _ = out_tx
+            .send(Ok(Event::default().event("done").data(data)))
+            .await;
+    });
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::CACHE_CONTROL,
+        HeaderValue::from_static("no-cache"),
+    );
+    headers.insert("x-accel-buffering", HeaderValue::from_static("no"));
+    if let Ok(val) = HeaderValue::from_str(&sid_header) {
+        headers.insert("x-session-id", val);
+    }
+
+    (headers, Sse::new(ReceiverStream::new(out_rx))).into_response()
+}
+
+/// `POST /api/v1/live-sessions/{session_id}/control` — send a control command.
+async fn live_session_control_handler(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(body): Json<LiveSessionControlRequest>,
+) -> impl IntoResponse {
+    let live = state.live_sessions.lock().unwrap();
+    let Some(record) = live.get(&session_id) else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "session_not_found",
+            "Live session not found",
+        );
+    };
+    if record.status == LiveSessionStatus::Closed {
+        return error_response(
+            StatusCode::GONE,
+            "session_closed",
+            "Live session is already closed",
+        );
+    }
+    match body.action.as_str() {
+        "interrupt" => {
+            record.control.interrupt();
+            (
+                StatusCode::OK,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                r#"{"ok":true,"action":"interrupt"}"#,
+            )
+                .into_response()
+        }
+        "disconnect" => {
+            record.control.disconnect();
+            (
+                StatusCode::OK,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                r#"{"ok":true,"action":"disconnect"}"#,
+            )
+                .into_response()
+        }
+        "set_model" => {
+            // Only supported for Claude sessions.
+            match &record.control {
+                LiveSessionControl::Claude(h) => {
+                    let _ = h.set_model(body.model.clone());
+                    (
+                        StatusCode::OK,
+                        [(axum::http::header::CONTENT_TYPE, "application/json")],
+                        r#"{"ok":true,"action":"set_model"}"#,
+                    )
+                        .into_response()
+                }
+                LiveSessionControl::Codex(_) => error_response(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "not_supported",
+                    "set_model is only supported for Claude sessions",
+                ),
+            }
+        }
+        other => error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_action",
+            &format!("Unknown action '{other}'. Supported: interrupt, disconnect, set_model"),
+        ),
+    }
+}
+
+/// `GET /api/v1/live-sessions` — list active live sessions.
+async fn list_live_sessions_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let live = state.live_sessions.lock().unwrap();
+    let sessions: Vec<LiveSessionSummary> = live
+        .values()
+        .filter(|r| r.status != LiveSessionStatus::Closed)
+        .map(|r| LiveSessionSummary {
+            session_id: r.session_id.clone(),
+            agent: r.agent_key.clone(),
+            status: r.status.clone(),
+            created_at: r.created_at,
+        })
+        .collect();
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        serde_json::to_string(&ListLiveSessionsResponse { sessions }).unwrap_or_default(),
+    )
+}
+
+/// `DELETE /api/v1/live-sessions/{session_id}` — disconnect a live session.
+async fn delete_live_session_handler(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> impl IntoResponse {
+    let mut live = state.live_sessions.lock().unwrap();
+    let Some(record) = live.get_mut(&session_id) else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            "session_not_found",
+            "Live session not found",
+        );
+    };
+    record.control.disconnect();
+    record.status = LiveSessionStatus::Closed;
+    let resp = DeleteLiveSessionResponse {
+        session_id,
+        status: LiveSessionStatus::Closed,
+    };
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        serde_json::to_string(&resp).unwrap_or_default(),
+    )
+        .into_response()
+}
+
 fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/agents", get(agents_handler))
@@ -1372,6 +1769,16 @@ fn build_router(state: AppState) -> Router {
         .route("/sessions", get(list_runs_handler))
         .route("/sessions/{session_id}", get(get_run_handler))
         .route("/sessions/{session_id}", delete(delete_run_handler))
+        .route("/live-sessions", post(create_live_session_handler))
+        .route("/live-sessions", get(list_live_sessions_handler))
+        .route(
+            "/live-sessions/{session_id}/control",
+            post(live_session_control_handler),
+        )
+        .route(
+            "/live-sessions/{session_id}",
+            delete(delete_live_session_handler),
+        )
         .with_state(state)
 }
 
@@ -1744,6 +2151,7 @@ pub async fn execute_with_run_fn(args: ServeArgs, run_fn: RunFn) -> anyhow::Resu
 
     let state = AppState {
         runs: Arc::new(Mutex::new(HashMap::new())),
+        live_sessions: Arc::new(Mutex::new(HashMap::new())),
         config: config.clone(),
         run_fn,
         auth_cache: Arc::new(Mutex::new(None)),


### PR DESCRIPTION
## Summary

- **`runner/approval.rs`** — extracts `ToolApprovalRequest`, `ToolDecision`, and `PermissionCallback` into a shared module so both Claude and Codex sessions have one canonical definition
- **`codex_session.rs`** — `CodexSessionOptions::on_tool_permission` callback replaces the auto-approve fallback for `ServerRequest` messages; falls back to approve-all when unset (preserving existing behaviour); builder method `with_tool_permission()`; manual `Debug` hides the closure
- **`claude_session.rs` / `codex_session.rs`** — both expose `into_parts() → (ControlHandle, Receiver<AgentEvent>)` via `ManuallyDrop` so the serve layer can extract ownership without triggering Drop (bridge thread detaches and exits when the control sender is eventually dropped)
- **`serve.rs`** — new live-session surface behind four routes:
  - `POST   /live-sessions` — open a Claude or Codex bidirectional session; returns SSE with `X-Session-Id` header + first `session` frame
  - `POST   /live-sessions/{id}/control` — `interrupt`, `disconnect`, `set_model` (Claude only)
  - `GET    /live-sessions` — list active sessions
  - `DELETE /live-sessions/{id}` — disconnect + mark closed

Events flow: sync bridge `mpsc::Receiver` → `spawn_blocking` forwarder → tokio `mpsc` channel → `Sse<ReceiverStream>`.

## Test plan

- [ ] `cargo test --manifest-path aikit-sdk/Cargo.toml --features "claude-control,codex-app-server"` — 34 pass (incl. new codex permission-callback tests)
- [ ] `cargo test --test serve_smoke_test` — 24 pass
- [ ] `cargo test --lib` — 134 pass
- [ ] Full pre-push suite — all pass