### PR TITLE
fix(session-sync): make state-dir test cross-platform (Windows CI red)

### DIFF
--- a/aikit-session-sync/src/state.rs
+++ b/aikit-session-sync/src/state.rs
@@ -77,6 +77,14 @@ pub struct JsonSyncStateStore {
 impl JsonSyncStateStore {
     pub fn open() -> std::io::Result<Self> {
         let root = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        Self::open_under(&root)
+    }
+
+    /// Create the `<root>/.aikit/session-sync/` state dir and return a store
+    /// rooted at it. `open()` passes the real home dir; tests pass a temp dir so
+    /// the assertion is independent of OS-specific home resolution
+    /// (`dirs::home_dir()` reads `USERPROFILE` on Windows, not `HOME`).
+    fn open_under(root: &Path) -> std::io::Result<Self> {
         let dir = root.join(".aikit").join("session-sync");
         std::fs::create_dir_all(&dir)?;
         Ok(Self {
@@ -143,16 +151,21 @@ mod tests {
 
     #[test]
     fn open_creates_state_dir_under_home() {
+        // Use open_under with a temp root so the assertion is cross-platform:
+        // dirs::home_dir() reads USERPROFILE on Windows, so overriding HOME
+        // would silently not take effect there.
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var_os("HOME");
-        std::env::set_var("HOME", tmp.path());
-        let store = JsonSyncStateStore::open().unwrap();
+        let store = JsonSyncStateStore::open_under(tmp.path()).unwrap();
         assert!(store.path.ends_with("state.json"));
         assert!(tmp.path().join(".aikit").join("session-sync").is_dir());
-        match prev {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
-        }
+    }
+
+    #[test]
+    fn open_uses_real_home() {
+        // Exercise the public open() entry point (home resolution + dir create).
+        let store = JsonSyncStateStore::open().unwrap();
+        assert!(store.path.ends_with("state.json"));
+        assert!(store.path.parent().unwrap().ends_with("session-sync"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`main` went red after #111 merged: the `windows-latest` matrix job failed at the `--lib` test step. Ubuntu, macOS, and the coverage gate all passed.

Root cause: `state::tests::open_creates_state_dir_under_home` overrode the `HOME` env var, but `JsonSyncStateStore::open()` resolves the home directory via `dirs::home_dir()`, which reads **`USERPROFILE` on Windows**, not `HOME`. So on Windows the override silently did nothing, `open()` created `.aikit/session-sync` under the *real* home, and the assertion checked the temp dir it never wrote → panic.

## Fix

- Extract `JsonSyncStateStore::open_under(root)` holding the dir-building logic. `open()` passes the real home; the test passes a temp root — no env mutation, platform-independent.
- Add `open_uses_real_home` so the public `open()` entry point (home resolution) stays covered.

## Validation

- `cargo test -p aikit-session-sync --lib` → 23 passed
- `cargo clippy -p aikit-session-sync --all-targets -- -D warnings` → clean
- `cargo llvm-cov -p aikit-session-sync --fail-under-lines 95` → 95.75% lines (state.rs 97.73%), gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)