### PR TITLE
ci(agent-e2e): nightly real-agent smoke against a custom LLM gateway

### DIFF
--- a/.github/workflows/nightly-agent-e2e.yml
+++ b/.github/workflows/nightly-agent-e2e.yml
@@ -1,0 +1,62 @@
+name: Nightly Agent E2E
+
+# Runs ACTUAL agents (Claude Code via aikit) against a custom LLM gateway and
+# asserts the capture + sync pipeline end-to-end. Kept OFF the PR path on
+# purpose: it needs gateway secrets, takes minutes, and shouldn't gate every PR
+# or run on forks. Nightly on main + manual dispatch.
+#
+# Required repo secrets:
+#   LLM_GATEWAY_URL — the gateway's Anthropic-compatible base URL (public HTTPS)
+#   LLM_GATEWAY_KEY — the gateway API key
+#
+# This is the reusable harness for real-agent testing: extend ci/agent-e2e/
+# (more agents, more cases) as agentic features grow.
+
+on:
+  schedule:
+    # 06:00 UTC nightly.
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-agent-e2e
+  cancel-in-progress: true
+
+jobs:
+  claude-smoke:
+    name: Claude smoke (real agent → gateway)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Verify gateway secrets are configured
+        id: guard
+        env:
+          LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
+          LLM_GATEWAY_KEY: ${{ secrets.LLM_GATEWAY_KEY }}
+        run: |
+          if [ -z "${LLM_GATEWAY_URL}" ] || [ -z "${LLM_GATEWAY_KEY}" ]; then
+            echo "gateway secrets not configured — skipping the real-agent smoke."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build the agent-e2e image
+        if: steps.guard.outputs.run == 'true'
+        run: docker build -f ci/agent-e2e/Dockerfile.agent-e2e -t aikit-agent-e2e .
+
+      - name: Run Claude smoke against the gateway
+        if: steps.guard.outputs.run == 'true'
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.LLM_GATEWAY_URL }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_GATEWAY_KEY }}
+        run: |
+          docker run --rm \
+            -e ANTHROPIC_BASE_URL \
+            -e ANTHROPIC_AUTH_TOKEN \
+            aikit-agent-e2e

--- a/ci/agent-e2e/Dockerfile.agent-e2e
+++ b/ci/agent-e2e/Dockerfile.agent-e2e
@@ -1,0 +1,42 @@
+# Real-agent E2E image for the nightly pipeline.
+#
+# Bundles the aikit binary with the Claude Code CLI so the smoke suite can run
+# ACTUAL agent turns against a custom LLM gateway (Anthropic-compatible), then
+# assert the capture + sync pipeline end-to-end. No real Anthropic spend: the
+# gateway is injected at runtime via ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN.
+#
+# Reusable: add more agent CLIs (codex, gemini, …) and more cases to smoke.sh as
+# agentic features grow. Claude-only for the first cut.
+
+# ---- build stage: compile the aikit binary ----
+FROM rust:1.93-bookworm AS build
+WORKDIR /src
+COPY . .
+# Default features include the agent adapters + watcher, which is what the
+# smoke suite exercises (agent run + session capture + session sync).
+RUN cargo build --release --bin aikit
+
+# ---- runtime stage: aikit + Claude Code CLI ----
+FROM node:22-bookworm-slim AS runtime
+
+# jq for asserting on the JSON sync summary; ca-certificates for TLS to the gateway.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# The real Claude Code CLI — this is the agent aikit drives.
+RUN npm install -g @anthropic-ai/claude-code
+
+COPY --from=build /src/target/release/aikit /usr/local/bin/aikit
+COPY ci/agent-e2e/smoke.sh /usr/local/bin/agent-smoke
+RUN chmod +x /usr/local/bin/agent-smoke
+
+# A non-root home so ~/.claude/projects is writable and isolated.
+ENV HOME=/home/agent
+RUN mkdir -p /home/agent && chmod 777 /home/agent
+WORKDIR /home/agent
+
+# The gateway endpoint + key are provided at `docker run` time, never baked in.
+#   ANTHROPIC_BASE_URL   — the gateway's Anthropic-compatible base URL
+#   ANTHROPIC_AUTH_TOKEN — the gateway API key
+CMD ["agent-smoke"]

--- a/ci/agent-e2e/README.md
+++ b/ci/agent-e2e/README.md
@@ -1,0 +1,62 @@
+# Real-agent E2E harness
+
+Runs **actual agents** (Claude Code, driven by `aikit`) against a custom
+LLM gateway and asserts the capture + sync pipeline end-to-end. This is where
+agentic behavior gets exercised with a real agent instead of mocks, so PR CI
+can stay fast and offline.
+
+## Why
+
+Unit/integration tests mock the transport. That can't catch "does a real agent
+turn actually complete, get captured to `~/.claude/projects`, and get detected
+by `aikit session sync`?". This harness does, using your own gateway
+(Anthropic-compatible, backed by a self-hosted model) so there's **no real
+Anthropic spend**.
+
+## Pieces
+
+| File | Role |
+|------|------|
+| `Dockerfile.agent-e2e` | Image: the `aikit` binary + the Claude Code CLI. |
+| `smoke.sh` | The suite: one real turn → assert capture → assert sync detection. |
+| `../../.github/workflows/nightly-agent-e2e.yml` | Nightly (06:00 UTC) + manual `workflow_dispatch`. |
+
+The smoke asserts the **pipeline, not the model's wording** — a modest
+self-hosted model must still pass. It checks: `aikit agent run --agent claude`
+exits 0, a `*.jsonl` transcript appears under `~/.claude/projects`, and
+`aikit session sync --dry-run` reports `synced >= 1`.
+
+## Required repo secrets
+
+| Secret | Meaning |
+|--------|---------|
+| `LLM_GATEWAY_URL` | The gateway's Anthropic-compatible base URL (public HTTPS). |
+| `LLM_GATEWAY_KEY` | The gateway API key. |
+
+The workflow **skips cleanly** (green, no-op) when these are unset — so forks
+and secret-less environments don't fail.
+
+## Run it
+
+- **CI:** Actions → *Nightly Agent E2E* → *Run workflow* (or wait for the nightly).
+- **Locally:**
+  ```bash
+  docker build -f ci/agent-e2e/Dockerfile.agent-e2e -t aikit-agent-e2e .
+  docker run --rm \
+    -e ANTHROPIC_BASE_URL="https://your-gateway.example.com" \
+    -e ANTHROPIC_AUTH_TOKEN="your-gateway-key" \
+    aikit-agent-e2e
+  ```
+
+## Extending
+
+This is the reusable base for real-agent testing. To grow it:
+
+- **More agents** — add the CLI to the Dockerfile (`codex`, `gemini`, …) and a
+  case in `smoke.sh` (or a sibling script). Codex needs an OpenAI-compatible
+  route from the gateway.
+- **More behaviors** — add cases for tool-use round-trips, streaming, resume,
+  multi-turn. Keep assertions on structure/pipeline, not model wording, so they
+  stay robust against the backing model.
+- **More environments** — matrix the runner/image to test different OSes or
+  agent-CLI versions.

--- a/ci/agent-e2e/smoke.sh
+++ b/ci/agent-e2e/smoke.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Real-agent smoke suite. Runs an ACTUAL Claude Code turn through aikit against
+# the injected LLM gateway, then asserts the capture + sync pipeline end-to-end.
+#
+# Deliberately asserts the PIPELINE, not the model's wording — a modest
+# self-hosted model behind the gateway must still make this pass. What we prove:
+#   1. `aikit agent run --agent claude` completes a real turn (exit 0).
+#   2. A session transcript was captured under ~/.claude/projects.
+#   3. `aikit session sync --dry-run` detects and would sync that transcript.
+#
+# Required env (injected by the nightly workflow from repo secrets):
+#   ANTHROPIC_BASE_URL   — gateway Anthropic-compatible base URL
+#   ANTHROPIC_AUTH_TOKEN — gateway API key
+set -euo pipefail
+
+: "${ANTHROPIC_BASE_URL:?ANTHROPIC_BASE_URL (gateway URL) is required}"
+: "${ANTHROPIC_AUTH_TOKEN:?ANTHROPIC_AUTH_TOKEN (gateway key) is required}"
+export ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN
+
+echo "== aikit version =="
+aikit --version || true
+echo "== gateway: ${ANTHROPIC_BASE_URL} =="
+
+# 1. A real agent turn via the gateway. We don't assert the reply text (the
+#    backing model may be small); a clean exit means a turn round-tripped.
+echo "== [1/3] running a real claude turn =="
+aikit agent run --agent claude --prompt "Reply with the single word: pong"
+echo "   turn completed (exit 0)"
+
+# 2. The turn must have produced a captured session transcript.
+echo "== [2/3] checking captured session files =="
+shopt -s nullglob
+mapfile -t sessions < <(find "$HOME/.claude/projects" -name '*.jsonl' 2>/dev/null)
+if [ "${#sessions[@]}" -eq 0 ]; then
+  echo "FAIL: no session transcript captured under ~/.claude/projects" >&2
+  exit 1
+fi
+echo "   captured ${#sessions[@]} session file(s)"
+
+# 3. Sync must detect the transcript. Dry-run keeps it network-free (no bucket):
+#    it detects + scrubs + hashes and reports what it WOULD upload.
+echo "== [3/3] session sync --dry-run detects the transcript =="
+summary="$(aikit session sync --tool claude_code --owner ci --dry-run --format json)"
+echo "   summary: ${summary}"
+detected="$(echo "${summary}" | jq -r '.synced // 0')"
+if [ "${detected}" -lt 1 ]; then
+  echo "FAIL: session sync did not detect the captured transcript (synced=${detected})" >&2
+  exit 1
+fi
+
+echo "SMOKE PASS: real agent turn captured and sync-detected (synced=${detected})"


### PR DESCRIPTION
Adds the reusable **real-agent E2E harness** requested as a follow-up: runs an actual Claude Code turn (driven by `aikit`) against a custom Anthropic-compatible LLM gateway, then asserts the capture + sync pipeline end-to-end — coverage that mocked-transport tests can't provide. Uses your own gateway, so no real Anthropic spend.

## Pieces
- `ci/agent-e2e/Dockerfile.agent-e2e` — `aikit` binary + Claude Code CLI.
- `ci/agent-e2e/smoke.sh` — real turn → assert a transcript is captured under `~/.claude/projects` → assert `session sync --dry-run` detects it (`synced >= 1`). **Asserts the pipeline, not the model's wording**, so a modest self-hosted model still passes.
- `.github/workflows/nightly-agent-e2e.yml` — nightly (06:00 UTC) + `workflow_dispatch`; **off the PR path** (needs secrets, minutes-long); **skips cleanly** when secrets are unset (forks stay green).
- `ci/agent-e2e/README.md` — secrets, local run, how to extend.

## Decisions baked in (per request)
- **Public HTTPS gateway** → GitHub-hosted runner, no Tailscale.
- **Claude-only** first cut.
- **Smoke-scoped** first cut (one turn + capture + sync detection).

## Required repo secrets
- `LLM_GATEWAY_URL` — gateway Anthropic-compatible base URL
- `LLM_GATEWAY_KEY` — gateway API key

## Verify / first run
Set the two secrets, then Actions → *Nightly Agent E2E* → *Run workflow*. I can't run it here (no gateway secrets), so it's built correct-by-construction and dispatch-triggerable for the first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)