### PR TITLE
refactor(sessions): ARCH-3 — unify live sessions behind a LiveSession trait

### DIFF
--- a/aikit-sdk/src/lib.rs
+++ b/aikit-sdk/src/lib.rs
@@ -474,6 +474,8 @@ pub use runner::{
 pub use runner::{
     open_codex_session, CodexControlHandle, CodexSession, CodexSessionError, CodexSessionOptions,
 };
+#[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
+pub use runner::{ControlError, LiveSession};
 
 // Re-export host tool types so cli-framework can depend on aikit-sdk alone.
 pub use aikit_agent::{HostToolDefinition, HostToolProvider};

--- a/aikit-sdk/src/runner/live_session.rs
+++ b/aikit-sdk/src/runner/live_session.rs
@@ -1,0 +1,172 @@
+//! ARCH-3: the `LiveSession` control-surface trait.
+//!
+//! Bidirectional sessions (`claude_session`, `codex_session`) expose near-identical
+//! control handles. Callers — `aikit serve`'s live-session registry and the
+//! `aikit session` REPL — drive them through the same three core operations
+//! (`send_turn` / `interrupt` / `disconnect`) plus two Claude-only operations
+//! (`set_model` / `get_context_usage`). This trait unifies that surface so both
+//! call sites store a `Box<dyn LiveSession>` instead of matching on the agent,
+//! and so the session/serve lifecycle can be exercised against a fake in tests
+//! without a real `claude`/`codex` binary.
+//!
+//! Backend-specific operations are **default methods** that return
+//! [`ControlError::Unsupported`]; a backend that supports one overrides it. This
+//! mirrors the `try_*` + `not_supported` shape the serve layer already used.
+//!
+//! The trait is HTTP-free: it returns a domain [`ControlError`]; the serve layer
+//! maps `Unsupported` → 422 and `Backend` → 500, the CLI maps to `anyhow`.
+
+/// Error from a [`LiveSession`] control operation.
+#[derive(Debug)]
+pub enum ControlError {
+    /// The backend does not support this operation (e.g. `set_model` on Codex).
+    /// The `&'static str` is the operation name, for the caller's message.
+    Unsupported(&'static str),
+    /// The backend rejected the operation or its control channel is closed.
+    Backend(String),
+}
+
+impl std::fmt::Display for ControlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ControlError::Unsupported(op) => write!(f, "{op} is not supported by this agent"),
+            ControlError::Backend(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for ControlError {}
+
+/// The control surface of a live bidirectional agent session.
+///
+/// Object-safe: methods take owned `String` (not `impl Into<String>`) so the
+/// trait can be used as `Box<dyn LiveSession>` / `Arc<dyn LiveSession>`.
+pub trait LiveSession: Send {
+    /// Send a follow-up user turn on the same session.
+    fn send_turn(&self, text: String) -> Result<(), ControlError>;
+
+    /// Interrupt the current turn.
+    fn interrupt(&self) -> Result<(), ControlError>;
+
+    /// Disconnect and tear down the session.
+    fn disconnect(&self) -> Result<(), ControlError>;
+
+    /// Switch the model mid-session. Unsupported by default.
+    fn set_model(&self, _model: Option<String>) -> Result<(), ControlError> {
+        Err(ControlError::Unsupported("set_model"))
+    }
+
+    /// Fetch context-window usage. Unsupported by default.
+    fn get_context_usage(&self) -> Result<serde_json::Value, ControlError> {
+        Err(ControlError::Unsupported("get_context_usage"))
+    }
+}
+
+#[cfg(feature = "claude-control")]
+impl LiveSession for super::claude_session::ControlHandle {
+    fn send_turn(&self, text: String) -> Result<(), ControlError> {
+        self.send_turn(text)
+            .map_err(|e| ControlError::Backend(e.to_string()))
+    }
+    fn interrupt(&self) -> Result<(), ControlError> {
+        super::claude_session::ControlHandle::interrupt(self)
+            .map_err(|e| ControlError::Backend(e.to_string()))
+    }
+    fn disconnect(&self) -> Result<(), ControlError> {
+        super::claude_session::ControlHandle::disconnect(self)
+            .map_err(|e| ControlError::Backend(e.to_string()))
+    }
+    fn set_model(&self, model: Option<String>) -> Result<(), ControlError> {
+        super::claude_session::ControlHandle::set_model(self, model)
+            .map_err(|e| ControlError::Backend(e.to_string()))
+    }
+    fn get_context_usage(&self) -> Result<serde_json::Value, ControlError> {
+        super::claude_session::ControlHandle::get_context_usage(self)
+            .map_err(|e| ControlError::Backend(e.to_string()))
+    }
+}
+
+#[cfg(feature = "codex-app-server")]
+impl LiveSession for super::codex_session::CodexControlHandle {
+    fn send_turn(&self, text: String) -> Result<(), ControlError> {
+        self.send_turn(text)
+            .map_err(|e| ControlError::Backend(e.to_string()))
+    }
+    fn interrupt(&self) -> Result<(), ControlError> {
+        super::codex_session::CodexControlHandle::interrupt(self)
+            .map_err(|e| ControlError::Backend(e.to_string()))
+    }
+    fn disconnect(&self) -> Result<(), ControlError> {
+        super::codex_session::CodexControlHandle::disconnect(self)
+            .map_err(|e| ControlError::Backend(e.to_string()))
+    }
+    // set_model / get_context_usage fall through to the default `Unsupported`.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// A `LiveSession` double: records calls, never touches a real process.
+    #[derive(Default)]
+    struct FakeSession {
+        turns: AtomicUsize,
+        interrupts: AtomicUsize,
+        disconnects: AtomicUsize,
+    }
+    impl LiveSession for FakeSession {
+        fn send_turn(&self, _text: String) -> Result<(), ControlError> {
+            self.turns.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn interrupt(&self) -> Result<(), ControlError> {
+            self.interrupts.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn disconnect(&self) -> Result<(), ControlError> {
+            self.disconnects.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn core_ops_dispatch_through_boxed_trait() {
+        let s: Box<dyn LiveSession> = Box::new(FakeSession::default());
+        assert!(s.send_turn("hi".into()).is_ok());
+        assert!(s.interrupt().is_ok());
+        assert!(s.disconnect().is_ok());
+    }
+
+    #[test]
+    fn backend_specific_ops_default_to_unsupported() {
+        let s: Box<dyn LiveSession> = Box::new(FakeSession::default());
+        assert!(matches!(
+            s.set_model(None),
+            Err(ControlError::Unsupported("set_model"))
+        ));
+        assert!(matches!(
+            s.get_context_usage(),
+            Err(ControlError::Unsupported("get_context_usage"))
+        ));
+    }
+
+    #[test]
+    fn arc_dyn_is_usable_from_multiple_holders() {
+        let s: Arc<dyn LiveSession> = Arc::new(FakeSession::default());
+        let a = Arc::clone(&s);
+        let b = Arc::clone(&s);
+        assert!(a.send_turn("one".into()).is_ok());
+        assert!(b.interrupt().is_ok());
+    }
+
+    #[test]
+    fn control_error_display_names_the_op() {
+        assert_eq!(
+            ControlError::Unsupported("set_model").to_string(),
+            "set_model is not supported by this agent"
+        );
+        assert_eq!(ControlError::Backend("boom".into()).to_string(), "boom");
+    }
+}

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -8,6 +8,8 @@ pub mod capabilities;
 pub mod claude_session;
 #[cfg(feature = "codex-app-server")]
 pub mod codex_session;
+#[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
+pub mod live_session;
 pub mod transport;
 pub mod types;
 pub mod usage;
@@ -36,6 +38,8 @@ pub use codex_session::{
 // Shared approval types; available when at least one session feature is enabled.
 #[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
 pub use approval::{PermissionCallback, ToolApprovalRequest, ToolDecision};
+#[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
+pub use live_session::{ControlError, LiveSession};
 pub use usage::aggregate_token_usage;
 
 use std::process::Child;

--- a/src/cli/serve/live_session.rs
+++ b/src/cli/serve/live_session.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use aikit_sdk::{
     open_claude_session, open_codex_session, ClaudeSessionError, ClaudeSessionOptions,
-    CodexControlHandle, CodexSessionError, CodexSessionOptions, ControlHandle,
+    CodexSessionError, CodexSessionOptions, ControlError, LiveSession,
 };
 use uuid::Uuid;
 
@@ -22,91 +22,31 @@ use super::{
     error_response, spawn_frame_forwarder, sse_response_with_headers, AppState, ServeEvent,
 };
 
-// ── control abstraction ───────────────────────────────────────────────────────
+// ── control-error mapping ─────────────────────────────────────────────────────
 
-/// Wraps either a [`ControlHandle`] (Claude) or [`CodexControlHandle`] (Codex)
-/// so both can be stored in a unified registry.
-pub(super) enum LiveSessionControl {
-    Claude(ControlHandle),
-    Codex(CodexControlHandle),
-}
-
-impl LiveSessionControl {
-    pub(super) fn interrupt(&self) {
-        match self {
-            LiveSessionControl::Claude(h) => {
-                let _ = h.interrupt();
-            }
-            LiveSessionControl::Codex(h) => {
-                let _ = h.interrupt();
-            }
-        }
-    }
-
-    pub(super) fn disconnect(&self) {
-        match self {
-            LiveSessionControl::Claude(h) => {
-                let _ = h.disconnect();
-            }
-            LiveSessionControl::Codex(h) => {
-                let _ = h.disconnect();
-            }
-        }
-    }
-
-    /// Switch model mid-session. Returns `Err(response)` for backends that
-    /// do not support this action.
-    #[allow(clippy::result_large_err)]
-    pub(super) fn try_set_model(&self, model: Option<String>) -> Result<(), Response> {
-        match self {
-            LiveSessionControl::Claude(h) => {
-                let _ = h.set_model(model);
-                Ok(())
-            }
-            LiveSessionControl::Codex(_) => Err(error_response(
-                StatusCode::UNPROCESSABLE_ENTITY,
-                "not_supported",
-                "set_model is only supported for Claude sessions",
-            )),
-        }
-    }
-
-    /// Send a follow-up turn on the same session. Both backends support this.
-    pub(super) fn send_turn(&self, text: String) {
-        match self {
-            LiveSessionControl::Claude(h) => {
-                let _ = h.send_turn(text);
-            }
-            LiveSessionControl::Codex(h) => {
-                let _ = h.send_turn(text);
-            }
-        }
-    }
-
-    /// Get context-window usage (Claude only). Returns `Err(response)` for
-    /// backends that do not support this action.
-    #[allow(clippy::result_large_err)]
-    pub(super) fn try_get_context_usage(&self) -> Result<serde_json::Value, Response> {
-        match self {
-            LiveSessionControl::Claude(h) => h.get_context_usage().map_err(|e| {
-                error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "context_usage_error",
-                    &e.to_string(),
-                )
-            }),
-            LiveSessionControl::Codex(_) => Err(error_response(
-                StatusCode::UNPROCESSABLE_ENTITY,
-                "not_supported",
-                "get_context_usage is only supported for Claude sessions",
-            )),
+/// Map a [`ControlError`] from a [`LiveSession`] operation onto an HTTP response.
+///
+/// `Unsupported` (e.g. `set_model` on Codex) → 422 `not_supported`; a backend
+/// error → 500 with the caller-supplied `backend_code`. The per-backend match
+/// this replaced is gone: the `LiveSession` trait already reports "unsupported"
+/// uniformly via its default methods.
+#[allow(clippy::result_large_err)]
+fn control_error_response(e: ControlError, backend_code: &'static str) -> Response {
+    match e {
+        ControlError::Unsupported(op) => error_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "not_supported",
+            &format!("{op} is not supported by this agent"),
+        ),
+        ControlError::Backend(msg) => {
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, backend_code, &msg)
         }
     }
 }
 
 // ── registry types ────────────────────────────────────────────────────────────
 
-#[derive(Clone, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub(super) enum LiveSessionStatus {
     Active,
@@ -116,7 +56,7 @@ pub(super) enum LiveSessionStatus {
 pub(super) struct LiveSessionRecord {
     pub session_id: String,
     pub agent_key: String,
-    pub control: LiveSessionControl,
+    pub control: Box<dyn LiveSession>,
     pub status: LiveSessionStatus,
     pub created_at: DateTime<Utc>,
 }
@@ -270,7 +210,7 @@ pub(super) async fn create_live_session_handler(
 
     let session_id = Uuid::new_v4().to_string();
 
-    let (control, events_rx) = match body.agent.as_str() {
+    let (control, events_rx): (Box<dyn LiveSession>, _) = match body.agent.as_str() {
         "claude" => {
             let opts = ClaudeSessionOptions {
                 model: body.model.clone(),
@@ -282,7 +222,7 @@ pub(super) async fn create_live_session_handler(
             match open_claude_session(&body.prompt, opts) {
                 Ok(s) => {
                     let (ctrl, evts) = s.into_parts();
-                    (LiveSessionControl::Claude(ctrl), evts)
+                    (Box::new(ctrl), evts)
                 }
                 Err(ClaudeSessionError::Connect(msg)) => {
                     return error_response(
@@ -307,7 +247,7 @@ pub(super) async fn create_live_session_handler(
             match open_codex_session(&body.prompt, opts) {
                 Ok(s) => {
                     let (ctrl, evts) = s.into_parts();
-                    (LiveSessionControl::Codex(ctrl), evts)
+                    (Box::new(ctrl), evts)
                 }
                 Err(CodexSessionError::Connect(msg)) => {
                     return error_response(
@@ -414,16 +354,16 @@ pub(super) async fn live_session_control_handler(
 
     match body.action.as_str() {
         "interrupt" => {
-            record.control.interrupt();
+            let _ = record.control.interrupt();
             ok_action("interrupt")
         }
         "disconnect" => {
-            record.control.disconnect();
+            let _ = record.control.disconnect();
             ok_action("disconnect")
         }
-        "set_model" => match record.control.try_set_model(body.model.clone()) {
+        "set_model" => match record.control.set_model(body.model.clone()) {
             Ok(_) => ok_action("set_model"),
-            Err(resp) => resp,
+            Err(e) => control_error_response(e, "session_error"),
         },
         "send_turn" => {
             let text = body.text.as_deref().unwrap_or("").trim().to_string();
@@ -434,17 +374,17 @@ pub(super) async fn live_session_control_handler(
                     "send_turn requires a non-empty 'text' field",
                 );
             }
-            record.control.send_turn(text);
+            let _ = record.control.send_turn(text);
             ok_action("send_turn")
         }
-        "get_context_usage" => match record.control.try_get_context_usage() {
+        "get_context_usage" => match record.control.get_context_usage() {
             Ok(usage) => (
                 StatusCode::OK,
                 [(axum::http::header::CONTENT_TYPE, "application/json")],
                 usage.to_string(),
             )
                 .into_response(),
-            Err(resp) => resp,
+            Err(e) => control_error_response(e, "context_usage_error"),
         },
         other => error_response(
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -489,7 +429,7 @@ pub(super) async fn delete_live_session_handler(
             "Live session not found",
         );
     };
-    record.control.disconnect();
+    let _ = record.control.disconnect();
     record.status = LiveSessionStatus::Closed;
     let resp = DeleteLiveSessionResponse {
         session_id,
@@ -601,6 +541,264 @@ mod tests {
             pending.load(Ordering::SeqCst),
             0,
             "all reservations should be released"
+        );
+    }
+
+    // ── ARCH-3: control-endpoint & lifecycle coverage via a fake session ────────
+    //
+    // Before ARCH-3 the registry held concrete `ControlHandle`/`CodexControlHandle`
+    // values, each backed by a real `claude`/`codex` subprocess — so the control
+    // and eviction handlers were untestable without a live binary. With
+    // `Box<dyn LiveSession>` we insert a `FakeSession` record directly and drive
+    // the handlers.
+
+    #[derive(Default)]
+    struct Counters {
+        turns: AtomicUsize,
+        interrupts: AtomicUsize,
+        disconnects: AtomicUsize,
+        set_models: AtomicUsize,
+    }
+
+    struct FakeSession {
+        c: Arc<Counters>,
+        supports_set_model: bool,
+    }
+
+    impl LiveSession for FakeSession {
+        fn send_turn(&self, _text: String) -> Result<(), ControlError> {
+            self.c.turns.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn interrupt(&self) -> Result<(), ControlError> {
+            self.c.interrupts.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn disconnect(&self) -> Result<(), ControlError> {
+            self.c.disconnects.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn set_model(&self, _model: Option<String>) -> Result<(), ControlError> {
+            if self.supports_set_model {
+                self.c.set_models.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            } else {
+                Err(ControlError::Unsupported("set_model"))
+            }
+        }
+        fn get_context_usage(&self) -> Result<serde_json::Value, ControlError> {
+            Ok(serde_json::json!({ "used_tokens": 1 }))
+        }
+    }
+
+    fn state_with_session(
+        control: Box<dyn LiveSession>,
+        status: LiveSessionStatus,
+    ) -> (crate::cli::serve::AppState, String) {
+        use crate::cli::serve::ServeConfig;
+        let sid = "sess-1".to_string();
+        let live: LiveSessions = Arc::new(std::sync::Mutex::new(HashMap::new()));
+        live.lock().unwrap().insert(
+            sid.clone(),
+            LiveSessionRecord {
+                session_id: sid.clone(),
+                agent_key: "claude".into(),
+                control,
+                status,
+                created_at: Utc::now(),
+            },
+        );
+        let state = crate::cli::serve::AppState {
+            runs: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            live_sessions: live,
+            pending_live_sessions: Arc::new(AtomicUsize::new(0)),
+            config: ServeConfig {
+                host: "127.0.0.1".into(),
+                port: 8787,
+                run_timeout_secs: 30,
+                max_sessions: 10,
+                api_key: None,
+                insecure: false,
+            },
+            run_fn: crate::cli::serve::run_session::make_stub_run_fn(),
+            auth_cache: Arc::new(std::sync::Mutex::new(None)),
+        };
+        (state, sid)
+    }
+
+    fn control_req(action: &str, text: Option<&str>) -> LiveSessionControlRequest {
+        LiveSessionControlRequest {
+            action: action.into(),
+            model: None,
+            text: text.map(Into::into),
+        }
+    }
+
+    async fn control_status(
+        state: &crate::cli::serve::AppState,
+        sid: &str,
+        req: LiveSessionControlRequest,
+    ) -> StatusCode {
+        live_session_control_handler(State(state.clone()), Path(sid.to_string()), Json(req))
+            .await
+            .into_response()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn control_dispatches_core_ops_to_the_session() {
+        let c = Arc::new(Counters::default());
+        let (state, sid) = state_with_session(
+            Box::new(FakeSession {
+                c: Arc::clone(&c),
+                supports_set_model: true,
+            }),
+            LiveSessionStatus::Active,
+        );
+
+        assert_eq!(
+            control_status(&state, &sid, control_req("interrupt", None)).await,
+            StatusCode::OK
+        );
+        assert_eq!(
+            control_status(&state, &sid, control_req("send_turn", Some("hello"))).await,
+            StatusCode::OK
+        );
+        assert_eq!(
+            control_status(&state, &sid, control_req("set_model", None)).await,
+            StatusCode::OK
+        );
+
+        assert_eq!(c.interrupts.load(Ordering::SeqCst), 1);
+        assert_eq!(c.turns.load(Ordering::SeqCst), 1);
+        assert_eq!(c.set_models.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn send_turn_with_blank_text_is_422_and_never_reaches_the_session() {
+        let c = Arc::new(Counters::default());
+        let (state, sid) = state_with_session(
+            Box::new(FakeSession {
+                c: Arc::clone(&c),
+                supports_set_model: true,
+            }),
+            LiveSessionStatus::Active,
+        );
+        assert_eq!(
+            control_status(&state, &sid, control_req("send_turn", Some("   "))).await,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(c.turns.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn set_model_on_unsupported_backend_is_422_not_supported() {
+        let c = Arc::new(Counters::default());
+        let (state, sid) = state_with_session(
+            Box::new(FakeSession {
+                c: Arc::clone(&c),
+                supports_set_model: false,
+            }),
+            LiveSessionStatus::Active,
+        );
+        assert_eq!(
+            control_status(&state, &sid, control_req("set_model", None)).await,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(c.set_models.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn get_context_usage_returns_200_json_from_the_session() {
+        let c = Arc::new(Counters::default());
+        let (state, sid) = state_with_session(
+            Box::new(FakeSession {
+                c,
+                supports_set_model: true,
+            }),
+            LiveSessionStatus::Active,
+        );
+        assert_eq!(
+            control_status(&state, &sid, control_req("get_context_usage", None)).await,
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn control_on_unknown_session_is_404() {
+        let c = Arc::new(Counters::default());
+        let (state, _sid) = state_with_session(
+            Box::new(FakeSession {
+                c,
+                supports_set_model: true,
+            }),
+            LiveSessionStatus::Active,
+        );
+        assert_eq!(
+            control_status(&state, "does-not-exist", control_req("interrupt", None)).await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn control_on_closed_session_is_410_gone() {
+        let c = Arc::new(Counters::default());
+        let (state, sid) = state_with_session(
+            Box::new(FakeSession {
+                c: Arc::clone(&c),
+                supports_set_model: true,
+            }),
+            LiveSessionStatus::Closed,
+        );
+        assert_eq!(
+            control_status(&state, &sid, control_req("interrupt", None)).await,
+            StatusCode::GONE
+        );
+        assert_eq!(c.interrupts.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn delete_disconnects_evicts_and_hides_from_list() {
+        let c = Arc::new(Counters::default());
+        let (state, sid) = state_with_session(
+            Box::new(FakeSession {
+                c: Arc::clone(&c),
+                supports_set_model: true,
+            }),
+            LiveSessionStatus::Active,
+        );
+
+        // Session shows in the listing while Active.
+        let listed = list_live_sessions_handler(State(state.clone()))
+            .await
+            .into_response();
+        assert_eq!(listed.status(), StatusCode::OK);
+
+        // Delete → disconnect called once, record marked Closed.
+        let del = delete_live_session_handler(State(state.clone()), Path(sid.clone()))
+            .await
+            .into_response();
+        assert_eq!(del.status(), StatusCode::OK);
+        assert_eq!(c.disconnects.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            state.live_sessions.lock().unwrap()[&sid].status,
+            LiveSessionStatus::Closed
+        );
+
+        // A closed session is filtered out of the listing.
+        let listed_after = list_live_sessions_handler(State(state.clone()))
+            .await
+            .into_response();
+        let bytes = axum::body::to_bytes(listed_after.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["sessions"].as_array().unwrap().len(), 0);
+
+        // And further control on it is 410 Gone.
+        assert_eq!(
+            control_status(&state, &sid, control_req("send_turn", Some("x"))).await,
+            StatusCode::GONE
         );
     }
 }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -8,7 +8,7 @@ use std::io::{self, BufRead, Write as IoWrite};
 
 use aikit_sdk::{
     open_claude_session, open_codex_session, AgentEvent, AgentEventPayload, ClaudeSessionOptions,
-    CodexSessionOptions,
+    CodexSessionOptions, LiveSession,
 };
 
 // ── public args ───────────────────────────────────────────────────────────────
@@ -35,70 +35,35 @@ pub struct ListSessionsArgs {
 // ── new session ───────────────────────────────────────────────────────────────
 
 pub fn execute_new(args: NewSessionArgs) -> anyhow::Result<()> {
-    use std::sync::Arc;
-
-    type SendFn = Box<dyn Fn(&str) -> anyhow::Result<()>>;
-    type VoidFn = Box<dyn Fn()>;
     type Events = std::sync::mpsc::Receiver<aikit_sdk::AgentEvent>;
 
-    // Both control handles share the same method names, so we normalise them
-    // to closures and drive the rest of the function identically.
-    let (send_turn_fn, interrupt_fn, disconnect_fn, events): (SendFn, VoidFn, VoidFn, Events) =
-        match args.agent.as_str() {
-            "claude" => {
-                let opts = ClaudeSessionOptions {
-                    model: args.model.clone(),
-                    ..ClaudeSessionOptions::default()
-                };
-                let (ctrl, evts) = open_claude_session(&args.prompt, opts)
-                    .map_err(|e| anyhow::anyhow!("Failed to open claude session: {e}"))?
-                    .into_parts();
-                let ctrl = Arc::new(ctrl);
-                let c1 = Arc::clone(&ctrl);
-                let c2 = Arc::clone(&ctrl);
-                let c3 = Arc::clone(&ctrl);
-                (
-                    Box::new(move |text: &str| {
-                        c1.send_turn(text).map_err(|e| anyhow::anyhow!("{e}"))
-                    }),
-                    Box::new(move || {
-                        let _ = c2.interrupt();
-                    }),
-                    Box::new(move || {
-                        let _ = c3.disconnect();
-                    }),
-                    evts,
-                )
-            }
-            "codex" => {
-                let opts = CodexSessionOptions::default()
-                    .with_approval_policy(args.approval_policy.clone())
-                    .with_sandbox(args.sandbox.clone());
-                let (ctrl, evts) = open_codex_session(&args.prompt, opts)
-                    .map_err(|e| anyhow::anyhow!("Failed to open codex session: {e}"))?
-                    .into_parts();
-                let ctrl = Arc::new(ctrl);
-                let c1 = Arc::clone(&ctrl);
-                let c2 = Arc::clone(&ctrl);
-                let c3 = Arc::clone(&ctrl);
-                (
-                    Box::new(move |text: &str| {
-                        c1.send_turn(text).map_err(|e| anyhow::anyhow!("{e}"))
-                    }),
-                    Box::new(move || {
-                        let _ = c2.interrupt();
-                    }),
-                    Box::new(move || {
-                        let _ = c3.disconnect();
-                    }),
-                    evts,
-                )
-            }
-            other => anyhow::bail!(
-                "Unknown agent '{}'. Live sessions support 'claude' or 'codex'.",
-                other
-            ),
-        };
+    // Both backends expose the same `LiveSession` control surface, so we box the
+    // concrete handle behind `dyn LiveSession` and drive the REPL identically.
+    let (session, events): (Box<dyn LiveSession>, Events) = match args.agent.as_str() {
+        "claude" => {
+            let opts = ClaudeSessionOptions {
+                model: args.model.clone(),
+                ..ClaudeSessionOptions::default()
+            };
+            let (ctrl, evts) = open_claude_session(&args.prompt, opts)
+                .map_err(|e| anyhow::anyhow!("Failed to open claude session: {e}"))?
+                .into_parts();
+            (Box::new(ctrl), evts)
+        }
+        "codex" => {
+            let opts = CodexSessionOptions::default()
+                .with_approval_policy(args.approval_policy.clone())
+                .with_sandbox(args.sandbox.clone());
+            let (ctrl, evts) = open_codex_session(&args.prompt, opts)
+                .map_err(|e| anyhow::anyhow!("Failed to open codex session: {e}"))?
+                .into_parts();
+            (Box::new(ctrl), evts)
+        }
+        other => anyhow::bail!(
+            "Unknown agent '{}'. Live sessions support 'claude' or 'codex'.",
+            other
+        ),
+    };
 
     let events_thread = std::thread::spawn({
         let ndjson = args.events;
@@ -109,18 +74,14 @@ pub fn execute_new(args: NewSessionArgs) -> anyhow::Result<()> {
         }
     });
 
-    run_repl(&send_turn_fn, &interrupt_fn, &disconnect_fn)?;
+    run_repl(session.as_ref())?;
     let _ = events_thread.join();
     Ok(())
 }
 
 /// Drive a multi-turn REPL loop.  Reads lines from stdin; `/interrupt` sends
 /// an interrupt; an empty EOF or `/quit` ends the session.
-fn run_repl(
-    send_turn: &dyn Fn(&str) -> anyhow::Result<()>,
-    interrupt: &dyn Fn(),
-    disconnect: &dyn Fn(),
-) -> anyhow::Result<()> {
+fn run_repl(session: &dyn LiveSession) -> anyhow::Result<()> {
     let stdin = io::stdin();
     loop {
         print!("> ");
@@ -139,11 +100,15 @@ fn run_repl(
         }
         match text {
             "/quit" | "/exit" => break,
-            "/interrupt" => interrupt(),
-            _ => send_turn(text)?,
+            "/interrupt" => {
+                let _ = session.interrupt();
+            }
+            _ => session
+                .send_turn(text.to_string())
+                .map_err(|e| anyhow::anyhow!("{e}"))?,
         }
     }
-    disconnect();
+    let _ = session.disconnect();
     Ok(())
 }
 


### PR DESCRIPTION
## ARCH-3 (Phase 3) — `LiveSession` trait seam

Collapses the two hand-rolled control-dispatch clones behind a single `LiveSession` trait in `aikit-sdk`. Both call sites — `aikit serve`'s live-session registry and the `aikit session` REPL — now hold a `Box<dyn LiveSession>` / `&dyn LiveSession` instead of matching on the agent, and the session/serve lifecycle is finally testable against a fake with **no real `claude`/`codex` binary**.

### Scope (grilled & locked)
Only **(a) the live-session trait** is in scope. The audit's ARCH-3 also floated:
- **(b)** routing the in-process `aikit` agent through a `Transport` (delete `if agent_key == "aikit"`) — **out**: pokes the Phase-1-hardened one-shot path for a cosmetic gain.
- **(c)** folding the D4 `RunCancelHandle` into the trait — **out**: one-shot cancel = hard-kill subprocess; live teardown = graceful `disconnect()`. Different semantics; merging them conflates the two.

### What changed
| Layer | Before | After |
|---|---|---|
| aikit-sdk | two ~800-LOC session clones, no shared surface | `LiveSession` trait + domain `ControlError` (HTTP-free); impls for Claude `ControlHandle` (all 5 ops) and Codex `CodexControlHandle` (3 core + 2 default-`Unsupported`) |
| serve | `LiveSessionControl` enum + 5 hand-written match arms | `control: Box<dyn LiveSession>`; one `control_error_response` (Unsupported->422 `not_supported`, Backend->500) — **error codes preserved** |
| cli | closure-triple normalization (`SendFn`/`VoidFn`x2) | `run_repl(&dyn LiveSession)` |

Backend-specific ops (`set_model` / `get_context_usage`) are trait **default methods** returning `Unsupported`, mirroring the old `try_*` + `not_supported` shape exactly.

### The payoff — newly-possible tests
A `FakeSession` double + **7 `#[tokio::test]` handler/lifecycle tests** that were impossible before (the registry used to hold real subprocess handles):
core-op dispatch, blank-turn 422 (never reaches the session), unsupported `set_model` 422, context-usage 200, unknown-session 404, closed-session 410 Gone, `delete` -> disconnect -> evict -> hidden-from-list -> subsequent control 410.

### Verification
`scripts/run-tests.sh` (CI parity): version-sync, build, fmt, clippy, nextest, lib-release, workspace integration all pass. `clippy --all-features` also clean. All new SDK + serve tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
