### PR TITLE
test(session-sync): cover watch→sync path and CLI execute_sync

### DIFF
--- a/aikit-session-capture/src/watch.rs
+++ b/aikit-session-capture/src/watch.rs
@@ -213,6 +213,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn notify_driver_detects_created_file() {
+        // The notify-based driver is what `aikit session sync --watch` uses.
+        // Create the watch dir first (notify watches existing dirs), start the
+        // driver, then drop a .jsonl file in and assert the event is delivered.
+        // Generous timeout because OS notification latency varies across CI.
+        let tmp = tempfile::tempdir().unwrap();
+        let watch_path = tmp.path().to_path_buf();
+        let adapter = FakeAdapter {
+            kind: crate::ToolKind::ClaudeCode,
+            paths: vec![watch_path.clone()],
+        };
+        let adapters: Vec<&dyn Adapter> = vec![&adapter];
+        let mut driver = NotifyWatchDriver::new(adapters, Duration::from_millis(50))
+            .expect("notify watcher builds");
+
+        let sess_file = watch_path.join("sess.jsonl");
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            std::fs::write(&sess_file, "{\"type\":\"user\"}\n").unwrap();
+        });
+
+        let event = tokio::time::timeout(Duration::from_secs(10), driver.next_event()).await;
+        let path = event
+            .expect("notify driver should deliver an event within 10s")
+            .expect("event stream should not end");
+        assert_eq!(path.extension().unwrap(), "jsonl");
+    }
+
+    #[tokio::test]
     async fn polling_driver_detects_new_file() {
         let tmp = tempfile::tempdir().unwrap();
         let watch_path = tmp.path().to_path_buf();

--- a/aikit-session-sync/Cargo.toml
+++ b/aikit-session-sync/Cargo.toml
@@ -33,7 +33,7 @@ tracing = "0.1"
 walkdir = "2"
 
 [dev-dependencies]
-aikit-session-capture = { path = "../aikit-session-capture", version = "0.1.0", default-features = false, features = ["claudecode", "codex"] }
+aikit-session-capture = { path = "../aikit-session-capture", version = "0.1.0", default-features = false, features = ["claudecode", "codex", "watcher"] }
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"

--- a/aikit-session-sync/tests/watch_sync.rs
+++ b/aikit-session-sync/tests/watch_sync.rs
@@ -1,0 +1,154 @@
+//! Watch → sync integration: prove that a session file *arriving* and later
+//! *growing* on disk is picked up by a watch driver and synced to the blob
+//! sink, scrubbed and content-addressed, exactly as the `aikit session sync
+//! --watch` loop does.
+//!
+//! Uses `PollingWatchDriver` (not `NotifyWatchDriver`) on purpose: polling is
+//! deterministic — it scans on an interval and reports new/mtime-changed files
+//! — so this test is not subject to the timing/coalescing quirks of OS file
+//! notifications. The notify driver itself is smoke-tested separately in
+//! aikit-session-capture (`watch.rs`). The sync side here is the real thing:
+//! the same `SyncEngine::retry_with_backoff` call the CLI watch loop makes.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use aikit_session_capture::watch::{find_adapter_for_path, PollingWatchDriver, WatchDriver};
+use aikit_session_capture::{Adapter, AdapterError, ParseResult, ToolKind};
+use aikit_session_sync::state::InMemorySyncStateStore;
+use aikit_session_sync::{
+    InMemorySink, SyncConfig, SyncEngine, SyncOutcome, SyncSink, SyncStateStore, WatchRetryPolicy,
+};
+use async_trait::async_trait;
+
+/// A watch target rooted at a temp dir — no dependency on a real `~/.claude`
+/// layout. `parse_session_file` must never be called by sync (asserted).
+struct TempDirAdapter {
+    kind: ToolKind,
+    root: PathBuf,
+}
+
+#[async_trait]
+impl Adapter for TempDirAdapter {
+    fn kind(&self) -> ToolKind {
+        self.kind
+    }
+    fn watch_paths(&self) -> Vec<PathBuf> {
+        vec![self.root.clone()]
+    }
+    fn is_session_file(&self, path: &Path) -> bool {
+        path.starts_with(&self.root) && path.extension().is_some_and(|e| e == "jsonl")
+    }
+    async fn parse_session_file(
+        &self,
+        _path: &Path,
+        _from_offset: u64,
+    ) -> Result<ParseResult, AdapterError> {
+        panic!("session sync must not call parse_session_file")
+    }
+}
+
+fn engine(sink: Arc<InMemorySink>) -> SyncEngine {
+    SyncEngine::new(
+        SyncConfig {
+            owner: Some("alice".into()),
+            host: "watch-host".into(),
+            key_prefix: "sessions/".into(),
+            ..SyncConfig::default()
+        },
+        sink as Arc<dyn SyncSink>,
+        Arc::new(InMemorySyncStateStore::default()) as Arc<dyn SyncStateStore>,
+    )
+    .expect("engine")
+}
+
+/// Drive the polling watcher until it reports an event, then sync it the way
+/// the CLI `--watch` loop does. Bounded so a bug can't hang the suite.
+async fn watch_one_and_sync(
+    driver: &mut PollingWatchDriver,
+    adapter: &dyn Adapter,
+    engine: &SyncEngine,
+) -> SyncOutcome {
+    let path = tokio::time::timeout(Duration::from_secs(5), driver.next_event())
+        .await
+        .expect("watcher reported no event within 5s")
+        .expect("watcher stream ended");
+    let adapters: [&dyn Adapter; 1] = [adapter];
+    let matched = find_adapter_for_path(&adapters, &path).expect("adapter claims the path");
+    engine
+        .retry_with_backoff(matched, &path, 6, WatchRetryPolicy::default())
+        .await
+        .expect("watch sync failed")
+}
+
+#[tokio::test]
+async fn new_and_grown_session_files_are_synced_via_watch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    let file = tmp.path().join(format!("{session_id}.jsonl"));
+
+    let sink = Arc::new(InMemorySink::new());
+    let engine = engine(sink.clone());
+    let adapter = TempDirAdapter {
+        kind: ToolKind::ClaudeCode,
+        root: tmp.path().to_path_buf(),
+    };
+    let mut driver = PollingWatchDriver::new(
+        vec![Box::new(TempDirAdapter {
+            kind: ToolKind::ClaudeCode,
+            root: tmp.path().to_path_buf(),
+        })],
+        Duration::from_millis(25),
+    );
+
+    // 1. A new session file arrives with a live-looking secret.
+    tokio::fs::write(
+        &file,
+        "{\"role\":\"user\",\"text\":\"key=AKIAIOSFODNN7EXAMPLE\"}\n",
+    )
+    .await
+    .unwrap();
+
+    let first = watch_one_and_sync(&mut driver, &adapter, &engine).await;
+    let key1 = match first {
+        SyncOutcome::Synced { key, .. } => key,
+        other => panic!("expected Synced on new file, got {other:?}"),
+    };
+
+    // The secret was scrubbed on the watch path, not just in one-shot sync.
+    let stored = sink.get_content(&key1).expect("content object present");
+    let stored = String::from_utf8(stored.to_vec()).unwrap();
+    assert!(
+        !stored.contains("AKIAIOSFODNN7EXAMPLE"),
+        "raw secret must not reach the sink"
+    );
+    assert!(stored.contains("[REDACTED:aws_access_key]"));
+    assert!(key1.starts_with("sessions/alice/claude_code/"));
+    let env = sink
+        .get_envelope(&key1.replace(".jsonl", ".meta.json"))
+        .expect("envelope present");
+    assert_eq!(env.owner, "alice");
+    assert_eq!(env.session_id, session_id);
+    assert_eq!(sink.object_count(), 1);
+
+    // 2. The same transcript grows (a new turn is appended). mtime advances,
+    //    so the poller re-reports it; a second, distinct version is synced.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    tokio::fs::write(
+        &file,
+        "{\"role\":\"user\",\"text\":\"key=AKIAIOSFODNN7EXAMPLE\"}\n{\"role\":\"assistant\",\"text\":\"more\"}\n",
+    )
+    .await
+    .unwrap();
+
+    let key2 = match watch_one_and_sync(&mut driver, &adapter, &engine).await {
+        SyncOutcome::Synced { key, .. } => key,
+        other => panic!("expected Synced on grown file, got {other:?}"),
+    };
+    assert_ne!(
+        key1, key2,
+        "grown transcript must produce a new version key"
+    );
+    assert_eq!(sink.object_count(), 2, "both versions retained");
+}

--- a/tests/session_sync_cli_test.rs
+++ b/tests/session_sync_cli_test.rs
@@ -1,0 +1,129 @@
+//! CLI-level tests for `aikit session sync` (`execute_sync`).
+//!
+//! Covers the command glue that the in-crate `aikit-session-sync` tests can't
+//! reach: env-var resolution, the fail-closed owner rule, `--format`
+//! validation, and exit-code mapping. These call `execute_sync` in-process
+//! (not the spawned binary) so we can assert exit codes precisely.
+//!
+//! `execute_sync` reads process-global env vars, so every test serializes on a
+//! shared lock and starts from a cleaned env, restoring on drop. The exit-2
+//! config/auth paths all return *before* any S3 client is built or any file is
+//! written, so they need neither network nor a real home.
+#![cfg(feature = "agent-adapters")]
+
+use std::sync::OnceLock;
+
+use aikit::cli::session::{execute_sync, SyncSessionsArgs};
+use tokio::sync::{Mutex, MutexGuard};
+
+const VARS: &[&str] = &[
+    "AIKIT_SYNC_BUCKET",
+    "AIKIT_SYNC_ENDPOINT",
+    "AIKIT_SYNC_REGION",
+    "AIKIT_SYNC_OWNER",
+    "AIKIT_SYNC_PREFIX",
+    "AIKIT_SYNC_ALLOW_HTTP",
+    "AIKIT_SYNC_ENDPOINT_CA_BUNDLE",
+    "AIKIT_SYNC_CREDENTIAL_OWNER",
+    "RUST_LOG",
+];
+
+/// Serialize env-mutating tests on an async-aware lock (held across `.await`)
+/// and start each from a cleaned env.
+async fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let guard = LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    for v in VARS {
+        std::env::remove_var(v);
+    }
+    guard
+}
+
+/// Defaults: no flags set. Tests override the fields they exercise.
+fn args() -> SyncSessionsArgs {
+    SyncSessionsArgs {
+        bucket: None,
+        endpoint: None,
+        region: None,
+        owner: None,
+        key_prefix: None,
+        tools: vec![],
+        watch: false,
+        dry_run: false,
+        allow_http: false,
+        format: "default".to_string(),
+        log_level: None,
+    }
+}
+
+#[tokio::test]
+async fn invalid_format_returns_2() {
+    let _g = env_lock().await;
+    let mut a = args();
+    a.format = "yaml".to_string();
+    a.owner = Some("alice".into());
+    assert_eq!(execute_sync(a).await.unwrap(), 2);
+}
+
+#[tokio::test]
+async fn missing_bucket_and_endpoint_returns_2() {
+    let _g = env_lock().await;
+    let mut a = args();
+    a.owner = Some("alice".into()); // owner ok, but no bucket/endpoint
+    assert_eq!(execute_sync(a).await.unwrap(), 2);
+}
+
+#[tokio::test]
+async fn missing_owner_returns_2() {
+    let _g = env_lock().await;
+    let mut a = args();
+    a.bucket = Some("b".into());
+    a.endpoint = Some("http://127.0.0.1:9000".into());
+    a.allow_http = true;
+    // No owner anywhere → resolve_owner fails closed.
+    assert_eq!(execute_sync(a).await.unwrap(), 2);
+}
+
+#[tokio::test]
+async fn owner_mismatch_fails_closed_returns_2() {
+    let _g = env_lock().await;
+    std::env::set_var("AIKIT_SYNC_CREDENTIAL_OWNER", "bob");
+    let mut a = args();
+    a.bucket = Some("b".into());
+    a.endpoint = Some("http://127.0.0.1:9000".into());
+    a.allow_http = true;
+    a.owner = Some("alice".into()); // disagrees with credential owner "bob"
+    assert_eq!(execute_sync(a).await.unwrap(), 2);
+}
+
+/// Config supplied entirely through env (no flags) resolves and a dry run
+/// completes with exit 0 — proving the env fallbacks are wired. Unix-only and
+/// hermetic: `$HOME` is redirected to a temp dir so the state store and the
+/// adapters' `~/.claude`/`~/.codex` scans stay inside the sandbox and never
+/// touch the real home (dirs::home_dir honors $HOME on unix; on Windows it
+/// would not, which is why this is gated).
+#[cfg(unix)]
+#[tokio::test]
+async fn env_fallbacks_resolve_and_dry_run_exits_0() {
+    let _g = env_lock().await;
+    let home = tempfile::tempdir().unwrap();
+    let prev_home = std::env::var_os("HOME");
+    std::env::set_var("HOME", home.path());
+    std::env::set_var("AIKIT_SYNC_BUCKET", "env-bucket");
+    std::env::set_var("AIKIT_SYNC_ENDPOINT", "http://127.0.0.1:9000");
+    std::env::set_var("AIKIT_SYNC_OWNER", "env-alice");
+
+    let mut a = args();
+    a.dry_run = true; // no network; InMemorySink
+
+    let code = execute_sync(a).await.unwrap();
+
+    match prev_home {
+        Some(v) => std::env::set_var("HOME", v),
+        None => std::env::remove_var("HOME"),
+    }
+    assert_eq!(
+        code, 0,
+        "env-resolved dry run over an empty home should succeed"
+    );
+}


### PR DESCRIPTION
Closes the two test gaps identified after the session-sync feature shipped: the live **watch path** and the **CLI command glue** (`execute_sync`) were both untested.

## Watch → sync path

- **`aikit-session-sync/tests/watch_sync.rs`** (new): a session file *arriving* and later *growing* on disk is picked up by a `WatchDriver` and synced to the sink — scrubbed, content-addressed — via the **same `SyncEngine::retry_with_backoff` call the CLI `--watch` loop makes**. Asserts new → v1, grown → v2, both versions retained, and that the secret is redacted on the watch path (not just in one-shot sync). Uses `PollingWatchDriver` for determinism (no OS-notification timing flakiness).
- **`aikit-session-capture/src/watch.rs`**: `notify_driver_detects_created_file` smoke-tests the real **`NotifyWatchDriver`** (the driver `--watch` actually uses) with a generous 10s timeout.
- `aikit-session-sync` dev-deps enable the capture crate's `watcher` feature.

## CLI glue (`tests/session_sync_cli_test.rs`, new)

Calls `aikit::cli::session::execute_sync` in-process to assert exit-code / config / auth behavior the crate tests can't reach:

- invalid `--format` → `2`
- missing bucket/endpoint (non-dry-run) → `2`
- missing owner → `2`
- `--owner` vs `AIKIT_SYNC_CREDENTIAL_OWNER` mismatch → fails closed `2`
- full env-var resolution + dry-run → `0` (unix-gated, `$HOME` redirected to a temp dir so it's hermetic and never writes the real home — consistent with the Windows-CI isolation fixes)

Env-mutating tests serialize on an async-aware lock and start from a cleaned env.

## Validation

- `aikit-session-sync`: 23 lib + e2e_minio(real MinIO) + session_sync + **watch_sync** all pass
- `aikit-cli --test session_sync_cli_test`: **5 passed**
- `aikit-session-capture` watch (incl. new notify test): 3 passed
- clippy `--all-targets --all-features -D warnings`: clean (async mutex avoids `await_holding_lock`)
- coverage `aikit-session-sync`: **95.85%** lines (engine 96.90%, sink 98.68%), gate ≥95% holds

## Still not covered (by design)

The thin `watch_sync` loop *function* in `src/cli/session.rs` (an infinite `while let Some(path) = watcher.next_event()`) is glue over now-tested pieces; testing the loop body directly would require refactoring it out of the binary. The driver + the per-event sync it calls are both covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
