### PR TITLE
feat(aikit-sdk): bridge prerequisites — resume-discovery seam + claude turn_completed

### DIFF
--- a/aikit-sdk/src/runner/backend.rs
+++ b/aikit-sdk/src/runner/backend.rs
@@ -8,6 +8,7 @@
 //! Backend; an unknown key fails to parse.
 
 use std::ffi::OsString;
+use std::path::Path;
 
 use super::backends::argv_spec::ArgvCtx;
 use super::backends::{aikit, claude, codex, cursor, gemini, opencode};
@@ -130,6 +131,32 @@ impl Backend {
             Backend::OpenCode => opencode::CAPABILITIES,
             Backend::Cursor => cursor::CAPABILITIES,
             Backend::Aikit => aikit::CAPABILITIES,
+        }
+    }
+
+    /// Discover the newest locally resumable session id for this Backend.
+    pub fn discover_resumable_session(self, home: &Path) -> Option<String> {
+        match self {
+            Backend::Claude => {
+                let home_pattern = glob::Pattern::escape(&home.to_string_lossy());
+                let pattern = format!("{home_pattern}/.claude/projects/*/*.jsonl");
+                glob::glob(&pattern)
+                    .ok()?
+                    .filter_map(Result::ok)
+                    .filter_map(|path| {
+                        let modified = path.metadata().ok()?.modified().ok()?;
+                        let session_id = path.file_stem()?.to_str()?.to_string();
+                        Some((modified, session_id))
+                    })
+                    .max_by_key(|(modified, _)| *modified)
+                    .map(|(_, session_id)| session_id)
+            }
+            // TODO(per-backend): add on-disk resume discovery for other CLIs.
+            Backend::Codex
+            | Backend::Gemini
+            | Backend::OpenCode
+            | Backend::Cursor
+            | Backend::Aikit => None,
         }
     }
 
@@ -259,6 +286,52 @@ mod tests {
         assert_eq!(
             Backend::Cursor.binary_candidates(),
             &["cursor-agent", "agent"]
+        );
+    }
+
+    #[test]
+    fn claude_discovers_resumable_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_dir = dir.path().join(".claude/projects/example");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("sess-1.jsonl"), "{}\n").unwrap();
+
+        assert_eq!(
+            Backend::Claude.discover_resumable_session(dir.path()),
+            Some("sess-1".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_discovery_returns_none_when_empty_or_absent() {
+        let absent = tempfile::tempdir().unwrap();
+        assert_eq!(
+            Backend::Claude.discover_resumable_session(absent.path()),
+            None
+        );
+
+        let empty = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(empty.path().join(".claude/projects/example")).unwrap();
+        assert_eq!(
+            Backend::Claude.discover_resumable_session(empty.path()),
+            None
+        );
+    }
+
+    #[test]
+    fn claude_discovery_uses_newest_modified_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_dir = dir.path().join(".claude/projects/first");
+        let second_dir = dir.path().join(".claude/projects/second");
+        std::fs::create_dir_all(&first_dir).unwrap();
+        std::fs::create_dir_all(&second_dir).unwrap();
+        std::fs::write(first_dir.join("older.jsonl"), "{}\n").unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        std::fs::write(second_dir.join("newer.jsonl"), "{}\n").unwrap();
+
+        assert_eq!(
+            Backend::Claude.discover_resumable_session(dir.path()),
+            Some("newer".to_string())
         );
     }
 

--- a/aikit-sdk/src/runner/claude_session.rs
+++ b/aikit-sdk/src/runner/claude_session.rs
@@ -419,42 +419,7 @@ async fn run_session(
                         if ty == "control_request" || ty == "control_response" {
                             continue;
                         }
-                        // Emit SessionStarted on the first result message that
-                        // carries a session_id so callers can observe it and
-                        // use it for a subsequent `resume`.
-                        if ty == "result" {
-                            if let Some(sid) =
-                                value.get("session_id").and_then(|v| v.as_str())
-                            {
-                                let _ = event_tx.send(AgentEvent {
-                                    agent_key: "claude".to_string(),
-                                    seq,
-                                    stream: AgentEventStream::Stdout,
-                                    payload: AgentEventPayload::SessionStarted {
-                                        session_id: sid.to_string(),
-                                    },
-                                });
-                                seq += 1;
-                            }
-                        }
-                        if let Ok(Some(msg)) = parse_message(&value) {
-                            for frame in map_message(msg, AgentEventStream::Stdout, seq) {
-                                let payload = decoded_to_payload(frame);
-                                if event_tx
-                                    .send(AgentEvent {
-                                        agent_key: "claude".to_string(),
-                                        seq,
-                                        stream: AgentEventStream::Stdout,
-                                        payload,
-                                    })
-                                    .is_err()
-                                {
-                                    closed = true;
-                                    break;
-                                }
-                                seq += 1;
-                            }
-                        }
+                        emit_inbound_value_events(&event_tx, &value, ty, &mut seq, &mut closed);
                     }
                     Some(Err(e)) => {
                         emit_error(&event_tx, format!("stream error: {e}"));
@@ -522,6 +487,73 @@ fn decoded_to_payload(frame: Decoded) -> AgentEventPayload {
     }
 }
 
+fn send_stdout_event(
+    event_tx: &mpsc::Sender<AgentEvent>,
+    seq: &mut u64,
+    payload: AgentEventPayload,
+) -> bool {
+    if event_tx
+        .send(AgentEvent {
+            agent_key: "claude".to_string(),
+            seq: *seq,
+            stream: AgentEventStream::Stdout,
+            payload,
+        })
+        .is_err()
+    {
+        return false;
+    }
+    *seq += 1;
+    true
+}
+
+fn emit_inbound_value_events(
+    event_tx: &mpsc::Sender<AgentEvent>,
+    value: &serde_json::Value,
+    ty: &str,
+    seq: &mut u64,
+    closed: &mut bool,
+) {
+    // Emit SessionStarted on the first result message that carries a session_id
+    // so callers can observe it and use it for a subsequent `resume`.
+    if ty == "result" {
+        if let Some(sid) = value.get("session_id").and_then(|v| v.as_str()) {
+            if !send_stdout_event(
+                event_tx,
+                seq,
+                AgentEventPayload::SessionStarted {
+                    session_id: sid.to_string(),
+                },
+            ) {
+                *closed = true;
+                return;
+            }
+        }
+    }
+
+    if let Ok(Some(msg)) = parse_message(value) {
+        for frame in map_message(msg, AgentEventStream::Stdout, *seq) {
+            if !send_stdout_event(event_tx, seq, decoded_to_payload(frame)) {
+                *closed = true;
+                return;
+            }
+        }
+    }
+
+    if ty == "result"
+        && !send_stdout_event(
+            event_tx,
+            seq,
+            AgentEventPayload::AikitStepFinish {
+                iteration: 0,
+                finish_reason: "turn_completed".into(),
+            },
+        )
+    {
+        *closed = true;
+    }
+}
+
 fn emit_error(event_tx: &mpsc::Sender<AgentEvent>, message: String) {
     let _ = event_tx.send(AgentEvent {
         agent_key: "claude".to_string(),
@@ -581,6 +613,47 @@ mod tests {
         // Callback present → CLI routes permission prompts via "stdio".
         assert_eq!(opts.permission_prompt_tool_name.as_deref(), Some("stdio"));
         assert!(build_query_config(&with_cb).can_use_tool.is_some());
+    }
+
+    #[test]
+    fn result_message_emits_turn_completed_after_final_frame() {
+        let value = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "duration_ms": 1,
+            "duration_api_ms": 1,
+            "is_error": false,
+            "num_turns": 1,
+            "session_id": "sess-9",
+            "result": "done"
+        });
+        let (tx, rx) = mpsc::channel();
+        let mut seq = 0;
+        let mut closed = false;
+
+        emit_inbound_value_events(&tx, &value, "result", &mut seq, &mut closed);
+        drop(tx);
+
+        let events: Vec<_> = rx.into_iter().collect();
+        assert!(!closed);
+        assert_eq!(seq, 3);
+        assert!(matches!(
+            events[0].payload,
+            AgentEventPayload::SessionStarted { ref session_id } if session_id == "sess-9"
+        ));
+        assert!(matches!(
+            events[1].payload,
+            AgentEventPayload::StreamMessage(ref message)
+                if message.phase == crate::runner::types::MessagePhase::Final
+                    && message.text == "done"
+        ));
+        assert!(matches!(
+            events[2].payload,
+            AgentEventPayload::AikitStepFinish {
+                iteration: 0,
+                ref finish_reason
+            } if finish_reason == "turn_completed"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Two small, additive `aikit-sdk` changes that let an external bridge drive claude
as a **held live session**. Prerequisites for `cogni-plus/cogni-agents` spec 001
(the `cogni-agent-aikit` bridge that replaces cogni's Python `wrapper.py`).

## Changes
1. **claude emits a canonical turn-complete event.** `claude_session` now emits
   `AikitStepFinish { finish_reason: "turn_completed" }` after each `result`
   message — exactly what `codex_session` already emits. This gives a
   backend-agnostic per-turn boundary a live-session consumer can segment on,
   instead of inferring from claude-specific stream shape. Inbound handling was
   refactored into `emit_inbound_value_events`.
2. **Resume-discovery backend seam.** New `Backend::discover_resumable_session(home)`:
   for claude it globs the newest `~/.claude/projects/*.jsonl` and returns its
   session id (adopting an existing transcript, so a cold pod resumes context);
   other backends return `None`. Keeps claude's on-disk knowledge inside aikit.

## Tests
`cargo test -p aikit-sdk --features claude-control` → 34 pass, incl. new:
turn-complete ordering (`SessionStarted` → `Final` → `turn_completed`), and
discovery found/absent/newest-mtime. clippy `-D warnings` + `fmt --check` clean.

Additive only; no public signatures changed. Consumed downstream via a
rev-pin once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)