### PR TITLE
Audit follow-ups: F6 injectable EvalRunner + D2 session-persona rejection

### DIFF
--- a/aikit-sdk/src/runner/backend.rs
+++ b/aikit-sdk/src/runner/backend.rs
@@ -262,6 +262,19 @@ mod tests {
         );
     }
 
+    // ---- D2: tool-policy enforcement is a per-Backend capability ----
+
+    #[test]
+    fn only_aikit_supports_tool_policy() {
+        for &b in ALL {
+            assert_eq!(
+                b.capabilities().supports_tool_policy,
+                b == Backend::Aikit,
+                "supports_tool_policy for {b:?}"
+            );
+        }
+    }
+
     #[test]
     fn only_aikit_is_in_process() {
         for &b in ALL {

--- a/aikit-sdk/src/runner/backends/aikit.rs
+++ b/aikit-sdk/src/runner/backends/aikit.rs
@@ -25,7 +25,8 @@ pub(crate) const CAPABILITIES: BackendCapabilities = BackendCapabilities::NONE
     .with_resumable_sessions()
     .with_mcp_routing()
     .with_subagents()
-    .with_context_compression();
+    .with_context_compression()
+    .with_supports_tool_policy();
 
 /// aikit emits canonical events directly; there is no line Dialect to decode.
 pub(crate) fn decode(

--- a/aikit-sdk/src/runner/capabilities.rs
+++ b/aikit-sdk/src/runner/capabilities.rs
@@ -46,6 +46,11 @@ pub struct BackendCapabilities {
     /// `false` ⇒ no adapter is registered for this Backend; passive capture
     /// is unavailable, not merely empty. Spec 010.
     pub passive_capture: bool,
+    /// Enforces `AgentPersona.tools` / `disallowed_tools` (D2 / ADR 0012 least-privilege tool
+    /// policy) as a hard filter. `false` ⇒ a tool policy handed to this Backend is silently
+    /// unenforceable — callers threading a persona/tool-policy through `RunOptions` must reject
+    /// rather than accept-and-drop it. Currently only the in-process `aikit` Backend enforces it.
+    pub supports_tool_policy: bool,
 }
 
 impl BackendCapabilities {
@@ -63,6 +68,7 @@ impl BackendCapabilities {
         subagents: false,
         context_compression: false,
         passive_capture: false,
+        supports_tool_policy: false,
     };
 
     pub const fn with_bidirectional(mut self) -> Self {
@@ -113,6 +119,11 @@ impl BackendCapabilities {
     /// when the matching `aikit-session-capture` feature is on.
     pub const fn with_passive_capture(mut self) -> Self {
         self.passive_capture = true;
+        self
+    }
+    /// Declare that this Backend enforces `AgentPersona.tools` / `disallowed_tools` (D2).
+    pub const fn with_supports_tool_policy(mut self) -> Self {
+        self.supports_tool_policy = true;
         self
     }
 }

--- a/aikit-skillopt/src/lib.rs
+++ b/aikit-skillopt/src/lib.rs
@@ -7,7 +7,7 @@ pub use prompts::skill_prompts;
 
 use std::path::PathBuf;
 
-use aikit_evals::{AikitEvalRunner, CheckDefinition, ChecksScorer, EvalCase};
+use aikit_evals::{CheckDefinition, ChecksScorer, EvalCase, EvalRunner};
 use aikit_textgrad::training::{resume_training, run_training};
 
 /// All caller-supplied data for a new training run.
@@ -28,7 +28,14 @@ pub struct SkillOptInputs {
 }
 
 /// Run a complete training loop for a skill document from scratch.
-pub async fn train_skill(inputs: SkillOptInputs) -> anyhow::Result<TrainingOutcome> {
+///
+/// `runner` drives every eval-case execution the loop performs (initial score, per-step
+/// rollouts, gate re-scoring). Callers pass `&AikitEvalRunner` in production; tests inject a
+/// scripted double to exercise gate accept/reject dynamics deterministically.
+pub async fn train_skill(
+    inputs: SkillOptInputs,
+    runner: &dyn EvalRunner,
+) -> anyhow::Result<TrainingOutcome> {
     let mut artifact = SkillArtifact::from_existing(
         inputs.initial_skill_md,
         inputs.skill_name,
@@ -37,12 +44,11 @@ pub async fn train_skill(inputs: SkillOptInputs) -> anyhow::Result<TrainingOutco
     let scorer = ChecksScorer {
         checks: inputs.checks,
     };
-    let runner = AikitEvalRunner;
     run_training(
         &mut artifact,
         &inputs.suite,
         &scorer,
-        &runner,
+        runner,
         skill_prompts(),
         inputs.config,
         &inputs.run_dir,
@@ -55,6 +61,8 @@ pub async fn train_skill(inputs: SkillOptInputs) -> anyhow::Result<TrainingOutco
 ///
 /// The caller MUST supply the same `skill_name` and `target_agent` as the original run.
 /// `resume_training` restores the artifact text from `best_skill.md` in `run_dir`.
+/// See [`train_skill`] for the meaning of `runner`.
+#[allow(clippy::too_many_arguments)]
 pub async fn resume_skill(
     run_dir: PathBuf,
     initial_skill_md: String,
@@ -62,17 +70,17 @@ pub async fn resume_skill(
     suite: Vec<EvalCase>,
     checks: Vec<CheckDefinition>,
     config: RunConfig,
+    runner: &dyn EvalRunner,
 ) -> anyhow::Result<TrainingOutcome> {
     let mut artifact =
         SkillArtifact::from_existing(initial_skill_md, skill_name, config.target_agent.clone());
     let scorer = ChecksScorer { checks };
-    let runner = AikitEvalRunner;
     resume_training(
         &run_dir,
         &mut artifact,
         &suite,
         &scorer,
-        &runner,
+        runner,
         skill_prompts(),
     )
     .await
@@ -82,10 +90,164 @@ pub async fn resume_skill(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aikit_evals::EvalCase;
+    use aikit_evals::{
+        AikitEvalRunner, CaseResult, CaseRunOptions, CaseRunOutput, CaseStatus, CaseTrialsResult,
+        EvalCase, TrialResult,
+    };
     use aikit_textgrad::training::state::{init_run_dir, write_runtime_state, RuntimeState};
-    use aikit_textgrad::training::SlowUpdateMode;
+    use aikit_textgrad::training::{SlowUpdateMode, StepRecord};
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    // ---- ScriptedEvalRunner: injectable EvalRunner double (F6) ----
+    //
+    // Two independent trigger-expectation markers ("M1"/"M2"), scored with GateMetric::Soft,
+    // give three controllable score levels per scripted call: neither present = 0.0, one = 0.5,
+    // both = 1.0. This lets tests script realistic multi-step score trajectories (improve,
+    // regress, mixed) and observe the GATE's actual accept/reject decisions and best_score
+    // bookkeeping — coverage the old windsurf-agent no-op could never exercise, since every
+    // call there failed identically and no score ever changed.
+    #[derive(Clone, Copy)]
+    enum ScriptedOutcome {
+        Score0,
+        Score1,
+        Score2,
+        TimedOut,
+    }
+
+    impl ScriptedOutcome {
+        fn stdout(self) -> &'static [u8] {
+            match self {
+                ScriptedOutcome::Score0 | ScriptedOutcome::TimedOut => b"",
+                ScriptedOutcome::Score1 => b"M1",
+                ScriptedOutcome::Score2 => b"M1 M2",
+            }
+        }
+    }
+
+    /// Two checks of *different* kinds (not two `TriggerExpectation`s): every
+    /// `TriggerExpectation` reports the same fixed `check_name` ("trigger_expectation")
+    /// regardless of pattern, and the GATE path routes through `score_cases`'s
+    /// majority-vote-by-name aggregation, which collapses same-named results — so two
+    /// same-kind checks would silently merge into one and only ever yield 0.0/1.0. Distinct
+    /// check kinds keep them as two separate named results, giving a real 0.0/0.5/1.0 range.
+    fn score_markers() -> Vec<CheckDefinition> {
+        vec![
+            CheckDefinition::CommandContains {
+                pattern: "M1".to_string(),
+                required: true,
+            },
+            CheckDefinition::TriggerExpectation {
+                pattern: "M2".to_string(),
+                expected: true,
+                required: true,
+            },
+        ]
+    }
+
+    /// Pops one scripted outcome per `run_case` call, in call order: initial score, then per
+    /// step (rollout, gate). Panics on an exhausted queue — that means the test's assumed call
+    /// count has drifted from the loop's actual behavior, which is itself worth surfacing loudly.
+    struct ScriptedEvalRunner {
+        outcomes: Mutex<VecDeque<ScriptedOutcome>>,
+        calls: AtomicUsize,
+    }
+
+    impl ScriptedEvalRunner {
+        fn new(outcomes: Vec<ScriptedOutcome>) -> Self {
+            Self {
+                outcomes: Mutex::new(outcomes.into_iter().collect()),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl EvalRunner for ScriptedEvalRunner {
+        async fn run_case(
+            &self,
+            case: &EvalCase,
+            _opts: &CaseRunOptions,
+            _checks: &[CheckDefinition],
+        ) -> (CaseRunOutput, CaseResult, String) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let outcome = self.outcomes.lock().unwrap().pop_front().expect(
+                "ScriptedEvalRunner queue exhausted — expected call count no longer matches",
+            );
+            let output = CaseRunOutput {
+                stdout: outcome.stdout().to_vec(),
+                stderr: vec![],
+                exit_code: Some(0),
+                timed_out: matches!(outcome, ScriptedOutcome::TimedOut),
+            };
+            let result = CaseResult {
+                id: case.id.clone(),
+                status: CaseStatus::Passed,
+                command_count: Some(0),
+                input_tokens: None,
+                output_tokens: None,
+                check_results: vec![],
+                error_message: None,
+            };
+            (output, result, String::new())
+        }
+
+        async fn run_case_trials(
+            &self,
+            case: &EvalCase,
+            opts: &CaseRunOptions,
+            checks: &[CheckDefinition],
+            trial_count: u32,
+            _max_parallelism: Option<u32>,
+        ) -> CaseTrialsResult {
+            let mut trials = Vec::new();
+            for trial_id in 1..=trial_count {
+                let (_out, result, _trace) = self.run_case(case, opts, checks).await;
+                trials.push(TrialResult {
+                    trial_id,
+                    status: result.status,
+                    command_count: result.command_count,
+                    input_tokens: result.input_tokens,
+                    output_tokens: result.output_tokens,
+                    check_results: result.check_results,
+                    error_message: result.error_message,
+                });
+            }
+            let pass_count = trials
+                .iter()
+                .filter(|t| t.status == CaseStatus::Passed)
+                .count() as u32;
+            let total_trials = trial_count.max(1);
+            let pass_rate = pass_count as f64 / total_trials as f64;
+            let aggregated_status = if pass_rate >= opts.pass_threshold {
+                CaseStatus::Passed
+            } else {
+                CaseStatus::Failed
+            };
+            CaseTrialsResult {
+                id: case.id.clone(),
+                trials,
+                aggregated_status,
+                pass_count,
+                total_trials,
+                pass_rate,
+            }
+        }
+    }
+
+    /// Read and deserialize `run_dir/history.json`, written one `StepRecord` per accepted step.
+    async fn read_history(dir: &TempDir) -> Vec<StepRecord> {
+        let bytes = tokio::fs::read(dir.path().join("history.json"))
+            .await
+            .expect("history.json should exist after a run");
+        serde_json::from_slice(&bytes).expect("history.json should deserialize as Vec<StepRecord>")
+    }
 
     fn make_eval_case(id: &str, tags: &[&str]) -> EvalCase {
         EvalCase {
@@ -110,15 +272,12 @@ mod tests {
             gate_epsilon: 0.01,
             slow_update_mode: SlowUpdateMode::ForceAccept,
             protected_soft_cap_chars: 500,
-            // These are orchestration smoke tests: they verify train_skill/resume_skill wire
-            // up state, checkpoints, and best_skill.md — NOT a live optimization against a real
-            // agent. `windsurf` supports skill deployment (`skills: Some(".windsurf/skills")`, so
-            // materialize resolves a skill dir) but is NOT a runnable Backend, so the eval runner
-            // fails fast without spawning any subprocess: the loop is a deterministic no-op and
-            // best_skill.md == best_text. Previously these used "cursor-agent", which passed for
-            // the same reason (skill-capable, not runnable); ARCH-2's canonical "cursor" key
-            // turned them into slow (~10min), nondeterministic real-CLI runs. A follow-up should
-            // give train_skill an injectable mock EvalRunner for genuine loop coverage.
+            // `windsurf` supports skill deployment (`skills: Some(".windsurf/skills")`, so
+            // materialize resolves a skill dir) but is NOT a runnable Backend, so AikitEvalRunner
+            // fails fast without spawning any subprocess. Used only by the retained
+            // `test_train_skill_end_to_end`/`test_best_skill_md_content_matches_outcome` smoke
+            // tests below; the value is irrelevant to ScriptedEvalRunner-based tests, which never
+            // spawn a real agent regardless of this key (see F6 spec).
             target_agent: "windsurf".to_string(),
             target_model: None,
             optimizer_agent: "windsurf".to_string(),
@@ -143,12 +302,22 @@ mod tests {
         }
     }
 
+    /// Like [`make_inputs`], but wired for [`ScriptedEvalRunner`]: uses the two-marker checks
+    /// so scores are controllable, and `n_epochs` steps (batch=1, one train case) so the queue
+    /// has exactly one rollout+gate pair per epoch.
+    fn make_scripted_inputs(dir: &TempDir, n_epochs: u32) -> SkillOptInputs {
+        let mut inputs = make_inputs(dir);
+        inputs.checks = score_markers();
+        inputs.config.n_epochs = n_epochs;
+        inputs
+    }
+
     // AC-7: train_skill runs end-to-end and returns Ok with best_artifact_path = best_skill.md.
     #[tokio::test]
     async fn test_train_skill_end_to_end() {
         let dir = TempDir::new().unwrap();
         let inputs = make_inputs(&dir);
-        let result = train_skill(inputs).await;
+        let result = train_skill(inputs, &AikitEvalRunner).await;
         assert!(result.is_ok(), "train_skill failed: {result:?}");
         let outcome = result.unwrap();
         let expected_path = dir.path().join("best_skill.md");
@@ -161,7 +330,7 @@ mod tests {
     async fn test_best_skill_md_content_matches_outcome() {
         let dir = TempDir::new().unwrap();
         let inputs = make_inputs(&dir);
-        let outcome = train_skill(inputs).await.unwrap();
+        let outcome = train_skill(inputs, &AikitEvalRunner).await.unwrap();
         let on_disk = std::fs::read_to_string(&outcome.best_artifact_path).unwrap();
         assert_eq!(on_disk, outcome.best_text);
     }
@@ -199,6 +368,10 @@ mod tests {
             .await
             .unwrap();
 
+        // Empty queue: a completed run (epoch >= n_epochs) with no test cases must resume
+        // without ever consulting the runner. `ScriptedEvalRunner` panics on any pop, so this
+        // proves the short-circuit rather than merely asserting the outcome.
+        let runner = ScriptedEvalRunner::new(vec![]);
         let result = resume_skill(
             dir.path().to_path_buf(),
             "# Test Skill\n\nOriginal.".to_string(),
@@ -206,6 +379,7 @@ mod tests {
             suite,
             vec![],
             config,
+            &runner,
         )
         .await;
 
@@ -216,6 +390,11 @@ mod tests {
             "expected best_score 0.9, got {}",
             outcome.best_score
         );
+        assert_eq!(
+            runner.call_count(),
+            0,
+            "completed resume must not call the runner"
+        );
     }
 
     // AC-12: train_skill with zero selection cases returns TEXTGRAD_NO_SELECTION_CASES error.
@@ -224,7 +403,8 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let mut inputs = make_inputs(&dir);
         inputs.suite = vec![make_eval_case("train-1", &["train"])];
-        let result = train_skill(inputs).await;
+        // Validation fails before the runner is ever touched — empty queue proves it.
+        let result = train_skill(inputs, &ScriptedEvalRunner::new(vec![])).await;
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
         assert!(
@@ -239,13 +419,159 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let mut inputs = make_inputs(&dir);
         inputs.config.batch_size = 0;
-        let result = train_skill(inputs).await;
+        let result = train_skill(inputs, &ScriptedEvalRunner::new(vec![])).await;
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
         assert!(
             err.contains("TEXTGRAD_INVALID_CONFIG"),
             "expected TEXTGRAD_INVALID_CONFIG in: {err}"
         );
+    }
+
+    // ---- F6 payoff: genuine GATE accept/reject coverage via ScriptedEvalRunner ----
+
+    #[tokio::test]
+    async fn test_gate_accepts_improving_scores() {
+        use ScriptedOutcome::*;
+        let dir = TempDir::new().unwrap();
+        let inputs = make_scripted_inputs(&dir, 2);
+        let runner = ScriptedEvalRunner::new(vec![
+            Score0, // initial score = 0.0
+            Score1, Score1, // epoch0: rollout (irrelevant), gate = 0.5 -> accept (best=0.5)
+            Score1, Score2, // epoch1: rollout (irrelevant), gate = 1.0 -> accept (best=1.0)
+        ]);
+
+        let outcome = train_skill(inputs, &runner).await.unwrap();
+        assert!(
+            (outcome.best_score - 1.0).abs() < 1e-9,
+            "expected best_score 1.0, got {}",
+            outcome.best_score
+        );
+
+        let history = read_history(&dir).await;
+        assert_eq!(history.len(), 2);
+        assert!(
+            history[0].accepted && history[1].accepted,
+            "both steps should accept"
+        );
+        assert!((history[0].score_candidate - 0.5).abs() < 1e-9);
+        assert!((history[1].score_candidate - 1.0).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn test_gate_rejects_flat_or_regressing_scores() {
+        use ScriptedOutcome::*;
+        let dir = TempDir::new().unwrap();
+        let inputs = make_scripted_inputs(&dir, 2);
+        let runner = ScriptedEvalRunner::new(vec![
+            Score1, // initial score = 0.5
+            Score0, Score0, // epoch0: rollout, gate = 0.0 -> reject (best stays 0.5)
+            Score0, Score1, // epoch1: rollout, gate = 0.5 (not > 0.5+epsilon) -> reject
+        ]);
+
+        let outcome = train_skill(inputs, &runner).await.unwrap();
+        assert!(
+            (outcome.best_score - 0.5).abs() < 1e-9,
+            "expected best_score to stay at 0.5, got {}",
+            outcome.best_score
+        );
+
+        let history = read_history(&dir).await;
+        assert_eq!(history.len(), 2);
+        assert!(
+            !history[0].accepted && !history[1].accepted,
+            "neither step should accept"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gate_tracks_max_through_mixed_trajectory() {
+        use ScriptedOutcome::*;
+        let dir = TempDir::new().unwrap();
+        let inputs = make_scripted_inputs(&dir, 3);
+        let runner = ScriptedEvalRunner::new(vec![
+            Score0, // initial score = 0.0
+            Score1, Score1, // epoch0: gate = 0.5 -> accept (best=0.5)
+            Score1, Score0, // epoch1: gate = 0.0 -> reject (best stays 0.5)
+            Score1, Score2, // epoch2: gate = 1.0 -> accept (best=1.0)
+        ]);
+
+        let outcome = train_skill(inputs, &runner).await.unwrap();
+        assert!(
+            (outcome.best_score - 1.0).abs() < 1e-9,
+            "best_score must track the max seen (1.0), got {}",
+            outcome.best_score
+        );
+
+        let history = read_history(&dir).await;
+        assert_eq!(history.len(), 3);
+        let accepted: Vec<bool> = history.iter().map(|r| r.accepted).collect();
+        assert_eq!(
+            accepted,
+            vec![true, false, true],
+            "expected improve/reject/improve pattern, got {accepted:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gate_rejects_timed_out_rollout_without_panicking() {
+        use ScriptedOutcome::*;
+        let dir = TempDir::new().unwrap();
+        let inputs = make_scripted_inputs(&dir, 1);
+        let runner = ScriptedEvalRunner::new(vec![
+            Score1, // initial score = 0.5
+            Score1, TimedOut, // rollout (irrelevant), gate times out -> empty stdout -> 0.0
+        ]);
+
+        let outcome = train_skill(inputs, &runner).await.unwrap();
+        assert!(
+            (outcome.best_score - 0.5).abs() < 1e-9,
+            "a timed-out gate call must be treated as a reject, not crash the loop"
+        );
+
+        let history = read_history(&dir).await;
+        assert_eq!(history.len(), 1);
+        assert!(!history[0].accepted);
+    }
+
+    #[tokio::test]
+    async fn test_scripted_runner_run_case_trials_aggregates_pass_rate() {
+        // run_case_trials is never called by the training loop itself (only run_case is —
+        // see F6 spec), but ScriptedEvalRunner must still implement it correctly as a trait
+        // member, matching the house StubRunner/StubEvalRunner pattern.
+        use ScriptedOutcome::*;
+        let runner = ScriptedEvalRunner::new(vec![Score2, Score0, Score2]);
+        let case = make_eval_case("c1", &["train"]);
+        let opts = CaseRunOptions {
+            agent_key: "scripted".to_string(),
+            model: None,
+            project_root: std::path::PathBuf::from("/tmp"),
+            timeout_seconds: 1,
+            pass_threshold: 0.5,
+        };
+
+        let result = runner.run_case_trials(&case, &opts, &[], 3, None).await;
+
+        assert_eq!(result.total_trials, 3);
+        assert_eq!(
+            result.pass_count, 3,
+            "CaseStatus::Passed regardless of stdout content"
+        );
+        assert_eq!(runner.call_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_scripted_runner_call_count_matches_rollout_and_gate_calls() {
+        use ScriptedOutcome::*;
+        let dir = TempDir::new().unwrap();
+        let inputs = make_scripted_inputs(&dir, 1);
+        let runner = ScriptedEvalRunner::new(vec![Score1, Score1, Score1]);
+
+        train_skill(inputs, &runner).await.unwrap();
+
+        // 1 initial-score call + 1 rollout + 1 gate call (1 train case, 1 selection case,
+        // gate_trials=1, n_epochs=1).
+        assert_eq!(runner.call_count(), 3);
     }
 
     // AC-10: no epoch/gate/edit logic in this crate.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -157,6 +157,25 @@ pub fn execute(args: RunArgs) -> Result<()> {
         }
     }
 
+    // D2 / ADR 0012: a session persona carries a least-privilege tool policy
+    // (AgentPersona.tools/disallowed_tools). Only the in-process `aikit` backend enforces it;
+    // handing it to an external backend would silently drop the tool policy while the caller
+    // believes it was applied. Fail loud — matches serve's F2 422 `unsupported_tool_policy`.
+    // Unknown agent keys are left to the existing dispatch error path below.
+    if session_persona_json.is_some() {
+        if let Some(backend) = aikit_sdk::runner::Backend::from_key(&agent) {
+            if !backend.capabilities().supports_tool_policy {
+                eprintln!(
+                    "error: --session-persona: session personas are only enforced by the \
+                     in-process 'aikit' backend; agent '{}' cannot apply a persona/tool policy. \
+                     Omit --session-persona or use --agent aikit.",
+                    agent
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
     // Serialize session_agents for RunOptions.
     let session_agents_json: std::collections::HashMap<String, serde_json::Value> =
         session_agents_map

--- a/src/cli/serve/run_session.rs
+++ b/src/cli/serve/run_session.rs
@@ -413,8 +413,13 @@ pub(super) fn validate_request(
     // there is no honoring path, so accepting `tools`/`disallowed_tools` silently
     // would let a caller believe it constrained the agent when it did not. Fail
     // loud instead — a dropped least-privilege request must never look accepted.
+    // Consult BackendCapabilities::supports_tool_policy (shared with the `aikit run`
+    // CLI check) rather than a hardcoded key comparison, so the two call sites can't drift.
     let has_tool_policy = body.tools.is_some() || body.disallowed_tools.is_some();
-    if has_tool_policy && body.agent != "aikit" {
+    let supports_tool_policy = aikit_sdk::runner::Backend::from_key(&body.agent)
+        .map(|b| b.capabilities().supports_tool_policy)
+        .unwrap_or(false);
+    if has_tool_policy && !supports_tool_policy {
         return Some(error_response(
             StatusCode::UNPROCESSABLE_ENTITY,
             "unsupported_tool_policy",

--- a/tests/cli_session_persona_test.rs
+++ b/tests/cli_session_persona_test.rs
@@ -1,0 +1,83 @@
+//! D2: `aikit agent run --session-persona` on a backend that can't enforce it must fail
+//! loud (matching serve's F2 422 `unsupported_tool_policy`), not silently drop the tool
+//! policy. See `BackendCapabilities::supports_tool_policy` (aikit-sdk) and the check in
+//! `src/cli/run.rs`. No real agent CLI is required: the rejection fires before any agent
+//! is dispatched, and the one accepting case uses `--dry-run` to stay hermetic.
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+const PERSONA_JSON: &str = r#"{"reviewer":{"name":"reviewer","description":"d","prompt":"p"}}"#;
+
+fn aikit_cmd(args: &[&str]) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_aikit"));
+    cmd.args(args);
+    cmd
+}
+
+#[test]
+fn session_persona_on_external_agent_is_rejected() {
+    aikit_cmd(&[
+        "agent",
+        "run",
+        "-a",
+        "claude",
+        "-p",
+        "hi",
+        "--session-agents",
+        PERSONA_JSON,
+        "--session-persona",
+        "reviewer",
+    ])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("--session-persona"))
+    .stderr(predicate::str::contains(
+        "only enforced by the in-process 'aikit' backend",
+    ));
+}
+
+#[test]
+fn session_persona_on_external_agent_is_rejected_under_dry_run_too() {
+    // Dry-run validates config; a silently-dropped tool policy is exactly the kind of
+    // config error dry-run exists to catch, so it must reject just like a real run.
+    aikit_cmd(&[
+        "agent",
+        "run",
+        "-a",
+        "claude",
+        "-p",
+        "hi",
+        "--session-agents",
+        PERSONA_JSON,
+        "--session-persona",
+        "reviewer",
+        "--dry-run",
+    ])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("--session-persona"));
+}
+
+#[test]
+fn session_persona_on_aikit_backend_passes_the_check() {
+    // `--dry-run` keeps this hermetic (no real in-process agent turn is executed) while
+    // still exercising persona resolution and the D2 capability check's accept branch.
+    aikit_cmd(&[
+        "agent",
+        "run",
+        "-a",
+        "aikit",
+        "-p",
+        "hi",
+        "--session-agents",
+        PERSONA_JSON,
+        "--session-persona",
+        "reviewer",
+        "--dry-run",
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("Session persona: reviewer"));
+}


### PR DESCRIPTION
## Summary

Closes the last two deferred follow-ups from the [2026-07-07 audit-remediation arc](docs/adr/0012) (ADRs 0012-0016; Phase 1+2 → #104, Phase 2.1 cleanup → #105, ARCH-3 → #106):

- **F6** — `train_skill`/`resume_skill` (aikit-skillopt) hardcoded `AikitEvalRunner`, even though `aikit-textgrad::run_training`/`resume_training` already accept `runner: &dyn EvalRunner`. Tests were stuck on a non-runnable agent key (`windsurf`) whose every eval call failed identically, so the GATE's actual accept/reject dynamics had zero coverage. Now `runner` is an explicit parameter, with a `ScriptedEvalRunner` test double (queued per-call score outcomes) driving realistic improving/regressing/mixed-trajectory tests against the real GATE logic.
- **D2** — `aikit run --agent claude --session-persona <name>` silently dropped the persona's tool policy on external backends (no enforcement path there), while the caller believed a least-privilege policy was applied — the same silent-drop serve's F2 check (#105) already rejects with 422. Added `BackendCapabilities::supports_tool_policy` (true only for the in-process `aikit` backend) and consulted it from both `aikit run` (new: exits 1 before dispatch, including under `--dry-run`) and serve's existing F2 check (refactored off a hardcoded `"aikit"` string comparison onto the same capability, so the two can't drift).

Both items were grilled and locked before implementation; spec at `specs/f6-d2-followups-2026-07-23.md` (local-only, gitignored per repo convention).

## Test plan
- [x] `cargo test -p aikit-skillopt` — 19 tests incl. 7 new scripted-trajectory/call-count tests
- [x] `cargo test -p aikit-sdk` — new `only_aikit_supports_tool_policy` capability test
- [x] `cargo test --test cli_session_persona_test` — 3 new CLI-level D2 tests (reject/dry-run-reject/accept)
- [x] existing `tool_policy_on_external_agent_is_rejected` serve regression test still green after the capability refactor
- [x] `./scripts/run-tests.sh` full CI-parity sweep: 1419 passed, 0 failed (14 skipped, feature-gated)
- [x] `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] diff coverage (cargo-llvm-cov + diff-cover vs main): 95% (172 lines, 7 missing — all `const fn` compile-time evaluation or async-fn brace-boundary instrumentation artifacts, not real gaps; both explained in the PR discussion)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
