### PR TITLE
docs(session-sync): document `aikit session sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ built-in `aikit` agent, or anything else in the catalog.
   schema-driven form-fill endpoints on `aikit serve` (`/api/v1/aitools/…`),
   including `agents/draft_definition` to draft an agent definition from plain
   English. See [`aikit-magictool`](aikit-magictool/README.md).
+- **Session sync (optional)** — `aikit session sync` uploads the transcripts
+  Claude Code and Codex already write to disk, secret-scrubbed and
+  content-addressed, to S3-compatible blob storage (one-shot or `--watch`).
 - **Templates and package management** — `aikit init` scaffolds a
   Spec-Driven Development project; `aikit install/update/remove/list` manage
   packaged commands, skills, and agent definitions from GitHub or a local
@@ -229,7 +232,40 @@ feature. When enabled, `aikit serve` also exposes magic-tool routes under
 Built-in tool: `agents/draft_definition` — draft an `AgentDefinition` from a
 description. Reusable library: [`aikit-magictool`](aikit-magictool/README.md).
 
-## 4. Packages
+## 4. Session sync (`aikit session sync`)
+
+Sync the session transcripts your local AI coding tools already write to disk —
+**Claude Code** and **Codex** — up to S3-compatible blob storage, with secrets
+scrubbed before anything leaves the machine. It's a write-only producer: read
+the JSONL, scrub, upload content-addressed snapshots plus a `.meta.json`
+envelope. It never launches the tool and never reads back.
+
+```bash
+# Credentials come from the AWS environment, never flags.
+export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
+
+# One-shot sync of Claude Code sessions to a MinIO bucket
+aikit session sync --owner alice --bucket my-sessions \
+  --endpoint https://minio.internal:9000 --tool claude_code
+
+# Preview without uploading
+aikit session sync --owner alice --bucket my-sessions \
+  --endpoint https://minio.internal:9000 --dry-run --format json
+
+# Watch continuously (laptop daemon / pod sidecar)
+aikit session sync --owner alice --bucket my-sessions \
+  --endpoint https://minio.internal:9000 --watch
+```
+
+Objects land at
+`<key-prefix>/<owner>/<tool>/<session-id>/<sha256>.jsonl` (default prefix
+`sessions/`). Same content → same key (idempotent); grown transcripts create new
+versions and all versions are retained. See the
+[`session sync` command reference](webdocs/cli-commands.mdx) for the full flag
+and environment table. Requires the `agent-adapters` feature (`watcher` for
+`--watch`).
+
+## 5. Packages
 
 Distribute commands, skills, and agent definitions as `aikit.toml`
 packages. Install them per project for whichever assistant you use.
@@ -272,7 +308,7 @@ A package's `aikit.toml` describes name, version, description, and an
 package can target multiple assistants because the artifacts mapping is
 per-agent.
 
-## 5. MCP server registration (`aikit agent mcp`)
+## 6. MCP server registration (`aikit agent mcp`)
 
 Merge one MCP server entry into whichever agent's config file is
 appropriate (`mcpServers` for Cursor/Claude, VS Code `servers`, OpenCode
@@ -296,7 +332,7 @@ Six catalog keys are supported: `cursor-agent` (alias `cursor`), `claude`,
 `--overwrite` to replace an existing server id. Full reference:
 [webdocs/mcp.mdx](webdocs/mcp.mdx).
 
-## 6. Programmatic use
+## 7. Programmatic use
 
 Both crates expose the same capabilities as the CLI:
 

--- a/webdocs/cli-commands.mdx
+++ b/webdocs/cli-commands.mdx
@@ -19,6 +19,7 @@ AIKit organizes functionality into logical command groups:
 - **`mcp list`** - List supported agents and their project/global config paths
 - **`agent mcp`** - List supported agents or merge one MCP server into agent config files
 - **`serve`** - Start an HTTP server for multi-turn agent sessions ([dedicated page](/serve))
+- **`session sync`** - Sync raw, secret-scrubbed Claude Code / Codex session transcripts to S3-compatible blob storage
 - **`llm`** - Invoke an LLM via OpenAI-compatible API (supports streaming and JSON output)
 - **`check`** / **`agent check`** - Validate installed tools and AI agent CLIs
 - **`version`** - Display version information
@@ -65,6 +66,7 @@ aikit <command> --help
 | `mcp list` | List agents + config paths | `aikit mcp list` |
 | `agent mcp` | MCP config merge | `aikit agent mcp list` / `aikit agent mcp add --agent claude ...` |
 | `serve` | Multi-turn HTTP API | `aikit serve --port 8787` |
+| `session sync` | Sync sessions to blob | `aikit session sync --owner me --bucket b --endpoint https://…` |
 | `llm` | Invoke an LLM | `aikit llm -m gpt-4o -p "Hello"` |
 | `check` | Validate environment | `aikit check` |
 | `install` | Install package | `aikit install owner/repo` |
@@ -291,6 +293,81 @@ curl -s -X POST http://127.0.0.1:8787/api/v1/messages \
 Any other explicit `Accept` returns `406 Not Acceptable`. See the
 [serve API reference](/serve) for full request/response schemas, SSE event
 names, session lifecycle, and error codes.
+
+### session sync
+
+Sync **raw, secret-scrubbed** session transcripts from local AI coding tools to
+S3-compatible blob storage. Sync is a **write-only producer**: it reads the
+JSONL files each tool already wrote to disk, scrubs credentials, and uploads
+content-addressed snapshots plus a JSON metadata sidecar. It never launches the
+tool and never reads back — analysis/search is a separate downstream tool.
+
+Only the two flat-file JSONL tools are supported today: **Claude Code** and
+**Codex**. OpenCode (SQLite) is out of scope for v1.
+
+Every object lands under a deterministic key inside the bucket:
+
+```
+<key-prefix>/<owner>/<tool>/<session-id>/<sha256>.jsonl       # scrubbed transcript
+<key-prefix>/<owner>/<tool>/<session-id>/<sha256>.meta.json   # envelope: host, hash, timestamps, versions
+```
+
+```bash
+# Credentials come from the standard AWS environment, never flags.
+export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
+
+# One-shot: sync all detected Claude Code sessions to a MinIO bucket
+aikit session sync \
+  --owner alice \
+  --bucket my-sessions \
+  --endpoint https://minio.internal:9000 \
+  --tool claude_code
+
+# Preview only — detect, scrub, hash, summarize; upload nothing
+aikit session sync --owner alice --bucket my-sessions \
+  --endpoint https://minio.internal:9000 --dry-run --format json
+
+# Continuously watch and sync on every change (laptop daemon / pod sidecar)
+aikit session sync --owner alice --bucket my-sessions \
+  --endpoint https://minio.internal:9000 --watch
+```
+
+**Options:**
+
+| Flag | Env | Default | Description |
+|------|-----|---------|-------------|
+| `--bucket` | `AIKIT_SYNC_BUCKET` | — (required) | Target S3 bucket |
+| `--endpoint` | `AIKIT_SYNC_ENDPOINT` | — (required) | S3-compatible endpoint URL |
+| `--region` | `AIKIT_SYNC_REGION` | `us-east-1` | Region (a sentinel value is fine for MinIO) |
+| `--owner` | `AIKIT_SYNC_OWNER` | credential-derived | Owner prefix; required (see fail-closed rule below) |
+| `--key-prefix` | `AIKIT_SYNC_PREFIX` | `sessions/` | Root key prefix — the top-level "folder" in the bucket |
+| `--tool` | — | all JSONL tools | Repeatable; `claude_code` or `codex` |
+| `--watch` | — | off | Continuous mode: sync on filesystem change |
+| `--dry-run` | — | off | Detect + scrub + hash + summarize, upload nothing |
+| `--allow-http` | `AIKIT_SYNC_ALLOW_HTTP` | `false` | Permit plain-HTTP endpoints (local MinIO dev) |
+| `--format` | — | `default` | `default` (human) or `json` (machine-readable summary) |
+| `--log-level` | `RUST_LOG` | `info` | Log verbosity |
+
+**Credentials** are read from the standard AWS environment
+(`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, or a workload-identity chain) and
+are **never** accepted as flags. Two additional env-only knobs:
+
+- `AIKIT_SYNC_CREDENTIAL_OWNER` — the owner identity derived from the credential.
+  If it is set **and** disagrees with `--owner`, sync **fails closed** (exit `2`)
+  rather than guessing. If neither is set, sync also refuses to start — an owner
+  is always required.
+- `AIKIT_SYNC_ENDPOINT_CA_BUNDLE` — path to a custom CA PEM bundle for a
+  self-signed MinIO/S3 endpoint.
+
+**Idempotency & retention:** the object key is the SHA-256 of the scrubbed
+bytes, so re-syncing unchanged content is a no-op; a grown transcript produces a
+new version object and **all versions are retained** (v1 keeps everything).
+
+**Exit codes:** `0` everything synced or already current · `1` one or more files
+failed after retries · `2` configuration/auth error before any upload (missing
+bucket/endpoint, or an owner mismatch).
+
+Requires a build with the `agent-adapters` feature (plus `watcher` for `--watch`).
 
 ### agent mcp
 


### PR DESCRIPTION
Documents the `aikit session sync` command (feature merged in #110).

- **webdocs/cli-commands.mdx** — command-overview entry, quick-reference row, and a full detail section: key layout (`<key-prefix>/<owner>/<tool>/<session-id>/<sha256>.jsonl` + `.meta.json`), flag/env table, credentials-from-AWS-env, fail-closed owner rule, idempotency/retention, and exit codes.
- **README.md** — a "What you get" bullet and a new "Session sync" section.

(The in-repo `.cursor/skills/aikit/SKILL.md` was also updated locally but is gitignored, so it's not part of this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)