### PR TITLE
feat(runner): spec 013 common sub-agent invocation envelope (slice 1)

### DIFF
--- a/aikit-sdk/src/run_progress.rs
+++ b/aikit-sdk/src/run_progress.rs
@@ -198,6 +198,16 @@ impl RunProgress {
                 self.add_row(format!("step> {} {}", iteration, finish_reason));
             }
             AgentEventPayload::RawTransportLine { .. } => {}
+            AgentEventPayload::Result { text, .. } => {
+                let t = text.replace('\n', " ").replace('\r', "");
+                let t = t.trim();
+                if !t.is_empty() {
+                    self.add_row(format!(
+                        "result> {}",
+                        truncate(t, self.config.max_text_width)
+                    ));
+                }
+            }
             AgentEventPayload::SessionStarted { .. } => {}
         }
     }
@@ -313,6 +323,41 @@ mod tests {
             payload: AgentEventPayload::JsonLine(val),
         };
         progress.push("opencode", &event);
+        assert_eq!(progress.formatted_lines().count(), 0);
+    }
+
+    #[test]
+    fn test_result_payload_renders_final_answer() {
+        let mut progress = RunProgress::new(ProgressViewConfig::default());
+        let event = AgentEvent {
+            agent_key: "codex".to_string(),
+            seq: 0,
+            stream: AgentEventStream::Stdout,
+            payload: AgentEventPayload::Result {
+                text: "the fix is applied".to_string(),
+                structured: None,
+                session_id: None,
+            },
+        };
+        progress.push("codex", &event);
+        let lines: Vec<_> = progress.formatted_lines().collect();
+        assert_eq!(lines, vec!["result> the fix is applied"]);
+    }
+
+    #[test]
+    fn test_result_payload_empty_text_is_suppressed() {
+        let mut progress = RunProgress::new(ProgressViewConfig::default());
+        let event = AgentEvent {
+            agent_key: "codex".to_string(),
+            seq: 0,
+            stream: AgentEventStream::Stdout,
+            payload: AgentEventPayload::Result {
+                text: "   ".to_string(),
+                structured: None,
+                session_id: None,
+            },
+        };
+        progress.push("codex", &event);
         assert_eq!(progress.formatted_lines().count(), 0);
     }
 

--- a/aikit-sdk/src/runner/argv.rs
+++ b/aikit-sdk/src/runner/argv.rs
@@ -8,6 +8,7 @@
 use std::ffi::OsString;
 
 use super::backend::Backend;
+use super::invocation::InvocationEnvelope;
 
 /// The runnable agent keys, in canonical order. Kept in lockstep with
 /// [`Backend::ALL`] (enforced by a test below).
@@ -19,26 +20,48 @@ pub fn is_runnable(agent_key: &str) -> bool {
     Backend::from_key(agent_key).is_some()
 }
 
-/// Build the spawn argv for an agent key. Delegates to the typed
-/// [`Backend::build_argv`].
-///
-/// Panics if `agent_key` is not a known Backend (callers gate with
-/// [`is_runnable`]) or if it is the in-process `aikit` Backend.
-pub(super) fn build_argv(
+/// Build the spawn argv carrying a spec-013 [`InvocationEnvelope`]. Each
+/// Backend maps honored knobs onto its native flags; the runner resolves the
+/// envelope (fail-closed for unsupported security knobs) before calling this.
+pub(crate) fn build_argv_envelope(
     agent_key: &str,
     model: Option<&String>,
     yolo: bool,
     stream: bool,
     events_mode: bool,
     session_id: Option<&str>,
+    envelope: Option<&InvocationEnvelope>,
 ) -> Vec<OsString> {
     let backend = Backend::from_key(agent_key).expect("unknown agent key for build_argv");
-    backend.build_argv(model, yolo, stream, events_mode, session_id)
+    backend.build_argv_envelope(model, yolo, stream, events_mode, session_id, envelope)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Legacy no-envelope builder, retained as a test helper so the historical
+    // argv assertions run unchanged against the envelope path (envelope = None
+    // ⇒ identical argv). Production goes through `build_argv_envelope`.
+    #[allow(dead_code)]
+    fn build_argv(
+        agent_key: &str,
+        model: Option<&String>,
+        yolo: bool,
+        stream: bool,
+        events_mode: bool,
+        session_id: Option<&str>,
+    ) -> Vec<OsString> {
+        build_argv_envelope(
+            agent_key,
+            model,
+            yolo,
+            stream,
+            events_mode,
+            session_id,
+            None,
+        )
+    }
 
     #[test]
     fn test_is_runnable_true_for_supported_false_for_others() {
@@ -424,5 +447,181 @@ mod tests {
         assert!(argv.contains(&OsString::from("test-id-def")));
         let resume_pos = argv.iter().position(|a| a == "--resume").unwrap();
         assert_eq!(argv[resume_pos + 1], OsString::from("test-id-def"));
+    }
+
+    // ── spec 013: invocation-envelope argv mapping ───────────────────────────
+
+    use crate::runner::{InvocationEnvelope, SandboxPolicy};
+    use std::path::PathBuf;
+
+    fn env_with(sandbox: Option<SandboxPolicy>) -> InvocationEnvelope {
+        InvocationEnvelope {
+            sandbox,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn spec013_codex_sandbox_maps_to_native_token_and_suppresses_yolo() {
+        let env = env_with(Some(SandboxPolicy::BoundedWrite));
+        let argv = build_argv_envelope("codex", None, false, false, false, None, Some(&env));
+        assert!(argv.contains(&OsString::from("--sandbox")));
+        assert!(argv.contains(&OsString::from("workspace-write")));
+        assert!(
+            !argv.contains(&OsString::from("--yolo")),
+            "explicit sandbox subsumes --yolo; got {:?}",
+            argv
+        );
+
+        let ro = build_argv_envelope(
+            "codex",
+            None,
+            false,
+            false,
+            false,
+            None,
+            Some(&env_with(Some(SandboxPolicy::ReadOnly))),
+        );
+        assert!(ro.contains(&OsString::from("read-only")));
+
+        let un = build_argv_envelope(
+            "codex",
+            None,
+            false,
+            false,
+            false,
+            None,
+            Some(&env_with(Some(SandboxPolicy::Unrestricted))),
+        );
+        assert!(un.contains(&OsString::from("danger-full-access")));
+    }
+
+    #[test]
+    fn spec013_codex_inactive_envelope_is_identical_to_legacy() {
+        // No knobs set ⇒ identical to the historical argv (yolo honored).
+        let env = InvocationEnvelope::default();
+        let with_env = build_argv_envelope("codex", None, true, false, false, None, Some(&env));
+        let legacy = build_argv("codex", None, true, false, false, None);
+        assert_eq!(with_env, legacy);
+        assert!(with_env.contains(&OsString::from("--yolo")));
+    }
+
+    #[test]
+    fn spec013_codex_envelope_emits_d2_d6_native_flags() {
+        let env = InvocationEnvelope {
+            working_dir: Some(PathBuf::from("/repo")),
+            extra_writable_roots: vec![PathBuf::from("/shared"), PathBuf::from("/cache")],
+            bare: true,
+            ephemeral: true,
+            skip_git_repo_check: true,
+            ..Default::default()
+        };
+        let argv = build_argv_envelope("codex", None, false, false, false, None, Some(&env));
+        assert!(argv.contains(&OsString::from("--cd")));
+        assert!(argv.contains(&OsString::from("/repo")));
+        assert!(argv.contains(&OsString::from("--add-dir")));
+        assert!(argv.contains(&OsString::from("/shared")));
+        assert!(argv.contains(&OsString::from("/cache")));
+        assert!(argv.contains(&OsString::from("--ignore-user-config")));
+        assert!(argv.contains(&OsString::from("--ephemeral")));
+        assert!(argv.contains(&OsString::from("--skip-git-repo-check")));
+    }
+
+    #[test]
+    fn spec013_claude_bare_emits_native_flag() {
+        let env = InvocationEnvelope {
+            bare: true,
+            ..Default::default()
+        };
+        let argv = build_argv_envelope("claude", None, false, false, false, None, Some(&env));
+        assert!(argv.contains(&OsString::from("--bare")));
+        // without bare, the flag is absent
+        let plain = build_argv_envelope(
+            "claude",
+            None,
+            false,
+            false,
+            false,
+            None,
+            Some(&InvocationEnvelope::default()),
+        );
+        assert!(!plain.contains(&OsString::from("--bare")));
+    }
+
+    #[test]
+    fn spec013_gemini_sandbox_toggle() {
+        // restrictive policy ⇒ `-s`; unrestricted/none ⇒ no `-s`
+        let on = build_argv_envelope(
+            "gemini",
+            None,
+            false,
+            false,
+            false,
+            None,
+            Some(&env_with(Some(SandboxPolicy::BoundedWrite))),
+        );
+        assert!(on.contains(&OsString::from("-s")));
+
+        let ro = build_argv_envelope(
+            "gemini",
+            None,
+            false,
+            false,
+            false,
+            None,
+            Some(&env_with(Some(SandboxPolicy::ReadOnly))),
+        );
+        assert!(ro.contains(&OsString::from("-s")));
+
+        let off = build_argv_envelope(
+            "gemini",
+            None,
+            false,
+            false,
+            false,
+            None,
+            Some(&env_with(Some(SandboxPolicy::Unrestricted))),
+        );
+        assert!(!off.contains(&OsString::from("-s")));
+
+        let none = build_argv_envelope(
+            "gemini",
+            None,
+            false,
+            false,
+            false,
+            None,
+            Some(&InvocationEnvelope::default()),
+        );
+        assert!(!none.contains(&OsString::from("-s")));
+    }
+
+    #[test]
+    fn spec013_opencode_working_dir_emits_dir_flag() {
+        let env = InvocationEnvelope {
+            working_dir: Some(PathBuf::from("/repo")),
+            ..Default::default()
+        };
+        let argv = build_argv_envelope("opencode", None, false, false, false, None, Some(&env));
+        assert!(argv.contains(&OsString::from("--dir")));
+        assert!(argv.contains(&OsString::from("/repo")));
+        // run subcommand precedes the stdin marker
+        let run_pos = argv.iter().position(|a| a == "run").unwrap();
+        let dash_pos = argv.iter().position(|a| a == "-").unwrap();
+        assert!(run_pos < dash_pos);
+    }
+
+    #[test]
+    fn spec013_cursor_envelope_adds_no_native_flags() {
+        // cursor has no native spec-013 knobs; an (already-resolved) envelope
+        // must not add flags. Security requests fail closed before argv.
+        let env = InvocationEnvelope {
+            bare: true,
+            ephemeral: true,
+            ..Default::default()
+        };
+        let with_env = build_argv_envelope("cursor", None, false, false, false, None, Some(&env));
+        let legacy = build_argv("cursor", None, false, false, false, None);
+        assert_eq!(with_env, legacy);
     }
 }

--- a/aikit-sdk/src/runner/backend.rs
+++ b/aikit-sdk/src/runner/backend.rs
@@ -12,6 +12,7 @@ use std::ffi::OsString;
 use super::backends::argv_spec::ArgvCtx;
 use super::backends::{aikit, claude, codex, cursor, gemini, opencode};
 use super::capabilities::BackendCapabilities;
+use super::invocation::InvocationEnvelope;
 use super::types::{
     AgentEventPayload, AgentEventStream, QuotaExceededInfo, StreamMessage, TokenUsage, UsageSource,
 };
@@ -192,15 +193,18 @@ impl Backend {
         }
     }
 
-    /// Build the subprocess argv. Panics for the in-process [`Backend::Aikit`],
-    /// which is never spawned.
-    pub(crate) fn build_argv(
+    /// Build the subprocess argv carrying a spec-013 [`InvocationEnvelope`].
+    /// Each Backend's `argv` maps the honored knobs onto its native flags; an
+    /// `envelope` of `None` is the identity (legacy) argv. Panics for the
+    /// in-process [`Backend::Aikit`], which is never spawned.
+    pub(crate) fn build_argv_envelope(
         self,
         model: Option<&String>,
         yolo: bool,
         stream: bool,
         events_mode: bool,
         session_id: Option<&str>,
+        envelope: Option<&InvocationEnvelope>,
     ) -> Vec<OsString> {
         let ctx = ArgvCtx {
             model,
@@ -208,6 +212,7 @@ impl Backend {
             stream,
             events_mode,
             session_id,
+            envelope,
         };
         match self {
             Backend::Claude => claude::argv(ctx),

--- a/aikit-sdk/src/runner/backends/argv_spec.rs
+++ b/aikit-sdk/src/runner/backends/argv_spec.rs
@@ -7,6 +7,8 @@
 
 use std::ffi::OsString;
 
+use crate::runner::invocation::InvocationEnvelope;
+
 #[derive(Clone, Copy)]
 pub(crate) enum SessionMode {
     /// Session id is appended as a positional argument (handled per-Backend).
@@ -63,4 +65,9 @@ pub(crate) struct ArgvCtx<'a> {
     pub stream: bool,
     pub events_mode: bool,
     pub session_id: Option<&'a str>,
+    /// Spec-013 invocation envelope (`None` ⇒ legacy/identity behavior: no
+    /// sandbox/working-root/approval flags are emitted, preserving every
+    /// existing argv test). When `Some`, each Backend's `argv` maps the
+    /// honored knobs onto its native flags.
+    pub envelope: Option<&'a InvocationEnvelope>,
 }

--- a/aikit-sdk/src/runner/backends/claude.rs
+++ b/aikit-sdk/src/runner/backends/claude.rs
@@ -346,6 +346,13 @@ pub(crate) fn argv(ctx: ArgvCtx) -> Vec<OsString> {
         OsString::from("--dangerously-skip-permissions"),
     ];
     SPEC.push_model(&mut argv, ctx.model);
+    // spec 013 D6: claude's reproducible-run flag. claude's sandbox (AppLevel)
+    // is enforced via the session persona / tool-policy layer, not an argv flag.
+    if let Some(e) = ctx.envelope {
+        if e.bare {
+            argv.push(OsString::from("--bare"));
+        }
+    }
     let fmt = if ctx.events_mode {
         if ctx.stream {
             "stream-json"

--- a/aikit-sdk/src/runner/backends/codex.rs
+++ b/aikit-sdk/src/runner/backends/codex.rs
@@ -11,7 +11,7 @@ use crate::runner::backends::quota_match::{match_quota, JsonPat, RawPat};
 use crate::runner::capabilities::BackendCapabilities;
 use crate::runner::types::{
     AgentEventPayload, AgentEventStream, MessageKind, MessagePhase, MessageRole, QuotaExceededInfo,
-    StreamMessage, TokenUsage, UsageSource,
+    SandboxPolicy, StreamMessage, TokenUsage, UsageSource,
 };
 
 pub(crate) const KEY: &str = "codex";
@@ -265,11 +265,54 @@ pub(crate) fn argv(ctx: ArgvCtx) -> Vec<OsString> {
         None => vec![OsString::from(SPEC.binary), OsString::from("exec")],
     };
     SPEC.push_model(&mut argv, ctx.model);
-    SPEC.push_yolo(&mut argv, ctx.yolo);
+
+    // spec 013 D1: an explicit `--sandbox` subsumes `--yolo` — codex's
+    // workspace-write / danger-full-access already auto-approve within bounds.
+    // When no envelope sandbox is requested, preserve the legacy `--yolo` path
+    // (every existing argv test exercises this branch).
+    let explicit_sandbox = ctx.envelope.and_then(|e| e.sandbox);
+    if let Some(policy) = explicit_sandbox {
+        argv.push(OsString::from("--sandbox"));
+        argv.push(OsString::from(codex_sandbox_token(policy)));
+    } else {
+        SPEC.push_yolo(&mut argv, ctx.yolo);
+    }
+
+    // spec 013 D2/D6: honored knobs → native flags.
+    if let Some(e) = ctx.envelope {
+        if let Some(dir) = e.working_dir.as_deref() {
+            argv.push(OsString::from("--cd"));
+            argv.push(dir.as_os_str().to_owned());
+        }
+        for root in &e.extra_writable_roots {
+            argv.push(OsString::from("--add-dir"));
+            argv.push(root.as_os_str().to_owned());
+        }
+        if e.skip_git_repo_check {
+            argv.push(OsString::from("--skip-git-repo-check"));
+        }
+        if e.ephemeral {
+            argv.push(OsString::from("--ephemeral"));
+        }
+        if e.bare {
+            argv.push(OsString::from("--ignore-user-config"));
+        }
+    }
+
     argv.extend_from_slice(&[
         OsString::from("--json"),
         OsString::from("--"),
         OsString::from("-"),
     ]);
     argv
+}
+
+/// Map a common [`SandboxPolicy`] onto codex's native `--sandbox` vocabulary
+/// (spec 013 D1 sandbox-mapping table).
+fn codex_sandbox_token(policy: SandboxPolicy) -> &'static str {
+    match policy {
+        SandboxPolicy::ReadOnly => "read-only",
+        SandboxPolicy::BoundedWrite => "workspace-write",
+        SandboxPolicy::Unrestricted => "danger-full-access",
+    }
 }

--- a/aikit-sdk/src/runner/backends/gemini.rs
+++ b/aikit-sdk/src/runner/backends/gemini.rs
@@ -158,6 +158,14 @@ pub(crate) fn argv(ctx: ArgvCtx) -> Vec<OsString> {
         ]);
     }
     SPEC.push_model(&mut argv, ctx.model);
+    // spec 013 D1: enable gemini's OS sandbox for any restrictive policy. The
+    // sandbox backend + profile + extra-root mounts are Command-env configured
+    // (seatbelt profile / SANDBOX_MOUNTS); slice 1 lands the `-s` toggle.
+    if let Some(e) = ctx.envelope {
+        if matches!(e.sandbox, Some(p) if p.as_kebab_str() != "unrestricted") {
+            argv.push(OsString::from("-s"));
+        }
+    }
     SPEC.push_session_flag(&mut argv, ctx.session_id);
     argv
 }

--- a/aikit-sdk/src/runner/backends/opencode.rs
+++ b/aikit-sdk/src/runner/backends/opencode.rs
@@ -158,6 +158,13 @@ pub(crate) fn argv(ctx: ArgvCtx) -> Vec<OsString> {
     let mut argv = vec![OsString::from(SPEC.binary)];
     SPEC.push_model(&mut argv, ctx.model);
     argv.push(OsString::from("run"));
+    // spec 013 D2: opencode's native per-call working root.
+    if let Some(e) = ctx.envelope {
+        if let Some(dir) = e.working_dir.as_deref() {
+            argv.push(OsString::from("--dir"));
+            argv.push(dir.as_os_str().to_owned());
+        }
+    }
     // `--dangerously-skip-permissions` (auto-approve tool use) must be passed
     // in BOTH plain and events mode. Without it opencode prompts for each
     // write/edit, so an unattended agent silently produces nothing.

--- a/aikit-sdk/src/runner/invocation.rs
+++ b/aikit-sdk/src/runner/invocation.rs
@@ -1,0 +1,506 @@
+//! Spec 013 — the common sub-agent invocation envelope.
+//!
+//! The caller-facing trust/IO knobs that sit above the Backend/Transport seam:
+//! filesystem-trust policy ([`SandboxPolicy`]), the tool-approval axis, the
+//! working root, extra writable roots, and the lifecycle toggles. Each Backend
+//! declares, per knob, how it can honor a request ([`KnobSupport`]); aikit maps
+//! a common request onto each Backend's native mechanism. A security knob a
+//! Backend cannot honor at all fails closed ([`resolve_envelope`]) — never a
+//! silent downgrade of trust (ADR 0012).
+//!
+//! This module owns the *contract* (the capability matrix + resolution). The
+//! per-Backend argv translation of an honored knob lives in
+//! `backends/<name>::argv`. aikit does not synthesize its own OS sandbox here;
+//! that is out of scope for aikit-sdk (spec 005 NG-002).
+
+use std::path::PathBuf;
+
+use super::backend::Backend;
+use super::types::{KnobSupport, RunOptions, SandboxPolicy};
+
+/// The per-call invocation envelope: every spec-013 knob expressed as data.
+/// Built from [`RunOptions`] at the subprocess boundary and mapped per-Backend
+/// to native argv. Backend-agnostic; one shape for CLI and (future) `serve`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InvocationEnvelope {
+    /// `--sandbox` (D1). `None` = Backend default.
+    pub sandbox: Option<SandboxPolicy>,
+    /// `--auto-approve` (D1 approval axis).
+    pub auto_approve: bool,
+    /// `-C, --cd` working root (D2). Mirrors `RunOptions::current_dir`.
+    pub working_dir: Option<PathBuf>,
+    /// `--add-dir` extra writable roots (D2).
+    pub extra_writable_roots: Vec<PathBuf>,
+    /// `--output-result` / `-o` (D3).
+    pub result_file: Option<PathBuf>,
+    /// `--output-schema` (D4 convenience knob).
+    pub output_schema: Option<serde_json::Value>,
+    /// `--bare` skip user config/hooks/MCP (D6).
+    pub bare: bool,
+    /// `--ephemeral` do not persist the session (D6).
+    pub ephemeral: bool,
+    /// `--skip-git-repo-check` (D6).
+    pub skip_git_repo_check: bool,
+}
+
+impl InvocationEnvelope {
+    /// Derive the envelope from a [`RunOptions`]. Pure; tested.
+    pub fn from_options(opts: &RunOptions) -> Self {
+        InvocationEnvelope {
+            sandbox: opts.sandbox,
+            auto_approve: opts.auto_approve,
+            working_dir: opts.current_dir.clone(),
+            extra_writable_roots: opts.extra_writable_roots.clone(),
+            result_file: opts.result_file.clone(),
+            output_schema: opts.output_schema.clone(),
+            bare: opts.bare,
+            ephemeral: opts.ephemeral,
+            skip_git_repo_check: opts.skip_git_repo_check,
+        }
+    }
+
+    /// True if the envelope carries any spec-013 knob the Backend must map.
+    pub fn is_active(&self) -> bool {
+        self.sandbox.is_some()
+            || self.auto_approve
+            || self.working_dir.is_some()
+            || !self.extra_writable_roots.is_empty()
+            || self.result_file.is_some()
+            || self.output_schema.is_some()
+            || self.bare
+            || self.ephemeral
+            || self.skip_git_repo_check
+    }
+}
+
+/// A requested security knob the Backend cannot honor. Returned by
+/// [`resolve_envelope`] so the caller can fail closed (spec 013 exit code 3)
+/// rather than run at a wider trust level than asked.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedKnob {
+    pub backend: Backend,
+    pub knob: &'static str,
+    pub detail: String,
+}
+
+impl std::fmt::Display for UnsupportedKnob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "agent '{}' cannot honor --{}: {}",
+            self.backend.key(),
+            self.knob,
+            self.detail
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedKnob {}
+
+impl Backend {
+    /// Per-policy filesystem-trust support (spec 013 D1/D5). Queried for the
+    /// *specific* requested policy — one Backend may differ across the three
+    /// values. codex/gemini enforce at the OS layer; claude/opencode/aikit only
+    /// cooperatively; cursor not at all.
+    pub fn sandbox_support(self, policy: SandboxPolicy) -> KnobSupport {
+        let _ = policy; // support is uniform per Backend today; param reserved for per-value futures.
+        match self {
+            Backend::Codex | Backend::Gemini => KnobSupport::SupportedOsEnforced,
+            Backend::Claude | Backend::OpenCode | Backend::Aikit => KnobSupport::SupportedAppLevel,
+            Backend::Cursor => KnobSupport::Unsupported,
+        }
+    }
+
+    /// `--auto-approve` support (D1 approval axis). Independent of the sandbox
+    /// axis on claude/opencode/gemini/aikit; coupled into `--sandbox` on codex.
+    pub fn auto_approve_support(self) -> KnobSupport {
+        match self {
+            Backend::Codex
+            | Backend::Claude
+            | Backend::Gemini
+            | Backend::OpenCode
+            | Backend::Aikit => KnobSupport::SupportedAppLevel,
+            Backend::Cursor => KnobSupport::Unsupported,
+        }
+    }
+
+    /// `-C, --cd` working-root support (D2). The child cwd is OS-enforced
+    /// (`Command::current_dir`) for every Backend, including in-process aikit.
+    pub fn working_dir_support(self) -> KnobSupport {
+        KnobSupport::SupportedOsEnforced
+    }
+
+    /// `--add-dir` extra-writable-roots support (D2). codex (`--add-dir`) and
+    /// gemini (`SANDBOX_MOUNTS`) enforce via their sandbox; aikit cooperatively;
+    /// claude/opencode/cursor have no native mechanism.
+    pub fn extra_writable_roots_support(self) -> KnobSupport {
+        match self {
+            Backend::Codex | Backend::Gemini => KnobSupport::SupportedOsEnforced,
+            Backend::Aikit => KnobSupport::SupportedAppLevel,
+            Backend::Claude | Backend::OpenCode | Backend::Cursor => KnobSupport::Unsupported,
+        }
+    }
+
+    /// `--output-schema` support (D4 convenience knob). codex and claude have a
+    /// native flag; elsewhere aikit validates the final message itself.
+    pub fn output_schema_support(self) -> KnobSupport {
+        match self {
+            Backend::Codex | Backend::Claude => KnobSupport::SupportedOsEnforced,
+            Backend::Gemini | Backend::OpenCode | Backend::Cursor | Backend::Aikit => {
+                KnobSupport::Emulated
+            }
+        }
+    }
+
+    /// `--bare` support (D6). codex (`--ignore-user-config`) and claude
+    /// (`--bare`); no native equivalent elsewhere.
+    pub fn bare_support(self) -> KnobSupport {
+        match self {
+            Backend::Codex | Backend::Claude => KnobSupport::SupportedOsEnforced,
+            Backend::Gemini | Backend::OpenCode | Backend::Cursor | Backend::Aikit => {
+                KnobSupport::Unsupported
+            }
+        }
+    }
+
+    /// `--ephemeral` support (D6). codex only today.
+    pub fn ephemeral_support(self) -> KnobSupport {
+        match self {
+            Backend::Codex => KnobSupport::SupportedOsEnforced,
+            _ => KnobSupport::Unsupported,
+        }
+    }
+
+    /// `--skip-git-repo-check` support (D6). codex only today.
+    pub fn skip_git_repo_check_support(self) -> KnobSupport {
+        match self {
+            Backend::Codex => KnobSupport::SupportedOsEnforced,
+            _ => KnobSupport::Unsupported,
+        }
+    }
+}
+
+/// Pre-flight resolution (spec 013 D5). Security knobs (`--sandbox`,
+/// `--add-dir`) that the Backend cannot honor at all fail closed; convenience
+/// knobs never fail. Returns the knob that blocked resolution, if any.
+///
+/// `SupportedAppLevel` is *not* a failure — it is honored at cooperative
+/// fidelity and reported honestly; the caller decides whether that suffices.
+pub fn resolve_envelope(backend: Backend, env: &InvocationEnvelope) -> Result<(), UnsupportedKnob> {
+    if let Some(policy) = env.sandbox {
+        let support = backend.sandbox_support(policy);
+        if !support.is_available() {
+            return Err(UnsupportedKnob {
+                backend,
+                knob: "sandbox",
+                detail: format!(
+                    "policy '{}' is unsupported (no native sandbox mechanism)",
+                    policy
+                ),
+            });
+        }
+    }
+    if !env.extra_writable_roots.is_empty()
+        && !backend.extra_writable_roots_support().is_available()
+    {
+        return Err(UnsupportedKnob {
+            backend,
+            knob: "add-dir",
+            detail: "extra writable roots are unsupported (no native mechanism)".to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::backend::ALL;
+
+    #[test]
+    fn sandbox_policy_round_trips() {
+        for &p in SandboxPolicy::ALL {
+            let s = serde_json::to_string(&p).unwrap();
+            let back: SandboxPolicy = serde_json::from_str(&s).unwrap();
+            assert_eq!(back, p, "serde round trip for {p:?}");
+        }
+        assert_eq!(SandboxPolicy::ReadOnly.as_kebab_str(), "read-only");
+        assert_eq!(SandboxPolicy::BoundedWrite.as_kebab_str(), "bounded-write");
+        assert_eq!(SandboxPolicy::Unrestricted.as_kebab_str(), "unrestricted");
+    }
+
+    #[test]
+    fn sandbox_policy_parses_canonical_and_legacy_aliases() {
+        // canonical
+        assert!("read-only".parse::<SandboxPolicy>().unwrap() == SandboxPolicy::ReadOnly);
+        assert!("bounded-write".parse::<SandboxPolicy>().unwrap() == SandboxPolicy::BoundedWrite);
+        assert!("unrestricted".parse::<SandboxPolicy>().unwrap() == SandboxPolicy::Unrestricted);
+        // legacy / native aliases accepted for migration friendliness
+        assert!("readonly".parse::<SandboxPolicy>().unwrap() == SandboxPolicy::ReadOnly);
+        assert!("workspace-write".parse::<SandboxPolicy>().unwrap() == SandboxPolicy::BoundedWrite);
+        assert!(
+            "danger-full-access".parse::<SandboxPolicy>().unwrap() == SandboxPolicy::Unrestricted
+        );
+        assert!("full-access".parse::<SandboxPolicy>().unwrap() == SandboxPolicy::Unrestricted);
+        // unknown
+        assert!("bogus".parse::<SandboxPolicy>().is_err());
+        assert!("".parse::<SandboxPolicy>().is_err());
+    }
+
+    #[test]
+    fn knob_support_is_available_excludes_unsupported() {
+        assert!(KnobSupport::SupportedOsEnforced.is_available());
+        assert!(KnobSupport::SupportedAppLevel.is_available());
+        assert!(KnobSupport::Emulated.is_available());
+        assert!(!KnobSupport::Unsupported.is_available());
+    }
+
+    /// The load-bearing spec-013 matrix: sandbox fidelity per Backend, per
+    /// policy value. Locked so a future change is a conscious decision.
+    #[test]
+    fn sandbox_support_matrix() {
+        for &policy in SandboxPolicy::ALL {
+            assert_eq!(
+                Backend::Codex.sandbox_support(policy),
+                KnobSupport::SupportedOsEnforced
+            );
+            assert_eq!(
+                Backend::Gemini.sandbox_support(policy),
+                KnobSupport::SupportedOsEnforced
+            );
+            assert_eq!(
+                Backend::Claude.sandbox_support(policy),
+                KnobSupport::SupportedAppLevel
+            );
+            assert_eq!(
+                Backend::OpenCode.sandbox_support(policy),
+                KnobSupport::SupportedAppLevel
+            );
+            assert_eq!(
+                Backend::Aikit.sandbox_support(policy),
+                KnobSupport::SupportedAppLevel
+            );
+            assert_eq!(
+                Backend::Cursor.sandbox_support(policy),
+                KnobSupport::Unsupported
+            );
+        }
+    }
+
+    #[test]
+    fn every_backend_declares_every_knob() {
+        // Exhaustive: no panic paths, every Backend answers every knob query.
+        for &b in ALL {
+            let _ = b.auto_approve_support();
+            let _ = b.working_dir_support();
+            let _ = b.extra_writable_roots_support();
+            let _ = b.output_schema_support();
+            let _ = b.bare_support();
+            let _ = b.ephemeral_support();
+            let _ = b.skip_git_repo_check_support();
+            for &p in SandboxPolicy::ALL {
+                let _ = b.sandbox_support(p);
+            }
+        }
+    }
+
+    #[test]
+    fn working_dir_supported_by_all() {
+        for &b in ALL {
+            assert_eq!(b.working_dir_support(), KnobSupport::SupportedOsEnforced);
+        }
+    }
+
+    #[test]
+    fn extra_roots_only_codex_gemini_aikit() {
+        for &b in ALL {
+            let s = b.extra_writable_roots_support();
+            match b {
+                Backend::Codex | Backend::Gemini => assert_eq!(s, KnobSupport::SupportedOsEnforced),
+                Backend::Aikit => assert_eq!(s, KnobSupport::SupportedAppLevel),
+                Backend::Claude | Backend::OpenCode | Backend::Cursor => {
+                    assert_eq!(s, KnobSupport::Unsupported)
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn output_schema_native_for_codex_claude_emulated_elsewhere() {
+        for &b in ALL {
+            let s = b.output_schema_support();
+            match b {
+                Backend::Codex | Backend::Claude => {
+                    assert_eq!(s, KnobSupport::SupportedOsEnforced)
+                }
+                Backend::Gemini | Backend::OpenCode | Backend::Cursor | Backend::Aikit => {
+                    assert_eq!(s, KnobSupport::Emulated)
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn lifecycle_knobs_codex_only_or_codex_claude() {
+        for &b in ALL {
+            // bare: codex + claude
+            assert_eq!(
+                Backend::Codex.bare_support(),
+                KnobSupport::SupportedOsEnforced
+            );
+            assert_eq!(
+                Backend::Claude.bare_support(),
+                KnobSupport::SupportedOsEnforced
+            );
+            // ephemeral / skip-git-repo-check: codex only
+            assert_eq!(
+                Backend::Codex.ephemeral_support(),
+                KnobSupport::SupportedOsEnforced
+            );
+            assert_eq!(
+                Backend::Codex.skip_git_repo_check_support(),
+                KnobSupport::SupportedOsEnforced
+            );
+            // every non-codex lifecycle is unsupported except claude bare
+            if !matches!(b, Backend::Codex) {
+                assert_eq!(b.ephemeral_support(), KnobSupport::Unsupported);
+                assert_eq!(b.skip_git_repo_check_support(), KnobSupport::Unsupported);
+                if !matches!(b, Backend::Claude) {
+                    assert_eq!(b.bare_support(), KnobSupport::Unsupported);
+                }
+            }
+        }
+    }
+
+    // ── fail-closed resolution (D5) ───────────────────────────────────────────
+
+    #[test]
+    fn resolve_cursor_with_sandbox_fails_closed() {
+        let env = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::ReadOnly),
+            ..Default::default()
+        };
+        let err = resolve_envelope(Backend::Cursor, &env).unwrap_err();
+        assert_eq!(err.backend, Backend::Cursor);
+        assert_eq!(err.knob, "sandbox");
+    }
+
+    #[test]
+    fn resolve_claude_with_sandbox_passes_app_level() {
+        // AppLevel is honored (cooperatively), not a failure.
+        let env = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::ReadOnly),
+            ..Default::default()
+        };
+        assert!(resolve_envelope(Backend::Claude, &env).is_ok());
+    }
+
+    #[test]
+    fn resolve_codex_with_sandbox_passes_os_enforced() {
+        let env = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::BoundedWrite),
+            ..Default::default()
+        };
+        assert!(resolve_envelope(Backend::Codex, &env).is_ok());
+    }
+
+    #[test]
+    fn resolve_extra_roots_fails_closed_on_claude() {
+        let env = InvocationEnvelope {
+            extra_writable_roots: vec![PathBuf::from("/tmp/x")],
+            ..Default::default()
+        };
+        let err = resolve_envelope(Backend::Claude, &env).unwrap_err();
+        assert_eq!(err.knob, "add-dir");
+        // codex/gemini/aikit honor it
+        assert!(resolve_envelope(Backend::Codex, &env).is_ok());
+        assert!(resolve_envelope(Backend::Gemini, &env).is_ok());
+        assert!(resolve_envelope(Backend::Aikit, &env).is_ok());
+    }
+
+    #[test]
+    fn resolve_empty_envelope_always_ok() {
+        let env = InvocationEnvelope::default();
+        for &b in ALL {
+            assert!(
+                resolve_envelope(b, &env).is_ok(),
+                "empty envelope for {b:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_convenience_knobs_never_fail() {
+        // output_schema/bare/ephemeral are convenience knobs — never fail closed.
+        let env = InvocationEnvelope {
+            output_schema: Some(serde_json::json!({"type": "object"})),
+            bare: true,
+            ephemeral: true,
+            skip_git_repo_check: true,
+            ..Default::default()
+        };
+        for &b in ALL {
+            assert!(
+                resolve_envelope(b, &env).is_ok(),
+                "convenience knobs for {b:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_knob_display_names_backend_and_knob() {
+        let err = resolve_envelope(
+            Backend::Cursor,
+            &InvocationEnvelope {
+                sandbox: Some(SandboxPolicy::ReadOnly),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("cursor"), "msg: {msg}");
+        assert!(msg.contains("--sandbox"), "msg: {msg}");
+    }
+
+    // ── InvocationEnvelope ─────────────────────────────────────────────────────
+
+    #[test]
+    fn envelope_from_options_maps_fields() {
+        let opts = RunOptions::default()
+            .with_sandbox(SandboxPolicy::BoundedWrite)
+            .with_auto_approve(true)
+            .with_current_dir(PathBuf::from("/repo"))
+            .with_extra_writable_root(PathBuf::from("/shared"))
+            .with_result_file(PathBuf::from("/r.txt"))
+            .with_output_schema(serde_json::json!({"type": "string"}))
+            .with_bare(true)
+            .with_ephemeral(true)
+            .with_skip_git_repo_check(true);
+        let env = InvocationEnvelope::from_options(&opts);
+        assert_eq!(env.sandbox, Some(SandboxPolicy::BoundedWrite));
+        assert!(env.auto_approve);
+        assert_eq!(
+            env.working_dir.as_deref(),
+            Some(std::path::Path::new("/repo"))
+        );
+        assert_eq!(env.extra_writable_roots, vec![PathBuf::from("/shared")]);
+        assert_eq!(
+            env.result_file.as_deref(),
+            Some(std::path::Path::new("/r.txt"))
+        );
+        assert!(env.output_schema.is_some());
+        assert!(env.bare && env.ephemeral && env.skip_git_repo_check);
+        assert!(env.is_active());
+    }
+
+    #[test]
+    fn empty_envelope_is_inactive() {
+        assert!(!InvocationEnvelope::default().is_active());
+        // a single convenience knob activates it
+        assert!(InvocationEnvelope {
+            bare: true,
+            ..Default::default()
+        }
+        .is_active());
+    }
+}

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -8,6 +8,7 @@ pub mod capabilities;
 pub mod claude_session;
 #[cfg(feature = "codex-app-server")]
 pub mod codex_session;
+pub mod invocation;
 #[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
 pub mod live_session;
 pub mod transport;
@@ -16,8 +17,9 @@ pub mod usage;
 
 pub use types::{
     AgentAvailabilityReason, AgentEvent, AgentEventPayload, AgentEventStream, AgentStatus,
-    MessageKind, MessagePhase, MessageRole, OutputMode, ProgressSink, QuotaCategory,
-    QuotaExceededInfo, RunError, RunOptions, RunResult, StreamMessage, TokenUsage, UsageSource,
+    KnobSupport, MessageKind, MessagePhase, MessageRole, OutputMode, ProgressSink, QuotaCategory,
+    QuotaExceededInfo, RunError, RunOptions, RunResult, SandboxPolicy, StreamMessage, TokenUsage,
+    UsageSource,
 };
 
 pub use argv::{is_runnable, runnable_agents};
@@ -35,6 +37,7 @@ pub use claude_session::{
 pub use codex_session::{
     open_codex_session, CodexControlHandle, CodexSession, CodexSessionError, CodexSessionOptions,
 };
+pub use invocation::{resolve_envelope, InvocationEnvelope, UnsupportedKnob};
 // Shared approval types; available when at least one session feature is enabled.
 #[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
 pub use approval::{PermissionCallback, ToolApprovalRequest, ToolDecision};
@@ -948,6 +951,82 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn test_spec013_fail_closed_on_unsupported_sandbox() {
+        use crate::runner::{Backend, RunError, SandboxPolicy};
+        let _guard = PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        // cursor has no native sandbox. Requesting one MUST fail closed in
+        // `connect` (resolve_envelope runs before spawn), so no real agent is
+        // needed beyond a discoverable binary for the availability probe.
+        let dir = tempfile::tempdir().unwrap();
+        let stub = dir.path().join("agent"); // cursor binary candidate
+        let mut f = std::fs::File::create(&stub).unwrap();
+        writeln!(f, "#!/bin/sh\necho hi").unwrap();
+        let mut perms = f.metadata().unwrap().permissions();
+        perms.set_mode(0o755);
+        f.set_permissions(perms).unwrap();
+        drop(f);
+
+        let orig_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{}", dir.path().display(), orig_path));
+
+        let opts = RunOptions::default().with_sandbox(SandboxPolicy::ReadOnly);
+        let result = run_agent_events("cursor", "hi", opts, |_| {});
+
+        std::env::set_var("PATH", orig_path);
+
+        match result {
+            Err(RunError::InvocationUnsupported(err)) => {
+                assert_eq!(err.backend, Backend::Cursor);
+                assert_eq!(err.knob, "sandbox");
+                // RunError::InvocationUnsupported Display delegates to UnsupportedKnob.
+                let rendered = RunError::InvocationUnsupported(err).to_string();
+                assert!(rendered.contains("cursor"), "{}", rendered);
+                assert!(rendered.contains("--sandbox"), "{}", rendered);
+            }
+            other => panic!("expected InvocationUnsupported, got {:?}", other),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_spec013_active_envelope_reaches_subprocess() {
+        use crate::runner::SandboxPolicy;
+        let _guard = PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        // An active envelope (sandbox=bounded-write, which codex honors at OS
+        // level) is mapped onto the codex argv and the run proceeds normally.
+        let dir = tempfile::tempdir().unwrap();
+        let stub = dir.path().join("codex");
+        let mut f = std::fs::File::create(&stub).unwrap();
+        writeln!(f, "#!/bin/sh\necho '{{\"msg\":\"ok\"}}'").unwrap();
+        let mut perms = f.metadata().unwrap().permissions();
+        perms.set_mode(0o755);
+        f.set_permissions(perms).unwrap();
+        drop(f);
+
+        let orig_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{}", dir.path().display(), orig_path));
+
+        let opts = RunOptions::default().with_sandbox(SandboxPolicy::BoundedWrite);
+        let mut events: Vec<AgentEvent> = Vec::new();
+        let result = run_agent_events("codex", "hi", opts, |ev| events.push(ev));
+
+        std::env::set_var("PATH", orig_path);
+
+        assert!(
+            result.is_ok(),
+            "codex with a supported sandbox should run: {:?}",
+            result.err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn test_run_agent_events_sequence_numbers_strictly_increasing() {
         let _guard = PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         use std::io::Write;
@@ -1086,6 +1165,7 @@ mod tests {
                 AgentEventPayload::AikitSubagentResult { .. } => "aikit_subagent_result",
                 AgentEventPayload::AikitContextCompressed { .. } => "aikit_context_compressed",
                 AgentEventPayload::AikitStepFinish { .. } => "aikit_step_finish",
+                AgentEventPayload::Result { .. } => "result",
                 AgentEventPayload::SessionStarted { .. } => "session_started",
             };
             payloads.push(kind.to_string());

--- a/aikit-sdk/src/runner/transport/subprocess.rs
+++ b/aikit-sdk/src/runner/transport/subprocess.rs
@@ -62,13 +62,25 @@ pub(crate) fn connect(
     );
 
     let sid = options.session_id.as_deref();
-    let argv = crate::runner::argv::build_argv(
+    // spec 013: derive the invocation envelope, fail closed on any security
+    // knob this Backend cannot honor (ADR 0012), then build the envelope-aware
+    // argv. An inactive envelope (no spec-013 knobs set) yields the identical
+    // legacy argv.
+    let envelope = crate::runner::invocation::InvocationEnvelope::from_options(options);
+    crate::runner::invocation::resolve_envelope(backend, &envelope)
+        .map_err(RunError::InvocationUnsupported)?;
+    let argv = crate::runner::argv::build_argv_envelope(
         backend.key(),
         options.model.as_ref(),
         options.yolo,
         options.stream,
         events_mode,
         sid,
+        if envelope.is_active() {
+            Some(&envelope)
+        } else {
+            None
+        },
     );
 
     let argv_display: Vec<String> = argv

--- a/aikit-sdk/src/runner/types.rs
+++ b/aikit-sdk/src/runner/types.rs
@@ -109,6 +109,90 @@ pub struct QuotaExceededInfo {
     pub raw_message: String,
 }
 
+/// Vendor-neutral filesystem-trust policy for a sub-agent run (spec 013 D1).
+///
+/// Named for the property, not any one CLI's vocabulary. Mapped per-Backend to
+/// its native sandbox mechanism; see
+/// [`Backend::sandbox_support`](crate::runner::Backend::sandbox_support).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxPolicy {
+    /// No writes.
+    ReadOnly,
+    /// Writes confined to the working root (`current_dir`) plus any
+    /// `extra_writable_roots`.
+    BoundedWrite,
+    /// No filesystem boundary.
+    Unrestricted,
+}
+
+impl SandboxPolicy {
+    /// All policies, in canonical order.
+    pub const ALL: &[SandboxPolicy] = &[
+        SandboxPolicy::ReadOnly,
+        SandboxPolicy::BoundedWrite,
+        SandboxPolicy::Unrestricted,
+    ];
+
+    /// The kebab-case wire identifier (e.g. `read-only`).
+    pub fn as_kebab_str(self) -> &'static str {
+        match self {
+            SandboxPolicy::ReadOnly => "read-only",
+            SandboxPolicy::BoundedWrite => "bounded-write",
+            SandboxPolicy::Unrestricted => "unrestricted",
+        }
+    }
+}
+
+impl std::str::FromStr for SandboxPolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim() {
+            "read-only" | "readonly" => Ok(SandboxPolicy::ReadOnly),
+            "bounded-write" | "workspace-write" => Ok(SandboxPolicy::BoundedWrite),
+            "unrestricted" | "danger-full-access" | "full-access" => {
+                Ok(SandboxPolicy::Unrestricted)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+impl std::fmt::Display for SandboxPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_kebab_str())
+    }
+}
+
+/// How a Backend honors an invocation knob (spec 013 D5).
+///
+/// For the security knob (`--sandbox`) the variants are a *fidelity* ladder:
+/// only [`KnobSupport::SupportedOsEnforced`] (or [`KnobSupport::Emulated`]) is a
+/// real trust boundary; [`KnobSupport::SupportedAppLevel`] is cooperative and is
+/// reported honestly so a caller can decide whether it suffices. A knob that is
+/// [`KnobSupport::Unsupported`] fails closed for security knobs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KnobSupport {
+    /// Backend enforces via OS primitives (codex Landlock/seatbelt, gemini
+    /// seatbelt/gVisor, or the process cwd for `working_dir`).
+    SupportedOsEnforced,
+    /// Backend enforces via cooperative tool/permission policy (claude
+    /// `--permission-mode`, opencode permissions, the in-process aikit policy).
+    SupportedAppLevel,
+    /// aikit enforces/emulates itself (a future aikit-side sandbox wrapper, or
+    /// post-hoc `--output-schema` validation).
+    Emulated,
+    /// No mechanism exists; a security knob with this value fails closed.
+    Unsupported,
+}
+
+impl KnobSupport {
+    /// Anything other than [`KnobSupport::Unsupported`] can be honored.
+    pub fn is_available(self) -> bool {
+        !matches!(self, KnobSupport::Unsupported)
+    }
+}
+
 /// Options for running an agent.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -144,6 +228,29 @@ pub struct RunOptions {
     pub session_agents: std::collections::HashMap<String, serde_json::Value>,
     /// Session ID for resume. None = new session (default, preserves existing behaviour).
     pub session_id: Option<String>,
+    // ── spec 013: common invocation envelope ─────────────────────────────────
+    /// Filesystem-trust policy (`--sandbox`). `None` = backend default. Maps
+    /// per-Backend to its native sandbox (spec 013 D1).
+    pub sandbox: Option<SandboxPolicy>,
+    /// Tool-approval axis: auto-approve every tool call without prompting
+    /// (`--auto-approve`). Independent of `sandbox` on most backends; coupled
+    /// into `--sandbox` on codex (spec 013 D1).
+    pub auto_approve: bool,
+    /// Extra writable roots beyond `current_dir` (`--add-dir`, spec 013 D2).
+    pub extra_writable_roots: Vec<std::path::PathBuf>,
+    /// Write the agent's final message to this file (`--output-result` / `-o`,
+    /// spec 013 D3).
+    pub result_file: Option<std::path::PathBuf>,
+    /// JSON Schema for typed final output (`--output-schema`); validated by
+    /// aikit when the Backend cannot enforce it natively (spec 013 D4).
+    pub output_schema: Option<serde_json::Value>,
+    /// Skip auto-discovery of user config/hooks/skills/MCP for reproducible
+    /// runs (`--bare`; codex `--ignore-user-config`, claude `--bare`, spec 013 D6).
+    pub bare: bool,
+    /// Do not persist the session (`--ephemeral`; codex `--ephemeral`, spec 013 D6).
+    pub ephemeral: bool,
+    /// Skip the headless git-repository guard (`--skip-git-repo-check`, spec 013 D6).
+    pub skip_git_repo_check: bool,
 }
 
 impl Default for RunOptions {
@@ -159,6 +266,14 @@ impl Default for RunOptions {
             session_persona: None,
             session_agents: std::collections::HashMap::new(),
             session_id: None,
+            sandbox: None,
+            auto_approve: false,
+            extra_writable_roots: Vec::new(),
+            result_file: None,
+            output_schema: None,
+            bare: false,
+            ephemeral: false,
+            skip_git_repo_check: false,
         }
     }
 }
@@ -225,6 +340,54 @@ impl RunOptions {
     /// Set the session ID for resume. None (default) starts a new session.
     pub fn with_session_id(mut self, id: impl Into<String>) -> Self {
         self.session_id = Some(id.into());
+        self
+    }
+
+    /// Set the filesystem-trust policy (spec 013 D1).
+    pub fn with_sandbox(mut self, policy: SandboxPolicy) -> Self {
+        self.sandbox = Some(policy);
+        self
+    }
+
+    /// Auto-approve every tool call (spec 013 D1 approval axis).
+    pub fn with_auto_approve(mut self, auto_approve: bool) -> Self {
+        self.auto_approve = auto_approve;
+        self
+    }
+
+    /// Add an extra writable root (spec 013 D2 `--add-dir`).
+    pub fn with_extra_writable_root(mut self, root: std::path::PathBuf) -> Self {
+        self.extra_writable_roots.push(root);
+        self
+    }
+
+    /// Set the result-file path (spec 013 D3 `--output-result` / `-o`).
+    pub fn with_result_file(mut self, path: std::path::PathBuf) -> Self {
+        self.result_file = Some(path);
+        self
+    }
+
+    /// Set the output JSON Schema (spec 013 D4 `--output-schema`).
+    pub fn with_output_schema(mut self, schema: serde_json::Value) -> Self {
+        self.output_schema = Some(schema);
+        self
+    }
+
+    /// Skip user config/hooks/MCP discovery (spec 013 D6 `--bare`).
+    pub fn with_bare(mut self, bare: bool) -> Self {
+        self.bare = bare;
+        self
+    }
+
+    /// Do not persist the session (spec 013 D6 `--ephemeral`).
+    pub fn with_ephemeral(mut self, ephemeral: bool) -> Self {
+        self.ephemeral = ephemeral;
+        self
+    }
+
+    /// Skip the git-repo guard (spec 013 D6 `--skip-git-repo-check`).
+    pub fn with_skip_git_repo_check(mut self, skip: bool) -> Self {
+        self.skip_git_repo_check = skip;
         self
     }
 }
@@ -302,6 +465,9 @@ pub enum RunError {
     SessionNotFound(String),
     /// Session file exists but could not be loaded or deserialized.
     SessionLoadFailed { id: String, reason: String },
+    /// A requested security knob cannot be honored by the backend (spec 013 D5,
+    /// fail-closed pre-flight). Carries the structured reason.
+    InvocationUnsupported(crate::runner::invocation::UnsupportedKnob),
 }
 
 impl std::fmt::Display for RunError {
@@ -350,6 +516,7 @@ impl std::fmt::Display for RunError {
             RunError::SessionLoadFailed { id, reason } => {
                 write!(f, "error: session '{}' could not be loaded: {}", id, reason)
             }
+            RunError::InvocationUnsupported(err) => write!(f, "{}", err),
         }
     }
 }
@@ -368,7 +535,8 @@ impl std::error::Error for RunError {
             | RunError::MissingProgressSink
             | RunError::WrongAgentKey(_)
             | RunError::SessionNotFound(_)
-            | RunError::SessionLoadFailed { .. } => None,
+            | RunError::SessionLoadFailed { .. }
+            | RunError::InvocationUnsupported(_) => None,
         }
     }
 }
@@ -529,6 +697,16 @@ pub enum AgentEventPayload {
     AikitStepFinish {
         iteration: u32,
         finish_reason: String,
+    },
+    /// Terminal result handle (spec 013 D3). Emitted once at run end. The
+    /// `--output-result`/`-o` flag writes `text` (and `structured` when
+    /// `--output-schema` was honored) to a file; streaming callers get the same
+    /// handle from this event without a temp file. Additive — existing
+    /// consumers' `_` arm absorbs it.
+    Result {
+        text: String,
+        structured: Option<serde_json::Value>,
+        session_id: Option<String>,
     },
     /// Emitted once per run as the first event when the SDK has assigned (or
     /// been given) a session_id. Useful for callers that mint a session


### PR DESCRIPTION
Implements spec 013 (specs/013-common-subagent-invocation-interface/spec.md), **slice 1** — the backend-agnostic trust/IO knobs above the Backend/Transport seam (the load-bearing, fully-unit-tested core). Slice 2 (CLI flag wiring + run-loop Result/exit-code propagation) follows.

## What lands
- **SandboxPolicy** (read-only | bounded-write | unrestricted, vendor-neutral) + **KnobSupport** (SupportedOsEnforced | SupportedAppLevel | Emulated | Unsupported) in runner/types.rs.
- **runner/invocation.rs** (new): InvocationEnvelope, the per-Backend capability matrix (sandbox queried **per policy value**, plus auto_approve, working_dir, extra_writable_roots, output_schema, bare/ephemeral/skip_git), and resolve_envelope() which **fails closed** on a security knob a Backend cannot honor (ADR 0012; spec 005 NG-002 — aikit does not synthesize its own OS sandbox).
- RunOptions fields + builders; AgentEventPayload::Result (additive, D3).
- **Argv mapping** via a new build_argv_envelope path threaded through ArgvCtx: codex (--sandbox/--cd/--add-dir/--ignore-user-config/--ephemeral/--skip-git-repo-check), claude (--bare), gemini (-s), opencode (--dir). Legacy positional builder removed; all 35 existing argv tests run unchanged via a None-envelope helper.
- subprocess::connect derives the envelope, runs the fail-closed pre-flight, then builds the argv.

## Design reconciliations with the spec doc
- Spec sketches a BackendCapabilities trait; this codebase already has a BackendCapabilities struct, so the faithful realization (ADR 0008) is methods on the closed Backend enum.
- Spec InvocationRequest == the existing RunOptions (one canonical request object); no parallel struct introduced.

## Test coverage
New logic (cargo-llvm-cov): invocation.rs 100%, argv.rs 100%, backend.rs 96%, argv_spec.rs 95%. New tests cover the capability matrix per policy-value, fail-closed resolution, per-backend argv mapping, the Result payload, and two echo-stub integration tests for the live envelope path + fail-closed. cargo fmt / clippy -D warnings / full workspace test suite (pre-push hook) all green.

## Deferred to slice 2
CLI flags (--sandbox, --auto-approve, -C/--cd, --add-dir, --output-result/-o, --output-schema, --bare, --ephemeral, --skip-git-repo-check, --capabilities), run-loop Result-event emission + --output-result file write, and exit-code propagation (spec D6 table).