### PR TITLE
fix(sdk): pass stdin marker to opencode run

### DIFF
--- a/aikit-sdk/src/runner/argv.rs
+++ b/aikit-sdk/src/runner/argv.rs
@@ -305,9 +305,16 @@ mod tests {
         assert!(argv.contains(&OsString::from("opencode")));
         assert!(argv.contains(&OsString::from("run")));
         assert!(!argv.contains(&OsString::from("test prompt")));
+        assert!(argv.contains(&OsString::from("-")));
         assert!(argv.contains(&OsString::from("-m")));
         assert!(argv.contains(&OsString::from("zai-coding-plan/glm-4.7")));
         assert!(argv.contains(&OsString::from("--dangerously-skip-permissions")));
+        let run_pos = argv.iter().position(|a| a == "run").unwrap();
+        let dash_pos = argv.iter().position(|a| a == "-").unwrap();
+        assert!(
+            run_pos < dash_pos,
+            "stdin marker must follow run subcommand"
+        );
     }
 
     #[test]
@@ -336,6 +343,7 @@ mod tests {
         assert!(argv.contains(&OsString::from("opencode")));
         assert!(argv.contains(&OsString::from("run")));
         assert!(!argv.contains(&OsString::from("test prompt")));
+        assert_eq!(*argv.last().unwrap(), OsString::from("-"));
         assert!(argv.contains(&OsString::from("--format")));
         assert!(argv.contains(&OsString::from("json")));
         assert!(!argv.contains(&OsString::from("--json")));

--- a/aikit-sdk/src/runner/backends/opencode.rs
+++ b/aikit-sdk/src/runner/backends/opencode.rs
@@ -1,4 +1,7 @@
-//! OpenCode backend: `opencode run --format json` over a subprocess.
+//! OpenCode backend: `opencode run --format json -` over a subprocess.
+//!
+//! The prompt is written to stdin; `-` tells `opencode run` to read the message
+//! from stdin (same pattern as `codex exec --json -- -`).
 
 use std::ffi::OsString;
 
@@ -155,5 +158,6 @@ pub(crate) fn argv(ctx: ArgvCtx) -> Vec<OsString> {
         argv.extend_from_slice(&[OsString::from("--format"), OsString::from("json")]);
     }
     SPEC.push_session_flag(&mut argv, ctx.session_id);
+    argv.push(OsString::from("-"));
     argv
 }


### PR DESCRIPTION
## Summary
- Append `-` as the final positional argument when spawning `opencode run`, so the prompt written to stdin is actually consumed
- Without this marker, `opencode run` prints help and exits, breaking unattended flows like `gscp`

## Test plan
- [x] `cargo test -p aikit-sdk opencode` (11 unit + 5 integration tests pass)
- [x] Built release binary and verified end-to-end:
  ```bash
  aikit agent run -a opencode -p "Reply with exactly: FIXED" -m "zai-coding-plan/glm-5.1" --yolo --events
  ```
  Returns assistant message instead of opencode help text