### PR TITLE
Phase 2.1: post-remediation follow-up cleanup (IPv6 bind, tool-policy 422, update pin note, config compat)

### DIFF
--- a/aikit-sdk/src/aikit_agent_adapter.rs
+++ b/aikit-sdk/src/aikit_agent_adapter.rs
@@ -746,3 +746,48 @@ fn error_code(message: &str) -> String {
         .unwrap_or("E_AIKIT_LLM_REQUEST_FAILED")
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // F3 (D2 follow-up): the previously-untested middle link of the tool-policy
+    // chain. serve builds `RunOptions.session_persona` from
+    // `SendMessageRequest.tools`/`disallowed_tools` (tested serve-side); this
+    // must land on `AgentConfig.session_persona`, which `loop_runner::build_tools`
+    // then hard-filters (tested in aikit-agent). This closes the gap between "the
+    // request carries the JSON" and "the agent actually filters the tool".
+    #[test]
+    fn disallowed_tools_flow_from_run_options_into_agent_config_persona() {
+        let tmp = tempfile::tempdir().unwrap();
+        let persona = serde_json::json!({
+            "name": "",
+            "description": "",
+            "prompt": "",
+            "tools": null,
+            "disallowed_tools": ["run_bash"],
+        });
+        let options = RunOptions::default().with_session_persona(persona);
+        let mut config = config_for_injected_gateway(tmp.path().to_path_buf(), &options);
+
+        apply_session_options(&options, &mut config);
+
+        let sp = config
+            .session_persona
+            .expect("session persona should be applied onto AgentConfig");
+        assert_eq!(sp.disallowed_tools, Some(vec!["run_bash".to_string()]));
+        assert!(sp.tools.is_none());
+    }
+
+    #[test]
+    fn no_tool_policy_leaves_persona_unset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let options = RunOptions::default();
+        let mut config = config_for_injected_gateway(tmp.path().to_path_buf(), &options);
+        apply_session_options(&options, &mut config);
+        assert!(
+            config.session_persona.is_none(),
+            "no tool policy → persona unset → full toolset (ADR 0012 default)"
+        );
+    }
+}

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -1143,6 +1143,15 @@ fn deploy_skills_for_agent(
 /// command/subagent/skill deployment (that needs an `--ai` selection this
 /// command doesn't take); it does refresh agent-agnostic `[artifacts]`
 /// mappings, matching `install`'s default (unscoped) artifact copy.
+/// A source ref is "pinned" when it is not one of the mutable default branches —
+/// i.e. a tag, version, or commit the package was deliberately installed at. An
+/// unpinned `owner/repo` install resolves to `main`, so those never trip this.
+/// (F5: `update` only tracks the installed ref; this tells `update` when to warn
+/// that a pin means it won't see newer releases.)
+fn is_pinned_ref(ref_: &str) -> bool {
+    !matches!(ref_, "main" | "master" | "HEAD" | "develop" | "trunk")
+}
+
 pub async fn execute_update(args: UpdateArgs) -> Result<(), AikError> {
     use crate::core::filesystem::AikDirectory;
 
@@ -1259,6 +1268,18 @@ async fn execute_update_with_client(
                     "Package '{}' is already up to date (version {}).",
                     args.package, installed_package.package.version
                 ),
+            }
+            // F5: a version/tag/commit-pinned install only ever re-checks THAT ref,
+            // so a newer upstream release will never be seen here. Honor the pin,
+            // but say so explicitly — "up to date" must never quietly mean "pinned"
+            // (D7: never misreport state).
+            if is_pinned_ref(&ref_) {
+                println!(
+                    "Note: this install is pinned to '{}', so `update` only tracks that ref. \
+                     To follow the latest release, reinstall from an unpinned source \
+                     (e.g. `owner/repo` without a version).",
+                    ref_
+                );
             }
             return Ok(());
         }
@@ -1559,6 +1580,18 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    // F5: pinned refs (tag/version/commit) trip the "won't track newer releases"
+    // note; the default branches an unpinned `owner/repo` resolves to do not.
+    #[test]
+    fn is_pinned_ref_distinguishes_pins_from_default_branches() {
+        assert!(is_pinned_ref("1.2.3"));
+        assert!(is_pinned_ref("v2.0.0"));
+        assert!(is_pinned_ref("a1b2c3d")); // commit sha
+        assert!(!is_pinned_ref("main"));
+        assert!(!is_pinned_ref("master"));
+        assert!(!is_pinned_ref("HEAD"));
+    }
 
     // Note: `execute_update_with_client` takes an already-resolved
     // `AikDirectory` rather than calling `AikDirectory::find()` itself

--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -149,6 +149,32 @@ pub(super) fn error_response(status: StatusCode, code: &str, message: &str) -> R
         .into_response()
 }
 
+// ── bind address / fail-closed policy ───────────────────────────────────────────
+
+/// Build the `SocketAddr` to bind, bracketing a bare IPv6 host.
+///
+/// `format!("{host}:{port}")` is ambiguous for IPv6 — `--host ::1` yields the
+/// unparseable `"::1:8787"`. If `host` parses as a bare `Ipv6Addr` (no brackets),
+/// wrap it as `[host]` so `--host ::1` / `--host ::` work without the caller
+/// having to know the bracket syntax.
+fn build_bind_addr(host: &str, port: u16) -> anyhow::Result<SocketAddr> {
+    let host_part = if host.parse::<std::net::Ipv6Addr>().is_ok() {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+    format!("{host_part}:{port}")
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid address {host}:{port}: {e}"))
+}
+
+/// SEC-2 / ADR 0012: refuse to start when bound to a non-loopback address with
+/// no `--api-key`, unless the operator explicitly passed `--insecure`. Works for
+/// both IPv4 and IPv6 (`Ipv6Addr::is_loopback` covers `::1`).
+fn startup_should_fail_closed(addr: &SocketAddr, has_api_key: bool, insecure: bool) -> bool {
+    !addr.ip().is_loopback() && !has_api_key && !insecure
+}
+
 // ── ServeEvent → SSE ──────────────────────────────────────────────────────────
 
 /// Serialize one [`ServeEvent`] to an SSE `Event`.
@@ -582,9 +608,7 @@ pub async fn execute_with_run_fn(args: ServeArgs, run_fn: RunFn) -> anyhow::Resu
         insecure: args.insecure,
     };
 
-    let addr: SocketAddr = format!("{}:{}", config.host, config.port)
-        .parse()
-        .map_err(|e| anyhow::anyhow!("invalid address {}:{}: {}", config.host, config.port, e))?;
+    let addr = build_bind_addr(&config.host, config.port)?;
 
     // SEC-2 / ADR 0012: the sandbox is the trust boundary for the agent
     // itself (full toolset, `run_bash` included — see ADR 0012); the
@@ -596,7 +620,7 @@ pub async fn execute_with_run_fn(args: ServeArgs, run_fn: RunFn) -> anyhow::Resu
     // `--insecure`. Loopback stays open by default (matches ADR 0012:
     // existing local consumers — agentrt, the optimization loop, chat BFFs
     // — are unaffected).
-    if !addr.ip().is_loopback() && config.api_key.is_none() && !config.insecure {
+    if startup_should_fail_closed(&addr, config.api_key.is_some(), config.insecure) {
         anyhow::bail!(
             "refusing to start: {addr} is a non-loopback bind address and no --api-key was \
              set. aikit serve has no host-safety sandboxing of its own (see ADR 0012 — the \
@@ -739,6 +763,46 @@ mod tests {
             stream: AgentEventStream::Stdout,
             payload,
         }
+    }
+
+    // -- F1: IPv6 bind address + fail-closed policy ------------------------
+
+    #[test]
+    fn build_bind_addr_brackets_bare_ipv6() {
+        // The reported bug: `--host ::1` built `"::1:8787"`, which does not parse.
+        let addr = build_bind_addr("::1", 8787).expect("bare IPv6 loopback should parse");
+        assert!(addr.is_ipv6());
+        assert!(addr.ip().is_loopback());
+        assert_eq!(addr.port(), 8787);
+
+        let any = build_bind_addr("::", 8787).expect("bare IPv6 any-addr should parse");
+        assert!(any.is_ipv6() && !any.ip().is_loopback());
+
+        // Already-bracketed and IPv4 forms still work unchanged.
+        assert!(build_bind_addr("[::1]", 8787).is_ok());
+        assert!(build_bind_addr("127.0.0.1", 8787)
+            .unwrap()
+            .ip()
+            .is_loopback());
+        assert!(!build_bind_addr("0.0.0.0", 8787).unwrap().ip().is_loopback());
+    }
+
+    #[test]
+    fn startup_fail_closed_covers_ipv4_and_ipv6() {
+        let v6_loop = build_bind_addr("::1", 8787).unwrap();
+        let v6_any = build_bind_addr("::", 8787).unwrap();
+        let v4_loop = build_bind_addr("127.0.0.1", 8787).unwrap();
+        let v4_any = build_bind_addr("0.0.0.0", 8787).unwrap();
+
+        // Loopback (v4 or v6) stays open with no key.
+        assert!(!startup_should_fail_closed(&v6_loop, false, false));
+        assert!(!startup_should_fail_closed(&v4_loop, false, false));
+        // Non-loopback with no key and no --insecure fails closed (v4 and v6).
+        assert!(startup_should_fail_closed(&v6_any, false, false));
+        assert!(startup_should_fail_closed(&v4_any, false, false));
+        // A key, or explicit --insecure, allows a non-loopback bind.
+        assert!(!startup_should_fail_closed(&v6_any, true, false));
+        assert!(!startup_should_fail_closed(&v4_any, false, true));
     }
 
     /// Extract `(tag, inner_json)` the same way `serve_event_to_sse` does,

--- a/src/cli/serve/run_session.rs
+++ b/src/cli/serve/run_session.rs
@@ -408,6 +408,23 @@ pub(super) fn validate_request(
             ),
         ));
     }
+    // D2 (follow-up F2): a tool policy is only enforced by the in-process `aikit`
+    // backend (via AgentPersona.tools/disallowed_tools). For external CLI backends
+    // there is no honoring path, so accepting `tools`/`disallowed_tools` silently
+    // would let a caller believe it constrained the agent when it did not. Fail
+    // loud instead — a dropped least-privilege request must never look accepted.
+    let has_tool_policy = body.tools.is_some() || body.disallowed_tools.is_some();
+    if has_tool_policy && body.agent != "aikit" {
+        return Some(error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "unsupported_tool_policy",
+            &format!(
+                "tools/disallowed_tools are only enforced for the in-process 'aikit' backend; \
+                 agent '{}' cannot apply a tool policy. Omit the field or use agent 'aikit'.",
+                body.agent
+            ),
+        ));
+    }
     if let Some(ref sid) = body.session_id {
         let in_memory = state.runs.lock().unwrap().contains_key(sid.as_str());
         if !in_memory {
@@ -1375,6 +1392,88 @@ mod tests {
         let resp = validate_request(&body, &state, &runnable);
         std::env::remove_var("AIKIT_SESSIONS_DIR");
         assert!(resp.is_some(), "unknown-but-safe id must still 404");
+    }
+
+    // --- F2 (D2 follow-up): tool policy on a non-aikit agent is rejected ---
+
+    #[test]
+    fn tool_policy_on_external_agent_is_rejected() {
+        use crate::cli::serve::ServeConfig;
+        use std::collections::HashMap;
+        use std::sync::{Arc, Mutex};
+
+        let state = AppState {
+            runs: Arc::new(Mutex::new(HashMap::new())),
+            live_sessions: Arc::new(Mutex::new(HashMap::new())),
+            pending_live_sessions: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            config: ServeConfig {
+                host: "127.0.0.1".into(),
+                port: 8787,
+                run_timeout_secs: 30,
+                max_sessions: 10,
+                api_key: None,
+                insecure: false,
+            },
+            run_fn: make_stub_run_fn(),
+            auth_cache: Arc::new(Mutex::new(None)),
+        };
+        let runnable = vec![
+            AgentInfo {
+                key: "aikit".to_string(),
+                name: "aikit".to_string(),
+                available: true,
+                auth: AuthStatus::Unknown,
+                capabilities: None,
+            },
+            AgentInfo {
+                key: "claude".to_string(),
+                name: "claude".to_string(),
+                available: true,
+                auth: AuthStatus::Unknown,
+                capabilities: None,
+            },
+        ];
+
+        let make = |agent: &str, tools: Option<Vec<String>>| SendMessageRequest {
+            agent: agent.into(),
+            session_id: None,
+            content: "hi".into(),
+            model: None,
+            yolo: false,
+            tools,
+            disallowed_tools: None,
+        };
+
+        // A tool policy on an external CLI backend is rejected loud (422), not
+        // silently dropped.
+        let rejected = validate_request(
+            &make("claude", Some(vec!["read_file".into()])),
+            &state,
+            &runnable,
+        );
+        assert!(
+            rejected.is_some(),
+            "tool policy on 'claude' must be rejected"
+        );
+
+        // The same policy on the in-process aikit backend is NOT rejected on
+        // tool-policy grounds (it's the one backend that enforces it).
+        let accepted = validate_request(
+            &make("aikit", Some(vec!["read_file".into()])),
+            &state,
+            &runnable,
+        );
+        assert!(
+            accepted.is_none(),
+            "tool policy on 'aikit' must be accepted"
+        );
+
+        // No tool policy → external agent is fine.
+        let no_policy = validate_request(&make("claude", None), &state, &runnable);
+        assert!(
+            no_policy.is_none(),
+            "external agent without a tool policy is fine"
+        );
     }
 
     // --- BUG-10: a Closed session must not be resurrectable via POST ---

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -221,3 +221,23 @@ pub fn save_config(config: &AikConfig) -> Result<(), Box<dyn std::error::Error>>
 
     config.save(&config_path)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // F8 (ARCH-2 follow-up): ARCH-2 removed `AikConfig.agents`. An older on-disk
+    // config that still carries an `[agents.*]` table must still load — `AikConfig`
+    // has no `#[serde(deny_unknown_fields)]`, so unknown keys are ignored rather
+    // than erroring. This guards against a field deletion silently breaking an
+    // existing user's config on upgrade.
+    #[test]
+    fn aik_config_ignores_removed_agents_field() {
+        let mut toml_str = toml::to_string(&AikConfig::default()).unwrap();
+        toml_str.push_str("\n[agents.claude]\nname = \"Claude\"\nrequires_cli = true\n");
+        let parsed: AikConfig =
+            toml::from_str(&toml_str).expect("old config with an [agents] table must still load");
+        assert_eq!(parsed.version, AikConfig::default().version);
+        assert_eq!(parsed.install_dir, AikConfig::default().install_dir);
+    }
+}


### PR DESCRIPTION
## Phase 2.1 — post-remediation follow-up cleanup

Closes the **Tier-A** follow-ups identified after PR #104 (tracked in `specs/phase2-followups-2026-07-21.md`).
All are small, low-risk, and close gaps the Phase 1/2 adversarial reviews surfaced. **1367 tests pass,
0 failures; clippy + rustfmt clean.**

| # | What | Why |
|---|------|-----|
| **F1** | serve brackets a bare IPv6 host (`build_bind_addr`); fail-closed predicate tested for IPv4 **and** IPv6 | `--host ::1` produced the unparseable `"::1:8787"` — serve wouldn't start on IPv6 loopback. Real bug (failed safe, silently). |
| **F2** | tool policy on a non-`aikit` agent → **422 `unsupported_tool_policy`** | `tools`/`disallowed_tools` are only enforced by the in-process `aikit` backend; accepting them for `claude`/`codex` with `200 OK` let a caller believe it constrained the agent when it didn't (D7: never misreport state). Fail loud. |
| **F3** | test for the tool-policy middle link (`RunOptions.session_persona` → `AgentConfig.session_persona`) | Serve-side plumbing and the `build_tools` filter were each tested, but not the adapter link between them; the chain is now proven end to end. |
| **F5** | `aikit update` prints an honest note when the tracked ref is a pin | A package installed as `owner/repo@1.2.3` re-checks only that ref, so "up to date" was technically true but misleading. Decision: **honor the pin, but say so.** |
| **F8** | regression test: dropping `AikConfig.agents` (ARCH-2) doesn't break loading an old config | `AikConfig` has no `deny_unknown_fields`, so serde ignores the removed key — this pins that so a future field deletion can't silently break existing configs. |

**F4** (named-event SSE assertions) needed no work — the `serve/mod.rs` unit tests already pin every
canonical SSE tag by name (tool_use/tool_result/subagent/context_compressed/step_finish/stream_message).

### Not in this PR (deferred, by the plan in the spec)
- **F6** skillopt mock `EvalRunner` (real `train_skill` loop coverage) — defer unless skillopt is active.
- **A1 ARCH-3** — `Session`/`ControlHandle` trait seam (Phase 3). The one strategic item; to be grilled
  before committing (scope/risk of the bidirectional-session refactor).
- **A2** MCP allowlist (by-design per ADR 0012), **A3** net-new specs, **A4** aikit-py, **A5** hygiene —
  demand-driven / opportunistic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
