### PR TITLE
fix: restore green Windows CI after session-sync merge ($HOME pollution + .aikit discovery)

### DIFF
--- a/aikit-session-sync/src/state.rs
+++ b/aikit-session-sync/src/state.rs
@@ -160,12 +160,30 @@ mod tests {
         assert!(tmp.path().join(".aikit").join("session-sync").is_dir());
     }
 
+    // Exercise the public open() entry point (home resolution + dir create).
+    //
+    // Unix only, and deliberately so: dirs::home_dir() honors $HOME on unix, so
+    // we can redirect it to a temp dir and keep the test hermetic. On Windows
+    // home_dir() ignores env vars and resolves the real user profile, so calling
+    // open() there would create `%USERPROFILE%\.aikit` on the shared CI runner —
+    // which cli_integration_test then discovers via its walk-up `.aikit` lookup
+    // (Windows temp dirs are nested under the user profile), breaking that
+    // suite's per-test isolation. Compiling this out on Windows keeps open()
+    // covered on the (ubuntu-only) coverage job without polluting $HOME anywhere.
+    #[cfg(unix)]
     #[test]
-    fn open_uses_real_home() {
-        // Exercise the public open() entry point (home resolution + dir create).
+    fn open_uses_home_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("HOME");
+        std::env::set_var("HOME", tmp.path());
         let store = JsonSyncStateStore::open().unwrap();
+        match prev {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
         assert!(store.path.ends_with("state.json"));
         assert!(store.path.parent().unwrap().ends_with("session-sync"));
+        assert!(tmp.path().join(".aikit").join("session-sync").is_dir());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Restores green Windows CI, which the session-sync merge (#110) turned red. Two Windows-only test-isolation fixes, both exposed once #113 unblocked the `windows-latest` "Run integration tests" step.

## Fix 1 — session-sync `open()` test polluted real `$HOME`

`JsonSyncStateStore::open()` does `dirs::home_dir().join(".aikit")` + `create_dir_all`. On Windows `home_dir()` resolves the **real user profile** (ignores env), so the `open_uses_real_home` test (added in #113) created `C:\Users\runneradmin\.aikit` on the runner. `cli_integration_test` discovers its package dir by **walking up from CWD** (`install.rs` → `AikDirectory::find`); Windows temp dirs are nested under the user profile, so that walk-up found the stray `~/.aikit` and 8 package tests saw leaked installs.

Fix: make the `open()` coverage test `#[cfg(unix)]` and redirect `$HOME` to a temp dir. `dirs::home_dir()` honors `$HOME` on unix, so it stays hermetic and still covers `open()` on the ubuntu-only coverage job; compiled out on Windows so session-sync writes nothing to `%USERPROFILE%`. `open_under(temp)` still covers the dir-building logic cross-platform.

## Fix 2 — `e2e_workflow_test` had no `.aikit` short-circuit guard

With Fix 1, one failure remained: `test_package_installation_workflow` asserted `work/.aikit` exists after install but got nothing — `AikDirectory::find()` walked up from the tempdir and found a stray `.aikit` left above (a pre-existing Windows-runner hazard), writing artifacts there instead of into `work`.

`newton_template_install_test.rs` already guards against this exact case by pre-creating `.aikit/` in the tempdir so `find()` short-circuits. Fix 2 applies the same guard (`isolate_aikit`) to the install-based `e2e_workflow_test` tests. Session-sync only shifted test-binary run order enough to expose the pre-existing weakness.

## Validation

- `cargo test -p aikit-session-sync --lib` → 23 passed
- `cargo test -p aikit-cli --test e2e_workflow_test` → 6 passed
- `cargo clippy -p aikit-session-sync --all-targets -- -D warnings` → clean
- `cargo llvm-cov -p aikit-session-sync --fail-under-lines 95` → 95.66% lines (state.rs 96.84%), gate passes
- Windows green pending on this PR's CI (the real cross-platform check).

## Follow-up (out of scope)

Something still leaves a stray home-level `.aikit` on the Windows runner (the source, not the victims). Both consuming suites are now guarded, but hardening the aikit binary's `.aikit` discovery to ignore a home-level match (or an env override for the discovery root) would remove the hazard at the source. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
