### PR TITLE
feat(aikit-sdk,serve): Backend Phase B capabilities — Claude bidirectional + agents API

### DIFF
--- a/aikit-sdk/src/lib.rs
+++ b/aikit-sdk/src/lib.rs
@@ -444,9 +444,9 @@ pub use runner::{
     aggregate_token_usage, extract_usage_from_line, get_agent_status, get_installed_agents,
     is_agent_available, is_runnable, normalize_json_line, run_agent, run_agent_events,
     run_builtin_agent, runnable_agents, AgentAvailabilityReason, AgentEvent, AgentEventPayload,
-    AgentEventStream, AgentStatus, MessageKind, MessagePhase, MessageRole, OutputMode,
-    ProgressSink, QuotaCategory, QuotaExceededInfo, RunError, RunOptions, RunResult, StreamMessage,
-    TokenUsage, UsageSource,
+    AgentEventStream, AgentStatus, BackendCapabilities, MessageKind, MessagePhase, MessageRole,
+    OutputMode, ProgressSink, QuotaCategory, QuotaExceededInfo, RunError, RunOptions, RunResult,
+    StreamMessage, TokenUsage, UsageSource,
 };
 
 pub mod run_progress;

--- a/aikit-sdk/src/runner/backends/claude.rs
+++ b/aikit-sdk/src/runner/backends/claude.rs
@@ -2,9 +2,9 @@
 //!
 //! Decode delegates to the typed `claude-agent-sdk` parser (`parse_message`)
 //! when the `claude-sdk` feature is enabled (default), emitting structured
-//! tool/thinking frames in addition to text; a hand-rolled text-only decode is
-//! the fallback. Phase B2 will light up the bidirectional control axis via the
-//! SDK client (see spec 006/007).
+//! tool/thinking/server-tool frames. Bidirectional control (interrupts, hooks,
+//! SDK-MCP, fork/resume) is wired via `runner/claude_session.rs` (spec 007
+//! B2/B3, feature `claude-control`).
 
 use std::ffi::OsString;
 
@@ -22,8 +22,10 @@ pub(crate) const KEY: &str = "claude";
 pub(crate) const BINARY_CANDIDATES: &[&str] = &["claude"];
 
 pub(crate) const CAPABILITIES: BackendCapabilities = BackendCapabilities::NONE
+    .with_bidirectional()
     .with_structured_tools()
     .with_reasoning()
+    .with_interruptible()
     .with_resumable_sessions()
     .with_mcp_routing()
     .with_hooks()

--- a/aikit-sdk/src/runner/capabilities.rs
+++ b/aikit-sdk/src/runner/capabilities.rs
@@ -17,7 +17,7 @@
 /// breaking change. Construct via [`BackendCapabilities::NONE`] and the
 /// builder-style `with_*` setters, or the `const fn` constructor used by the
 /// per-Backend tables.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub struct BackendCapabilities {
     /// Has a Control channel (approvals / interrupts / turn lifecycle).

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -435,6 +435,8 @@ struct AgentInfo {
     /// Whether the backend is authenticated. See [`AuthStatus`]. `available`
     /// backends with no probe mechanism report `unknown`.
     auth: AuthStatus,
+    /// Static capability flags declared by this backend. `null` for unknown keys.
+    capabilities: Option<aikit_sdk::BackendCapabilities>,
 }
 
 #[derive(Serialize)]
@@ -626,6 +628,7 @@ fn build_runnable_agents() -> Vec<AgentInfo> {
                 .map(|c| c.name.clone())
                 .unwrap_or_else(|| key.clone());
             AgentInfo {
+                capabilities: aikit_sdk::runner::Backend::from_key(&key).map(|b| b.capabilities()),
                 key,
                 name,
                 available: true,


### PR DESCRIPTION
## Summary

**Closes out spec 006 Phase B** — the control axis (B2/B3) is shipped; this PR flips the capability flags to match reality and surfaces them over HTTP.

- **`BackendCapabilities` serializable**: adds `#[derive(Serialize, Deserialize)]` so the struct can be sent as JSON without a custom mapping; re-exported from `aikit-sdk` top level
- **Claude capabilities updated**: `bidirectional = true`, `interruptible = true` — previously marked `(B)` in spec 006 ("unlocked in Phase B"), now correct since `runner/claude_session.rs` (spec 007 B2/B3) is merged; stale comment updated
- **`GET /api/v1/agents` exposes capabilities**: `AgentInfo` gains `capabilities: Option<BackendCapabilities>` populated via `Backend::from_key(key).map(|b| b.capabilities())`; `null` for unknown keys. HTTP clients can now discover `bidirectional`, `hooks`, `server_tools`, etc. without embedding backend knowledge

## Example response after this PR

```json
{
  "agents": [
    {
      "key": "claude",
      "available": true,
      "auth": "authenticated",
      "capabilities": {
        "bidirectional": true,
        "structured_tools": true,
        "reasoning": true,
        "hooks": true,
        "server_tools": true,
        "resumable_sessions": true,
        "mcp_routing": true,
        "subagents": true,
        "interruptible": true,
        "file_changes": false,
        "context_compression": false
      }
    }
  ]
}
```

## Test plan

- [x] `cargo test --test serve_smoke_test` — 24 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Pre-commit: format + clippy + unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)