### PR TITLE
ci(agent-e2e): reach the LLM gateway over the Tailnet, not a public endpoint

### DIFF
--- a/.github/workflows/nightly-agent-e2e.yml
+++ b/.github/workflows/nightly-agent-e2e.yml
@@ -1,13 +1,21 @@
 name: Nightly Agent E2E
 
-# Runs ACTUAL agents (Claude Code via aikit) against a custom LLM gateway and
-# asserts the capture + sync pipeline end-to-end. Kept OFF the PR path on
-# purpose: it needs gateway secrets, takes minutes, and shouldn't gate every PR
-# or run on forks. Nightly on main + manual dispatch.
+# Runs ACTUAL agents (Claude Code via aikit) against our LLM gateway over the
+# Tailnet, and asserts the capture + sync pipeline end-to-end. Kept OFF the PR
+# path on purpose: it needs secrets + Tailnet access, takes minutes, and
+# shouldn't gate every PR or run on forks. Nightly on main + manual dispatch.
+#
+# The gateway is reached over the Tailnet (not a public endpoint): the runner
+# joins the Tailnet with an ephemeral, tagged node, and the smoke container uses
+# the host network so it can resolve/reach the internal gateway address.
 #
 # Required repo secrets:
-#   LLM_GATEWAY_URL — the gateway's Anthropic-compatible base URL (public HTTPS)
-#   LLM_GATEWAY_KEY — the gateway API key
+#   TS_OAUTH_CLIENT_ID  — Tailscale OAuth client id (scoped to a tag, e.g. tag:ci)
+#   TS_OAUTH_SECRET     — Tailscale OAuth client secret
+#   LLM_GATEWAY_URL     — the gateway's Anthropic-compatible base URL on the
+#                         Tailnet (MagicDNS name or 100.x tailnet IP, e.g.
+#                         http://gateway.<tailnet>.ts.net:4000)
+#   LLM_GATEWAY_KEY     — the gateway API key
 #
 # This is the reusable harness for real-agent testing: extend ci/agent-e2e/
 # (more agents, more cases) as agentic features grow.
@@ -20,6 +28,8 @@ on:
 
 permissions:
   contents: read
+  # Required by tailscale/github-action to mint an OIDC token for OAuth.
+  id-token: write
 
 concurrency:
   group: nightly-agent-e2e
@@ -27,36 +37,51 @@ concurrency:
 
 jobs:
   claude-smoke:
-    name: Claude smoke (real agent → gateway)
+    name: Claude smoke (real agent → gateway over Tailnet)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Verify gateway secrets are configured
+      - name: Verify secrets are configured
         id: guard
         env:
           LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
           LLM_GATEWAY_KEY: ${{ secrets.LLM_GATEWAY_KEY }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
         run: |
-          if [ -z "${LLM_GATEWAY_URL}" ] || [ -z "${LLM_GATEWAY_KEY}" ]; then
-            echo "gateway secrets not configured — skipping the real-agent smoke."
+          if [ -z "${LLM_GATEWAY_URL}" ] || [ -z "${LLM_GATEWAY_KEY}" ] \
+             || [ -z "${TS_OAUTH_CLIENT_ID}" ] || [ -z "${TS_OAUTH_SECRET}" ]; then
+            echo "gateway/Tailscale secrets not configured — skipping the real-agent smoke."
             echo "run=false" >> "$GITHUB_OUTPUT"
           else
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Connect to the Tailnet
+        if: steps.guard.outputs.run == 'true'
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          # The OAuth client must be authorized for this tag in the Tailscale
+          # ACLs; the node is ephemeral and auto-removed when the job ends.
+          tags: tag:ci
+
       - name: Build the agent-e2e image
         if: steps.guard.outputs.run == 'true'
         run: docker build -f ci/agent-e2e/Dockerfile.agent-e2e -t aikit-agent-e2e .
 
-      - name: Run Claude smoke against the gateway
+      - name: Run Claude smoke against the gateway over the Tailnet
         if: steps.guard.outputs.run == 'true'
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.LLM_GATEWAY_URL }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_GATEWAY_KEY }}
         run: |
-          docker run --rm \
+          # --network host lets the container use the runner's Tailnet
+          # connectivity and MagicDNS resolution to reach the internal gateway.
+          docker run --rm --network host \
             -e ANTHROPIC_BASE_URL \
             -e ANTHROPIC_AUTH_TOKEN \
             aikit-agent-e2e

--- a/ci/agent-e2e/README.md
+++ b/ci/agent-e2e/README.md
@@ -28,25 +28,45 @@ exits 0, a `*.jsonl` transcript appears under `~/.claude/projects`, and
 
 ## Required repo secrets
 
+The gateway is reached **over the Tailnet**, not a public endpoint. The nightly
+workflow joins the Tailnet as an ephemeral, tagged node, then runs the smoke
+container with `--network host` so it can resolve/reach the internal gateway.
+
 | Secret | Meaning |
 |--------|---------|
-| `LLM_GATEWAY_URL` | The gateway's Anthropic-compatible base URL (public HTTPS). |
+| `TS_OAUTH_CLIENT_ID` | Tailscale OAuth client id, authorized for `tag:ci`. |
+| `TS_OAUTH_SECRET` | Tailscale OAuth client secret. |
+| `LLM_GATEWAY_URL` | Gateway Anthropic-compatible base URL **on the Tailnet** — a MagicDNS name or `100.x` tailnet IP, e.g. `http://gateway.<tailnet>.ts.net:4000`. |
 | `LLM_GATEWAY_KEY` | The gateway API key. |
 
-The workflow **skips cleanly** (green, no-op) when these are unset — so forks
-and secret-less environments don't fail.
+The workflow **skips cleanly** (green, no-op) when any of these are unset — so
+forks and secret-less environments don't fail.
+
+### Tailscale setup (one-time)
+
+1. In the Tailscale admin console → **Settings → OAuth clients**, create a client
+   with the **`auth_keys`** scope and attach the tag **`tag:ci`**.
+2. In the **ACL policy**, define `tag:ci` under `tagOwners` (e.g.
+   `"tag:ci": ["autogroup:admin"]`) and grant it access to the gateway node/port
+   (an ACL rule allowing `tag:ci` → the gateway's `:4000`).
+3. Add the client id/secret as the `TS_OAUTH_*` repo secrets above.
+
+Ephemeral nodes created by the action auto-remove when the job ends.
 
 ## Run it
 
 - **CI:** Actions → *Nightly Agent E2E* → *Run workflow* (or wait for the nightly).
-- **Locally:**
+- **Locally** (on a machine already on the Tailnet):
   ```bash
   docker build -f ci/agent-e2e/Dockerfile.agent-e2e -t aikit-agent-e2e .
-  docker run --rm \
-    -e ANTHROPIC_BASE_URL="https://your-gateway.example.com" \
+  docker run --rm --network host \
+    -e ANTHROPIC_BASE_URL="http://gateway.<tailnet>.ts.net:4000" \
     -e ANTHROPIC_AUTH_TOKEN="your-gateway-key" \
     aikit-agent-e2e
   ```
+  `--network host` lets the container use the host's Tailnet connectivity and
+  MagicDNS. If MagicDNS isn't available, use the gateway's `100.x` tailnet IP in
+  `ANTHROPIC_BASE_URL` instead of the MagicDNS name.
 
 ## Extending
 


### PR DESCRIPTION
Follow-up to the nightly real-agent harness (#118): switches gateway access from a **public endpoint to the Tailnet**, per the decision to keep the gateway off the public internet.

## Changes
- **Join the Tailnet in CI:** `tailscale/github-action@v3` brings up an **ephemeral, tagged (`tag:ci`) node** using an OAuth client. Adds `permissions: id-token: write` for the OIDC-based OAuth flow.
- **Container reaches the Tailnet:** the smoke runs with `docker run --network host`, so it uses the runner's Tailnet connectivity + MagicDNS to reach the internal gateway.
- **`LLM_GATEWAY_URL`** is now the gateway's **Tailnet address** (MagicDNS name or `100.x` IP, e.g. `http://gateway.<tailnet>.ts.net:4000`).
- Guard now also requires `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` and still **skips cleanly** (green no-op) when any secret is unset.
- README documents the new secrets + the one-time Tailscale OAuth/ACL setup.

## New/updated repo secrets
| Secret | Meaning |
|--------|---------|
| `TS_OAUTH_CLIENT_ID` | Tailscale OAuth client id, authorized for `tag:ci` |
| `TS_OAUTH_SECRET` | Tailscale OAuth client secret |
| `LLM_GATEWAY_URL` | Gateway base URL **on the Tailnet** (was public HTTPS) |
| `LLM_GATEWAY_KEY` | Gateway API key (unchanged) |

## One-time Tailscale setup (in the README)
1. OAuth client with `auth_keys` scope + `tag:ci`.
2. ACL: define `tag:ci` under `tagOwners` and allow `tag:ci` → the gateway node/port.
3. Add the `TS_OAUTH_*` secrets; point `LLM_GATEWAY_URL` at the Tailnet address.

## Verify
YAML validated. Can't run it here (needs the Tailnet + secrets), so first live check is: set secrets → Actions → *Nightly Agent E2E* → *Run workflow*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)