### PR TITLE
fix(serve): B10 tool visibility + B3/B5 session id stability

### DIFF
--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -320,6 +320,11 @@ pub(super) fn agent_event_to_frame(
                     content: msg.text.clone(),
                 })
             }
+            // CLI backends (codex, opencode) emit tool invocations as (Tool, Message).
+            (MessageRole::Tool, MessageKind::Message, _) => Some(StreamFrame::ToolUse {
+                name: msg.text.clone(),
+                input: serde_json::Value::Null,
+            }),
             (MessageRole::Tool, MessageKind::ToolOutput, _) => Some(StreamFrame::ToolResult {
                 name: agent_key.to_string(),
                 output: msg.text.clone(),
@@ -885,6 +890,50 @@ mod tests {
                 assert_eq!(name, "call-1");
                 assert_eq!(output, "boom");
                 assert!(is_error);
+            }
+            other => panic!("expected ToolResult frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_tool_message_becomes_tool_use() {
+        // codex emits (Tool, Message) for command text — should become ToolUse
+        let ev = event(AgentEventPayload::StreamMessage(StreamMessage {
+            text: "ls -la".to_string(),
+            phase: MessagePhase::Delta,
+            role: MessageRole::Tool,
+            kind: aikit_sdk::MessageKind::Message,
+            source: AgentEventStream::Stdout,
+            raw_line_seq: 0,
+            turn_id: None,
+        }));
+        match agent_event_to_frame(&ev, "codex") {
+            Some(StreamFrame::ToolUse { name, input }) => {
+                assert_eq!(name, "ls -la");
+                assert_eq!(input, serde_json::Value::Null);
+            }
+            other => panic!("expected ToolUse frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_tool_output_becomes_tool_result() {
+        // codex/opencode emit (Tool, ToolOutput) for command output — should become ToolResult
+        let ev = event(AgentEventPayload::StreamMessage(StreamMessage {
+            text: "Cargo.toml\nsrc/".to_string(),
+            phase: MessagePhase::Delta,
+            role: MessageRole::Tool,
+            kind: aikit_sdk::MessageKind::ToolOutput,
+            source: AgentEventStream::Stdout,
+            raw_line_seq: 0,
+            turn_id: None,
+        }));
+        match agent_event_to_frame(&ev, "codex") {
+            Some(StreamFrame::ToolResult {
+                output, is_error, ..
+            }) => {
+                assert_eq!(output, "Cargo.toml\nsrc/");
+                assert!(!is_error);
             }
             other => panic!("expected ToolResult frame, got {other:?}"),
         }

--- a/src/cli/serve/run_session.rs
+++ b/src/cli/serve/run_session.rs
@@ -36,9 +36,13 @@ pub(super) enum RunStatus {
 
 #[derive(Clone)]
 pub(super) struct RunRecord {
-    pub session_id: Option<String>,
+    /// Session token the underlying CLI backend recognises for `--resume`.
+    /// May differ from the server-minted map key.  `None` while the first
+    /// turn is in flight and the backend hasn't yet returned a session id.
+    pub backend_session_id: Option<String>,
     pub agent: String,
     pub status: RunStatus,
+    /// When the session was first opened (not updated on resume turns).
     pub started_at: DateTime<Utc>,
     pub last_active_at: DateTime<Utc>,
     pub abort_handle: Option<tokio::task::AbortHandle>,
@@ -294,7 +298,7 @@ fn resolve_response_mode(headers: &axum::http::HeaderMap) -> ResponseMode {
 
 #[derive(Serialize)]
 struct RunSummary {
-    session_id: Option<String>,
+    session_id: String,
     agent: String,
     status: RunStatus,
     started_at: DateTime<Utc>,
@@ -360,11 +364,10 @@ pub(super) fn validate_request(body: &SendMessageRequest, state: &AppState) -> O
         ));
     }
     if let Some(ref sid) = body.session_id {
-        let in_memory = {
-            let runs = state.runs.lock().unwrap();
-            runs.values().any(|r| r.session_id.as_deref() == Some(sid))
-        };
+        let in_memory = state.runs.lock().unwrap().contains_key(sid.as_str());
         if !in_memory {
+            // For the aikit backend, fall back to the persistent SessionStore so
+            // cross-restart resume works when the client holds the aikit session id.
             if body.agent == "aikit" {
                 let store = SessionStore::open();
                 match store.load(sid) {
@@ -445,28 +448,55 @@ fn run_error_to_frame(err: RunError) -> (StreamFrame, i32) {
 
 // ── spawn_run ─────────────────────────────────────────────────────────────────
 
+/// B3/B5: `runs` is keyed by a stable server-minted `session_id` so that
+/// multi-turn conversations occupy exactly one record.  Resume turns upsert
+/// into the existing record rather than inserting a sibling.
+///
+/// The returned `String` is the `server_session_id` — the key clients use for
+/// subsequent turns and for `GET/DELETE /api/v1/sessions/{id}`.
 #[allow(clippy::result_large_err)]
 pub(super) fn spawn_run(
     state: &AppState,
     body: &SendMessageRequest,
 ) -> Result<(tokio::sync::mpsc::Receiver<StreamFrame>, String), Response> {
-    let request_id = Uuid::new_v4().to_string();
     let now = Utc::now();
+
+    // Stable server-assigned session id.  For new sessions we mint a UUID; for
+    // resume turns the client supplies the id it received from the prior turn.
+    let server_session_id = body
+        .session_id
+        .clone()
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    // The backend resume token (may differ from server_session_id for external
+    // CLIs whose own session id is returned in the stream).
+    let backend_session_id_for_run: Option<String>;
+
     {
         let mut runs = state.runs.lock().unwrap();
-        // B9: atomic busy-check + capacity-check + insert under one lock.
-        if let Some(ref sid) = body.session_id {
-            let busy = runs.values().any(|r| {
-                r.session_id.as_deref() == Some(sid.as_str()) && r.status == RunStatus::Running
-            });
-            if busy {
+
+        // B9 (atomic busy + capacity + upsert under one lock).
+        if let Some(r) = runs.get(&server_session_id) {
+            if r.status == RunStatus::Running {
                 return Err(error_response(
                     StatusCode::CONFLICT,
                     "session_busy",
                     "Session is currently processing a message",
                 ));
             }
+            // For an in-memory resume turn use the recorded backend token.
+            // If the backend never returned one, fall back to the server id
+            // (works for aikit whose session_id == backend session_id).
+            backend_session_id_for_run = r
+                .backend_session_id
+                .clone()
+                .or_else(|| body.session_id.clone());
+        } else {
+            // New session or cross-restart aikit resume: treat the client-
+            // provided id as the backend token (it IS the aikit session_id).
+            backend_session_id_for_run = body.session_id.clone();
         }
+
         let active = runs
             .values()
             .filter(|r| r.status == RunStatus::Running)
@@ -481,10 +511,14 @@ pub(super) fn spawn_run(
                 ),
             ));
         }
-        runs.insert(
-            request_id.clone(),
-            RunRecord {
-                session_id: body.session_id.clone(),
+
+        // Upsert: update an existing record in place or insert a fresh one.
+        // `started_at` is preserved on resume turns so it reflects when the
+        // session was first opened.
+        let record = runs
+            .entry(server_session_id.clone())
+            .or_insert_with(|| RunRecord {
+                backend_session_id: backend_session_id_for_run.clone(),
                 agent: body.agent.clone(),
                 status: RunStatus::Running,
                 started_at: now,
@@ -492,11 +526,14 @@ pub(super) fn spawn_run(
                 abort_handle: None,
                 stderr_tail: String::new(),
                 last_exit_code: None,
-            },
-        );
+            });
+        record.status = RunStatus::Running;
+        record.last_active_at = now;
+        record.abort_handle = None;
+        record.stderr_tail = String::new();
+        record.last_exit_code = None;
     }
 
-    let session_id_in = body.session_id.clone();
     let content = body.content.clone();
     let model = body.model.clone();
     let yolo = body.yolo;
@@ -505,38 +542,52 @@ pub(super) fn spawn_run(
     let run_fn = state.run_fn.clone();
     let runs_ref = Arc::clone(&state.runs);
 
-    // B11: relay channel so `Session` frames update the record before the run
-    // completes, enabling concurrent requests to find the session_id early.
     let (inner_tx, mut inner_rx) = tokio::sync::mpsc::channel::<StreamFrame>(64);
     let (outer_tx, rx) = tokio::sync::mpsc::channel::<StreamFrame>(64);
+
+    // B5: emit the server-minted session id as the very first frame so clients
+    // have a stable, resolvable id before any backend frames arrive.
+    let _ = outer_tx.try_send(StreamFrame::Session {
+        session_id: server_session_id.clone(),
+    });
+
+    // B11: relay so back-end `Session` frames (backend token) update the record
+    // without racing with the initial synthetic frame above.
     let relay_runs = Arc::clone(&runs_ref);
-    let relay_request_id = request_id.clone();
+    let relay_sid = server_session_id.clone();
     let relay_outer_tx = outer_tx.clone();
     tokio::spawn(async move {
         while let Some(frame) = inner_rx.recv().await {
+            // When the backend emits its own session id, store it as the resume
+            // token but do NOT forward another Session frame (we already sent one).
             if let StreamFrame::Session { ref session_id } = frame {
                 let mut runs = relay_runs.lock().unwrap();
-                if let Some(r) = runs.get_mut(&relay_request_id) {
-                    if r.session_id.is_none() {
-                        r.session_id = Some(session_id.clone());
+                if let Some(r) = runs.get_mut(&relay_sid) {
+                    if r.backend_session_id.is_none() {
+                        r.backend_session_id = Some(session_id.clone());
                     }
                 }
+                // Suppress the duplicate Session frame from the backend.
+                continue;
             }
             if relay_outer_tx.send(frame).await.is_err() {
                 break;
             }
         }
     });
+
     let tx = outer_tx;
-    let request_id_clone = request_id.clone();
+    let sid_clone = server_session_id.clone();
 
     let task = tokio::task::spawn(async move {
         let mut options = RunOptions::new()
             .with_yolo(yolo)
             .with_stream(true)
             .with_timeout(timeout);
-        if let Some(ref sid) = session_id_in {
-            options = options.with_session_id(sid);
+        // Pass the backend resume token (not the server id) so external CLIs
+        // receive the id they originally issued (e.g. claude --resume <token>).
+        if let Some(ref backend_sid) = backend_session_id_for_run {
+            options = options.with_session_id(backend_sid);
         }
         if let Some(m) = model {
             options = options.with_model(m);
@@ -546,7 +597,7 @@ pub(super) fn spawn_run(
         let blocking_handle =
             tokio::task::spawn_blocking(move || run_fn(agent, content, options, tx_inner));
 
-        // B12: server-level wall-clock timeout so the blocking path is bounded.
+        // B12: server-level wall-clock timeout.
         let outcome: Result<RunFnOutcome, RunError> = tokio::select! {
             timed_out = tokio::time::timeout(timeout, blocking_handle) => {
                 match timed_out {
@@ -556,7 +607,7 @@ pub(super) fn spawn_run(
                             message: "Run exceeded timeout".to_string(),
                         }).await;
                         let mut runs = runs_ref.lock().unwrap();
-                        if let Some(r) = runs.get_mut(&request_id_clone) {
+                        if let Some(r) = runs.get_mut(&sid_clone) {
                             r.status = RunStatus::Idle;
                             r.last_active_at = Utc::now();
                             r.abort_handle = None;
@@ -572,7 +623,7 @@ pub(super) fn spawn_run(
                                 tracing::error!("spawn_blocking join error: {}", join_err);
                             }
                             let mut runs = runs_ref.lock().unwrap();
-                            if let Some(r) = runs.get_mut(&request_id_clone) {
+                            if let Some(r) = runs.get_mut(&sid_clone) {
                                 r.status = RunStatus::Idle;
                                 r.last_active_at = Utc::now();
                                 r.abort_handle = None;
@@ -584,7 +635,7 @@ pub(super) fn spawn_run(
             }
             _ = tx.closed() => {
                 let mut runs = runs_ref.lock().unwrap();
-                if let Some(r) = runs.get_mut(&request_id_clone) {
+                if let Some(r) = runs.get_mut(&sid_clone) {
                     r.status = RunStatus::Idle;
                     r.last_active_at = Utc::now();
                     r.abort_handle = None;
@@ -597,15 +648,14 @@ pub(super) fn spawn_run(
             Ok(out) => {
                 {
                     let mut runs = runs_ref.lock().unwrap();
-                    if let Some(r) = runs.get_mut(&request_id_clone) {
-                        if r.session_id.is_none() {
-                            r.session_id = out.session_id.clone();
+                    if let Some(r) = runs.get_mut(&sid_clone) {
+                        if r.backend_session_id.is_none() {
+                            r.backend_session_id = out.session_id.clone();
                         }
                         r.stderr_tail = out.stderr_tail.clone();
                         r.last_exit_code = Some(out.exit_code);
                     }
                 }
-                // E2: emit an error frame for non-zero exits with captured stderr.
                 if out.exit_code != 0 && !out.stderr_tail.is_empty() {
                     let code = classify_error_code(&out.stderr_tail).to_string();
                     let _ = tx
@@ -626,7 +676,7 @@ pub(super) fn spawn_run(
 
         {
             let mut runs = runs_ref.lock().unwrap();
-            if let Some(r) = runs.get_mut(&request_id_clone) {
+            if let Some(r) = runs.get_mut(&sid_clone) {
                 r.status = RunStatus::Idle;
                 r.last_active_at = Utc::now();
                 r.abort_handle = None;
@@ -644,12 +694,12 @@ pub(super) fn spawn_run(
 
     {
         let mut runs = state.runs.lock().unwrap();
-        if let Some(r) = runs.get_mut(&request_id) {
+        if let Some(r) = runs.get_mut(&server_session_id) {
             r.abort_handle = Some(task.abort_handle());
         }
     }
     drop(task);
-    Ok((rx, request_id))
+    Ok((rx, server_session_id))
 }
 
 // ── handlers ──────────────────────────────────────────────────────────────────
@@ -670,7 +720,7 @@ pub(super) async fn messages_handler(
     if let Some(err) = validate_request(&body, &state) {
         return err;
     }
-    let (rx, request_id) = match spawn_run(&state, &body) {
+    let (rx, server_session_id) = match spawn_run(&state, &body) {
         Ok(v) => v,
         Err(resp) => return resp,
     };
@@ -678,18 +728,18 @@ pub(super) async fn messages_handler(
         ResponseMode::Sse => {
             let stream = spawn_frame_forwarder(rx, {
                 let runs = Arc::clone(&state.runs);
-                let request_id = request_id.clone();
+                let server_session_id = server_session_id.clone();
                 move |saw_error| {
                     runs.lock()
                         .unwrap()
-                        .get(&request_id)
+                        .get(&server_session_id)
                         .and_then(|r| r.last_exit_code)
                         .unwrap_or(if saw_error { 1 } else { 0 })
                 }
             });
             sse_response_with_headers(stream, None)
         }
-        ResponseMode::Sync => sync_response(rx, Arc::clone(&state.runs), request_id).await,
+        ResponseMode::Sync => sync_response(rx, Arc::clone(&state.runs), server_session_id).await,
         ResponseMode::NotAcceptable => unreachable!(),
     }
 }
@@ -698,7 +748,7 @@ pub(super) async fn messages_handler(
 async fn sync_response(
     mut rx: tokio::sync::mpsc::Receiver<StreamFrame>,
     runs: Arc<Mutex<HashMap<String, RunRecord>>>,
-    request_id: String,
+    server_session_id: String,
 ) -> Response {
     let mut session_id: Option<String> = None;
     let mut content = String::new();
@@ -752,10 +802,7 @@ async fn sync_response(
 
     let (record_stderr, record_exit) = {
         let guard = runs.lock().unwrap();
-        if let Some(r) = guard.get(&request_id) {
-            if session_id.is_none() {
-                session_id.clone_from(&r.session_id);
-            }
+        if let Some(r) = guard.get(&server_session_id) {
             (r.stderr_tail.clone(), r.last_exit_code)
         } else {
             (String::new(), None)
@@ -803,10 +850,10 @@ async fn sync_response(
 pub(super) async fn list_runs_handler(State(state): State<AppState>) -> impl IntoResponse {
     let runs = state.runs.lock().unwrap();
     let sessions: Vec<RunSummary> = runs
-        .values()
-        .filter(|r| r.status != RunStatus::Closed)
-        .map(|r| RunSummary {
-            session_id: r.session_id.clone(),
+        .iter()
+        .filter(|(_, r)| r.status != RunStatus::Closed)
+        .map(|(sid, r)| RunSummary {
+            session_id: sid.clone(),
             agent: r.agent.clone(),
             status: r.status.clone(),
             started_at: r.started_at,
@@ -825,13 +872,13 @@ pub(super) async fn get_run_handler(
     Path(session_id): Path<String>,
 ) -> impl IntoResponse {
     let runs = state.runs.lock().unwrap();
-    let found = runs
-        .values()
-        .find(|r| r.session_id.as_deref() == Some(&session_id) && r.status != RunStatus::Closed);
-    match found {
+    match runs
+        .get(&session_id)
+        .filter(|r| r.status != RunStatus::Closed)
+    {
         Some(r) => {
             let resp = RunSummary {
-                session_id: r.session_id.clone(),
+                session_id: session_id.clone(),
                 agent: r.agent.clone(),
                 status: r.status.clone(),
                 started_at: r.started_at,
@@ -856,35 +903,27 @@ pub(super) async fn delete_run_handler(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> impl IntoResponse {
-    let abort_handles: Vec<tokio::task::AbortHandle> = {
+    let abort_handle: Option<tokio::task::AbortHandle> = {
         let mut runs = state.runs.lock().unwrap();
-        let matching_keys: Vec<String> = runs
-            .iter()
-            .filter_map(|(k, r)| {
-                if r.session_id.as_deref() == Some(&session_id) && r.status != RunStatus::Closed {
-                    Some(k.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if matching_keys.is_empty() {
-            return error_response(
-                StatusCode::NOT_FOUND,
-                "session_not_found",
-                "Session not found",
-            );
-        }
-        matching_keys
-            .into_iter()
-            .filter_map(|k| {
-                let r = runs.get_mut(&k).unwrap();
+        match runs.get_mut(&session_id) {
+            None
+            | Some(RunRecord {
+                status: RunStatus::Closed,
+                ..
+            }) => {
+                return error_response(
+                    StatusCode::NOT_FOUND,
+                    "session_not_found",
+                    "Session not found",
+                );
+            }
+            Some(r) => {
                 r.status = RunStatus::Closed;
                 r.abort_handle.take()
-            })
-            .collect()
+            }
+        }
     };
-    for handle in abort_handles {
+    if let Some(handle) = abort_handle {
         handle.abort();
     }
     let resp = DeleteSessionResponse {

--- a/tests/serve/serve_smoke_test.rs
+++ b/tests/serve/serve_smoke_test.rs
@@ -202,8 +202,9 @@ async fn test_api_root_redirect() {
 
 #[tokio::test]
 async fn test_new_then_resume_then_new_flow() {
-    // The stub mints "stub-session-1" the first time options.session_id is
-    // None; on resume it echoes whatever id the client supplied.
+    // The stub back-end mints a fixed "stub-session-1" backend token, but the
+    // *server* now mints its own stable UUID as the map key. Clients must use
+    // the server-emitted session_id, not the backend token.
     let run_fn = make_stub_run_fn_with_session(
         vec![StreamFrame::Text {
             content: "hello".to_string(),
@@ -214,7 +215,7 @@ async fn test_new_then_resume_then_new_flow() {
     let client = reqwest::Client::new();
     let base = format!("http://127.0.0.1:{}", port);
 
-    // ── 1. First turn: no session_id → server mints + returns it ──
+    // ── 1. First turn: no session_id → server mints + returns a UUID ──
     let resp = client
         .post(format!("{}/api/v1/messages", base))
         .json(&serde_json::json!({"agent": "aikit", "content": "hi"}))
@@ -232,7 +233,7 @@ async fn test_new_then_resume_then_new_flow() {
     let text = resp.text().await.unwrap();
 
     let sid1 = parse_session_id(&text).expect("first turn must emit an event: session frame");
-    assert_eq!(sid1, "stub-session-1");
+    assert!(!sid1.is_empty(), "server must mint a non-empty session_id");
     assert!(
         text.contains("event: text"),
         "stream must contain the stub text frame; got:\n{}",
@@ -244,7 +245,7 @@ async fn test_new_then_resume_then_new_flow() {
         text
     );
 
-    // The session should now be listable under its id.
+    // The session should now be listable under its server-minted id.
     tokio::time::sleep(Duration::from_millis(50)).await;
     let resp = client
         .get(format!("{}/api/v1/sessions/{}", base, sid1))
@@ -257,7 +258,7 @@ async fn test_new_then_resume_then_new_flow() {
     assert_eq!(body["agent"], "aikit");
     assert_eq!(body["status"], "idle");
 
-    // ── 2. Second turn: same session_id → stub echoes that id back ──
+    // ── 2. Second turn: same session_id → server returns the same UUID ──
     let resp = client
         .post(format!("{}/api/v1/messages", base))
         .json(&serde_json::json!({
@@ -270,13 +271,10 @@ async fn test_new_then_resume_then_new_flow() {
         .unwrap();
     assert_eq!(resp.status(), 200);
     let text = resp.text().await.unwrap();
-    let sid2 = parse_session_id(&text).expect("resume must echo session id");
-    assert_eq!(sid2, sid1, "resume must reuse the supplied session_id");
+    let sid2 = parse_session_id(&text).expect("resume must emit a session frame");
+    assert_eq!(sid2, sid1, "resume must return the same server session_id");
 
-    // ── 3. Third turn: no session_id again → mint a fresh one ──
-    // (Our stub uses a fixed mint id; swap in a different one mid-test by
-    // restarting the server is overkill. The contract we check here is that
-    // omitting session_id triggers a fresh `session` frame.)
+    // ── 3. Third turn: no session_id again → a fresh, different UUID ──
     let resp = client
         .post(format!("{}/api/v1/messages", base))
         .json(&serde_json::json!({"agent": "aikit", "content": "new topic"}))
@@ -286,7 +284,11 @@ async fn test_new_then_resume_then_new_flow() {
     assert_eq!(resp.status(), 200);
     let text = resp.text().await.unwrap();
     let sid3 = parse_session_id(&text).expect("third turn must emit a session frame");
-    assert_eq!(sid3, "stub-session-1");
+    assert!(!sid3.is_empty(), "server must mint a non-empty session_id");
+    assert_ne!(
+        sid3, sid1,
+        "new conversation must have a different session_id"
+    );
 }
 
 #[tokio::test]
@@ -329,7 +331,10 @@ async fn test_accept_application_json_returns_sync() {
     );
 
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body["session_id"], "sync-session-1");
+    let sid = body["session_id"]
+        .as_str()
+        .expect("session_id must be present");
+    assert!(!sid.is_empty(), "server must emit a session_id");
     assert_eq!(body["content"], "Hello, world!");
     assert_eq!(body["exit_code"], 0);
     assert!(
@@ -363,14 +368,19 @@ async fn test_accept_application_json_resume() {
         .unwrap();
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body["session_id"], "sync-resume-test");
+    let sid = body["session_id"]
+        .as_str()
+        .expect("session_id must be present")
+        .to_string();
+    assert!(!sid.is_empty(), "server must emit a session_id");
 
+    // Resume uses the server-minted UUID, not the stub's backend token.
     let resp = client
         .post(format!("{}/api/v1/messages", base))
         .header("Accept", "application/json")
         .json(&serde_json::json!({
             "agent": "aikit",
-            "session_id": "sync-resume-test",
+            "session_id": sid,
             "content": "again",
         }))
         .send()
@@ -378,7 +388,10 @@ async fn test_accept_application_json_resume() {
         .unwrap();
     assert_eq!(resp.status(), 200);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body["session_id"], "sync-resume-test");
+    assert_eq!(
+        body["session_id"], sid,
+        "resume must return the same server session_id"
+    );
     assert_eq!(body["content"], "ok");
 }
 
@@ -592,7 +605,8 @@ async fn test_list_sessions_includes_completed_run() {
         .send()
         .await
         .unwrap();
-    let _ = resp.text().await.unwrap();
+    let text = resp.text().await.unwrap();
+    let sid = parse_session_id(&text).expect("must emit a session frame");
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -606,7 +620,7 @@ async fn test_list_sessions_includes_completed_run() {
     let list = body["sessions"].as_array().unwrap();
     assert!(
         list.iter()
-            .any(|s| s["session_id"] == "stub-list-test" && s["agent"] == "aikit"),
+            .any(|s| s["session_id"] == sid && s["agent"] == "aikit"),
         "list must include the just-completed session; got: {:?}",
         list
     );
@@ -628,12 +642,14 @@ async fn test_delete_session() {
         .send()
         .await
         .unwrap();
-    let _ = resp.text().await.unwrap();
+    let text = resp.text().await.unwrap();
+    // Capture the server-minted session_id — needed for DELETE and GET.
+    let sid = parse_session_id(&text).expect("must emit a session frame");
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let resp = client
-        .delete(format!("{}/api/v1/sessions/stub-delete-test", base))
+        .delete(format!("{}/api/v1/sessions/{}", base, sid))
         .send()
         .await
         .unwrap();
@@ -643,7 +659,7 @@ async fn test_delete_session() {
 
     // Subsequent GET is 404.
     let resp = client
-        .get(format!("{}/api/v1/sessions/stub-delete-test", base))
+        .get(format!("{}/api/v1/sessions/{}", base, sid))
         .send()
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- **B10**: CLI backend tool invocations were invisible in the SSE stream. `codex`/`opencode` emit `(MessageRole::Tool, MessageKind::Message)` for tool calls — the missing match arm in `agent_event_to_frame` is added, mapping it to `StreamFrame::ToolUse`. Two new unit tests cover both the `(Tool, Message)` → `ToolUse` and the existing `(Tool, ToolOutput)` → `ToolResult` arms.

- **B3**: `runs: HashMap<String, RunRecord>` was keyed by per-turn `request_id` UUID, causing N rows for N turns of the same session. `spawn_run` now upserts: new sessions mint a stable server `session_id` UUID, resume turns update the existing record in place. `GET/DELETE /api/v1/sessions/{id}` are now O(1) and always address exactly one record. `RunRecord.session_id` removed; `RunRecord.backend_session_id` stores the backend's own resume token separately.

- **B5**: Non-aikit backends never emitted a `session` frame, making resume impossible from the API. `spawn_run` now emits `StreamFrame::Session { session_id }` immediately as the first frame (before any backend output) using the server-minted UUID. The relay task suppresses the duplicate `Session` frame from the backend and stores its token as `backend_session_id` for `--resume` passthrough. All six backends now always return a stable, resolvable `session_id`.

## Test plan

- [x] `cargo build -p aikit-cli` — clean
- [x] `cargo clippy -p aikit-cli -- -D warnings` — clean
- [x] `cargo test --test serve_smoke_test` — 24/24 pass (5 tests updated to capture server-minted UUIDs)
- [x] `cargo test -p aikit-cli --lib` — 136 pass, 1 ignored (7 pre-existing package-publish environment failures unrelated to this change)
- [x] Full pre-push suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)