### PR TITLE
fix(tests): isolate e2e_workflow_test .aikit discovery on Windows CI (follow-up to #114)

### DIFF
--- a/aikit-session-sync/tests/e2e_minio.rs
+++ b/aikit-session-sync/tests/e2e_minio.rs
@@ -57,6 +57,15 @@ impl Adapter for TempDirAdapter {
 }
 
 fn docker_available() -> bool {
+    // MinIO is a Linux container; testcontainers needs a Linux Docker daemon.
+    // GitHub's macOS/Windows runners don't provide one — and on Windows the
+    // docker CLI is present (so `docker version` succeeds) but only serves
+    // Windows containers, so the guard must also require a Linux target or the
+    // container start panics. The coverage job that needs this test runs on
+    // ubuntu, so gating to Linux keeps s3.rs coverage intact.
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
     std::process::Command::new("docker")
         .arg("version")
         .stdout(std::process::Stdio::null())

--- a/tests/e2e_workflow_test.rs
+++ b/tests/e2e_workflow_test.rs
@@ -10,11 +10,25 @@ use predicates::prelude::*;
 mod tests {
     use super::*;
 
+    /// Pre-create `<work>/.aikit/` so `AikDirectory::find()` short-circuits in the
+    /// test's tempdir instead of walking up and discovering an unrelated `.aikit/`
+    /// left somewhere above. On the Windows CI runner tempdirs are nested under the
+    /// user profile, so a stray home-level `.aikit/` up the tree would otherwise be
+    /// found and install would write artifacts there, leaving `work` empty. Mirrors
+    /// the guard in newton_template_install_test.rs.
+    fn isolate_aikit(work: &std::path::Path) {
+        let dir = work.join(".aikit");
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir).expect("pre-create .aikit/ in tempdir");
+        }
+    }
+
     /// Test complete package creation workflow: init -> build -> install -> list
     #[test]
     fn test_complete_package_workflow() -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let work = temp.path();
+        isolate_aikit(work);
 
         // Step 1: Initialize package
         cargo_bin_cmd!("aikit")
@@ -83,6 +97,7 @@ mod tests {
     fn test_package_installation_workflow() -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let work = temp.path();
+        isolate_aikit(work);
 
         // Create a package to install
         cargo_bin_cmd!("aikit")
@@ -147,6 +162,7 @@ mod tests {
     fn test_package_update_workflow() -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let work = temp.path();
+        isolate_aikit(work);
 
         // Step 1: Create and install initial package v1.0.0
         cargo_bin_cmd!("aikit")
@@ -251,6 +267,7 @@ mod tests {
     fn test_multiple_package_workflow() -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let work = temp.path();
+        isolate_aikit(work);
 
         // Create multiple packages
         let package_names = vec!["package-a", "package-b", "package-c"];


### PR DESCRIPTION
Follow-up to #114. That PR merged with only its first fix (the session-sync `open()` `$HOME` pollution); this second fix — the `e2e_workflow_test` `.aikit` guard — was pushed to the branch after the merge, so it never landed. Without it, `main`'s `windows-latest` integration step still fails on one test.

## Problem

After #114 removed the session-sync `$HOME` pollution, one Windows failure remained: `test_package_installation_workflow` asserted `work/.aikit` exists after install but got nothing. `install`'s `AikDirectory::find()` walks up from the tempdir; on the Windows runner tempdirs are nested under the user profile, so it discovered a stray `.aikit` left above and wrote artifacts there instead of into `work`.

## Fix

`newton_template_install_test.rs` already documents and guards this exact hazard by pre-creating `.aikit/` in its tempdir so `find()` short-circuits. This applies the same guard (`isolate_aikit`) to the install-based `e2e_workflow_test` tests. The underlying stray-`.aikit` weakness is pre-existing; the session-sync merge only shifted test-binary run order enough to expose it.

## Validation

- `cargo test -p aikit-cli --test e2e_workflow_test` → 6 passed (Linux)
- Windows green pending on this PR's CI (the decisive cross-platform check).

## Follow-up (out of scope)

Something still leaves a stray home-level `.aikit` on the Windows runner (the source, not the victims). Both consuming suites are now guarded, but hardening the aikit binary's `.aikit` discovery to ignore a home-level match — or adding an env override for the discovery root — would remove the hazard at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
