### PR TITLE
feat(cli): spec 013 slice 2 — CLI flags, --capabilities, exit codes, result handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,10 @@ path = "tests/serve/serve_signal_kill_test.rs"
 name = "serve_tool_policy_test"
 path = "tests/serve/serve_tool_policy_test.rs"
 
+[[test]]
+name = "spec013_invocation_test"
+path = "tests/cli/spec013_invocation_test.rs"
+
 [features]
 tools = ["dep:aikit-magictool"]
 # Session capture (spec 010): on-disk adapter parsing for AI coding tools.

--- a/aikit-sdk/src/runner/invocation.rs
+++ b/aikit-sdk/src/runner/invocation.rs
@@ -212,6 +212,61 @@ pub fn resolve_envelope(backend: Backend, env: &InvocationEnvelope) -> Result<()
     Ok(())
 }
 
+/// Human-readable label for a [`KnobSupport`] value, for `--capabilities`.
+pub fn knob_support_label(s: KnobSupport) -> &'static str {
+    match s {
+        KnobSupport::SupportedOsEnforced => "supported (os-enforced)",
+        KnobSupport::SupportedAppLevel => "supported (app-level)",
+        KnobSupport::Emulated => "emulated",
+        KnobSupport::Unsupported => "unsupported",
+    }
+}
+
+/// Render a Backend's resolved spec-013 capability matrix (one knob per line),
+/// for `aikit agent run --capabilities`. Pure; unit-tested.
+pub fn format_capabilities(backend: Backend) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("backend: {}\n", backend.key()));
+    out.push_str("sandbox:\n");
+    for &p in SandboxPolicy::ALL {
+        out.push_str(&format!(
+            "  {:14} {}\n",
+            p.as_kebab_str(),
+            knob_support_label(backend.sandbox_support(p))
+        ));
+    }
+    for (knob, support) in [
+        ("auto-approve", backend.auto_approve_support()),
+        ("working-dir", backend.working_dir_support()),
+        (
+            "extra-writable-roots",
+            backend.extra_writable_roots_support(),
+        ),
+        ("output-schema", backend.output_schema_support()),
+        ("bare", backend.bare_support()),
+        ("ephemeral", backend.ephemeral_support()),
+        ("skip-git-repo-check", backend.skip_git_repo_check_support()),
+    ] {
+        out.push_str(&format!("{:21} {}\n", knob, knob_support_label(support)));
+    }
+    out
+}
+
+/// Map a run's outcome to the spec-013 D6 exit code. A security-knob fail-closed
+/// pre-flight (`InvocationUnsupported`) → 3; a timeout → 124; otherwise the
+/// backend's own exit code passes through (0 = success; 130/137/143 are
+/// SIGINT/SIGKILL/SIGTERM from the process group; a runtime sandbox violation
+/// surfaces as the backend's own non-zero code). `None` status → 1.
+pub fn exit_code_for(status_code: Option<i32>, run_error: Option<&super::types::RunError>) -> i32 {
+    use super::types::RunError;
+    match run_error {
+        Some(RunError::InvocationUnsupported(_)) => return 3,
+        Some(RunError::TimedOut { .. }) => return 124,
+        _ => {}
+    }
+    status_code.unwrap_or(1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -502,5 +557,81 @@ mod tests {
             ..Default::default()
         }
         .is_active());
+    }
+
+    // ── --capabilities + exit-code helpers (slice 2) ───────────────────────────
+
+    #[test]
+    fn knob_support_label_all_variants() {
+        assert_eq!(
+            knob_support_label(KnobSupport::SupportedOsEnforced),
+            "supported (os-enforced)"
+        );
+        assert_eq!(
+            knob_support_label(KnobSupport::SupportedAppLevel),
+            "supported (app-level)"
+        );
+        assert_eq!(knob_support_label(KnobSupport::Emulated), "emulated");
+        assert_eq!(knob_support_label(KnobSupport::Unsupported), "unsupported");
+    }
+
+    #[test]
+    fn format_capabilities_codex_matrix() {
+        let s = format_capabilities(Backend::Codex);
+        assert!(s.contains("backend: codex"), "{}", s);
+        assert!(s.contains("sandbox:"), "{}", s);
+        assert!(s.contains("read-only"), "{}", s);
+        assert!(s.contains("bounded-write"), "{}", s);
+        assert!(s.contains("unrestricted"), "{}", s);
+        // codex sandbox is OS-enforced for every policy
+        assert!(s.contains("supported (os-enforced)"), "{}", s);
+        // every knob row is present
+        for knob in [
+            "auto-approve",
+            "working-dir",
+            "extra-writable-roots",
+            "output-schema",
+            "bare",
+            "ephemeral",
+            "skip-git-repo-check",
+        ] {
+            assert!(s.contains(knob), "missing knob {knob}:\n{s}");
+        }
+    }
+
+    #[test]
+    fn format_capabilities_cursor_marks_unsupported() {
+        let s = format_capabilities(Backend::Cursor);
+        assert!(s.contains("backend: cursor"), "{}", s);
+        assert!(s.contains("unsupported"), "{}", s);
+    }
+
+    #[test]
+    fn exit_code_for_maps_spec013_d6_table() {
+        use crate::runner::types::RunError;
+        use std::time::Duration;
+
+        assert_eq!(exit_code_for(Some(0), None), 0); // success
+        assert_eq!(exit_code_for(None, None), 1); // missing status => 1
+        assert_eq!(exit_code_for(Some(130), None), 130); // SIGINT
+        assert_eq!(exit_code_for(Some(143), None), 143); // SIGTERM
+        assert_eq!(exit_code_for(Some(137), None), 137); // SIGKILL
+        assert_eq!(exit_code_for(Some(7), None), 7); // backend non-zero pass-through
+
+        // fail-closed pre-flight => 3 (overrides status)
+        let unsupported = RunError::InvocationUnsupported(UnsupportedKnob {
+            backend: Backend::Cursor,
+            knob: "sandbox",
+            detail: "x".into(),
+        });
+        assert_eq!(exit_code_for(Some(0), Some(&unsupported)), 3);
+
+        // timeout => 124
+        let timed_out = RunError::TimedOut {
+            timeout: Duration::from_secs(10),
+            stdout: vec![],
+            stderr: vec![],
+        };
+        assert_eq!(exit_code_for(None, Some(&timed_out)), 124);
     }
 }

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -37,7 +37,9 @@ pub use claude_session::{
 pub use codex_session::{
     open_codex_session, CodexControlHandle, CodexSession, CodexSessionError, CodexSessionOptions,
 };
-pub use invocation::{resolve_envelope, InvocationEnvelope, UnsupportedKnob};
+pub use invocation::{
+    exit_code_for, format_capabilities, resolve_envelope, InvocationEnvelope, UnsupportedKnob,
+};
 // Shared approval types; available when at least one session feature is enabled.
 #[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
 pub use approval::{PermissionCallback, ToolApprovalRequest, ToolDecision};

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -169,6 +169,16 @@ pub fn build_app() -> Result<AikitApp> {
             session_persona: args.session_persona,
             resume: args.resume,
             resume_last: args.resume_last,
+            sandbox: args.sandbox,
+            auto_approve: args.auto_approve,
+            cd: args.cd,
+            add_dir: args.add_dir,
+            output_result: args.output_result,
+            output_schema: args.output_schema,
+            bare: args.bare,
+            ephemeral: args.ephemeral,
+            skip_git_repo_check: args.skip_git_repo_check,
+            capabilities: args.capabilities,
         };
         // run::execute is synchronous and creates its own tokio runtime internally
         // (via block_on_async in aikit-agent). Using spawn_blocking avoids a
@@ -809,6 +819,17 @@ struct RunArgs {
     session_persona: Option<String>,
     resume: Option<String>,
     resume_last: bool,
+    // spec 013 (slice 2): common invocation envelope
+    sandbox: Option<String>,
+    auto_approve: bool,
+    cd: Option<String>,
+    add_dir: Vec<String>,
+    output_result: Option<String>,
+    output_schema: Option<String>,
+    bare: bool,
+    ephemeral: bool,
+    skip_git_repo_check: bool,
+    capabilities: bool,
 }
 
 impl IntoCommandSpec for RunArgs {
@@ -854,6 +875,71 @@ impl IntoCommandSpec for RunArgs {
                     help: "Display live human-readable progress on stderr",
                     ..Default::default()
                 },
+                // ── spec 013 (slice 2): common invocation envelope ───────────────
+                ArgSpec {
+                    name: "sandbox",
+                    short: None,
+                    long: Some("sandbox"),
+                    kind: ArgKind::Option,
+                    value_type: ArgValueType::Enum(vec![
+                        "read-only",
+                        "bounded-write",
+                        "unrestricted",
+                    ]),
+                    cardinality: Cardinality::Optional,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Filesystem-trust policy: read-only|bounded-write|unrestricted (spec 013 D1)",
+                    ..Default::default()
+                },
+                flag_spec(
+                    "auto-approve",
+                    "Auto-approve every tool call without prompting (spec 013 D1)",
+                ),
+                opt_short_spec(
+                    "cd",
+                    'C',
+                    "Working root for the agent (spec 013 D2; default: cwd)",
+                ),
+                ArgSpec {
+                    name: "add-dir",
+                    short: None,
+                    long: Some("add-dir"),
+                    kind: ArgKind::Option,
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Repeated,
+                    default: None,
+                    conflicts_with: vec![],
+                    requires: vec![],
+                    help: "Extra writable root; repeatable (spec 013 D2)",
+                    ..Default::default()
+                },
+                opt_short_spec(
+                    "output-result",
+                    'o',
+                    "Write the agent's final message to <file> (spec 013 D3)",
+                ),
+                opt_spec(
+                    "output-schema",
+                    "JSON Schema file for typed final output (spec 013 D4)",
+                ),
+                flag_spec(
+                    "bare",
+                    "Skip user config/hooks/MCP for reproducible runs (spec 013 D6)",
+                ),
+                flag_spec(
+                    "ephemeral",
+                    "Do not persist the session (spec 013 D6)",
+                ),
+                flag_spec(
+                    "skip-git-repo-check",
+                    "Skip the headless git-repo guard (spec 013 D6)",
+                ),
+                flag_spec(
+                    "capabilities",
+                    "Print the resolved spec-013 capability matrix for --agent and exit",
+                ),
                 ArgSpec {
                     name: "dry-run",
                     short: None,
@@ -928,6 +1014,16 @@ impl FromArgValueMap for RunArgs {
             session_persona: get_opt_val(map, "session-persona"),
             resume: get_opt_val(map, "resume"),
             resume_last: get_bool_val(map, "resume-last"),
+            sandbox: get_opt_val(map, "sandbox"),
+            auto_approve: get_bool_val(map, "auto-approve"),
+            cd: get_opt_val(map, "cd"),
+            add_dir: get_repeated_val(map, "add-dir"),
+            output_result: get_opt_val(map, "output-result"),
+            output_schema: get_opt_val(map, "output-schema"),
+            bare: get_bool_val(map, "bare"),
+            ephemeral: get_bool_val(map, "ephemeral"),
+            skip_git_repo_check: get_bool_val(map, "skip-git-repo-check"),
+            capabilities: get_bool_val(map, "capabilities"),
         }
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,3 +1,4 @@
+use aikit_sdk::runner::{exit_code_for, format_capabilities, Backend, SandboxPolicy};
 use aikit_sdk::session_store::SessionStore;
 use aikit_sdk::{run_agent, run_agent_events, run_builtin_agent, AgentEvent, OutputMode};
 use aikit_sdk::{ProgressViewConfig, RunError, RunOptions, RunProgress};
@@ -24,6 +25,17 @@ pub struct RunArgs {
     pub session_persona: Option<String>,
     pub resume: Option<String>,
     pub resume_last: bool,
+    // spec 013 (slice 2): common invocation envelope
+    pub sandbox: Option<String>,
+    pub auto_approve: bool,
+    pub cd: Option<String>,
+    pub add_dir: Vec<String>,
+    pub output_result: Option<String>,
+    pub output_schema: Option<String>,
+    pub bare: bool,
+    pub ephemeral: bool,
+    pub skip_git_repo_check: bool,
+    pub capabilities: bool,
 }
 
 /// Load and merge `--session-agents` value into the registry.
@@ -66,6 +78,19 @@ fn load_session_agents(
 }
 
 pub fn execute(args: RunArgs) -> Result<()> {
+    // spec 013: --capabilities short-circuits before any prompt/run.
+    if args.capabilities {
+        let backend = Backend::from_key(&args.agent).ok_or_else(|| {
+            anyhow::anyhow!(
+                "unknown agent '{}' for --capabilities (use a concrete key: \
+                 codex|claude|gemini|opencode|cursor|aikit)",
+                args.agent
+            )
+        })?;
+        print!("{}", format_capabilities(backend));
+        return Ok(());
+    }
+
     let mut agent = args.agent;
     let mut model = args.model;
 
@@ -253,6 +278,58 @@ pub fn execute(args: RunArgs) -> Result<()> {
         options = options.with_session_id(sid.clone());
     }
 
+    // spec 013 (slice 2): invocation envelope.
+    // --yolo is a macro over `--sandbox unrestricted --auto-approve` (D1); an
+    // explicit --sandbox wins.
+    let explicit_sandbox: Option<SandboxPolicy> = match args.sandbox.as_deref() {
+        Some(s) => Some(s.parse::<SandboxPolicy>().map_err(|_| {
+            anyhow::anyhow!("--sandbox must be read-only|bounded-write|unrestricted")
+        })?),
+        None => None,
+    };
+    // --yolo is a macro over `--sandbox unrestricted --auto-approve` (D1); an
+    // explicit --sandbox wins.
+    let yolo_sandbox = if args.yolo {
+        Some(SandboxPolicy::Unrestricted)
+    } else {
+        None
+    };
+    if let Some(p) = explicit_sandbox.or(yolo_sandbox) {
+        options = options.with_sandbox(p);
+    }
+    if args.auto_approve || args.yolo {
+        options = options.with_auto_approve(true);
+    }
+    if let Some(ref d) = args.cd {
+        options = options.with_current_dir(std::path::PathBuf::from(d));
+    }
+    for d in &args.add_dir {
+        options = options.with_extra_writable_root(std::path::PathBuf::from(d));
+    }
+    if let Some(ref f) = args.output_result {
+        options = options.with_result_file(std::path::PathBuf::from(f));
+    }
+    if let Some(ref f) = args.output_schema {
+        let raw = std::fs::read_to_string(f)
+            .map_err(|e| anyhow::anyhow!("--output-schema: cannot read {}: {}", f, e))?;
+        let val: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("--output-schema: invalid JSON in {}: {}", f, e))?;
+        options = options.with_output_schema(val);
+    }
+    if args.bare {
+        options = options.with_bare(true);
+    }
+    if args.ephemeral {
+        options = options.with_ephemeral(true);
+    }
+    if args.skip_git_repo_check {
+        options = options.with_skip_git_repo_check(true);
+    }
+
+    // spec 013 D3: capture the result-handle inputs before `options` is moved.
+    let result_file = options.result_file.clone();
+    let result_session_id = options.session_id.clone();
+
     let is_builtin = agent == "aikit" || agent == "agent";
 
     if is_builtin {
@@ -281,54 +358,96 @@ pub fn execute(args: RunArgs) -> Result<()> {
             progress_sink,
         ) {
             Ok(result) => {
-                let exit_code = result.exit_code().unwrap_or(1);
-                std::process::exit(exit_code);
+                if let Some(p) = result_file.as_deref() {
+                    write_result_file(p, &String::from_utf8_lossy(&result.stdout));
+                }
+                std::process::exit(exit_code_for(result.exit_code(), None));
             }
             Err(e) => {
                 eprintln!("Error: {}", e);
-                std::process::exit(1);
+                std::process::exit(exit_code_for(None, Some(&e)));
             }
         }
     } else if args.events {
+        // spec 013 D3: track the final assistant text for the Result handle.
+        let mut last_text: Option<String> = None;
         match run_agent_events(&agent, &prompt, options, |event: AgentEvent| {
+            if let aikit_sdk::runner::AgentEventPayload::StreamMessage(sm) = &event.payload {
+                if matches!(sm.role, aikit_sdk::runner::MessageRole::Assistant)
+                    && !sm.text.trim().is_empty()
+                {
+                    last_text = Some(sm.text.clone());
+                }
+            }
             if let Ok(line) = serde_json::to_string(&event) {
                 println!("{}", line);
             }
         }) {
             Ok(result) => {
                 let _ = io::stderr().write_all(&result.stderr);
-                let exit_code = result.exit_code().unwrap_or(1);
-                std::process::exit(exit_code);
+                // spec 013 D3: emit one terminal Result event, then --output-result.
+                if let Some(t) = last_text.as_deref() {
+                    let res = AgentEvent {
+                        agent_key: agent.clone(),
+                        seq: 0,
+                        stream: aikit_sdk::runner::AgentEventStream::Stdout,
+                        payload: aikit_sdk::runner::AgentEventPayload::Result {
+                            text: t.to_string(),
+                            structured: None,
+                            session_id: result_session_id.clone(),
+                        },
+                    };
+                    if let Ok(line) = serde_json::to_string(&res) {
+                        println!("{}", line);
+                    }
+                    if let Some(p) = result_file.as_deref() {
+                        write_result_file(p, t);
+                    }
+                }
+                std::process::exit(exit_code_for(result.exit_code(), None));
             }
             Err(RunError::AgentNotRunnable(key)) => {
                 eprintln!("{}", RunError::AgentNotRunnable(key));
-                std::process::exit(1);
+                std::process::exit(exit_code_for(None, None));
             }
             Err(e) => {
                 eprintln!("Error: {}", e);
-                std::process::exit(1);
+                std::process::exit(exit_code_for(None, Some(&e)));
             }
         }
     } else if args.progress {
         let mut progress = RunProgress::new(ProgressViewConfig::default());
         let mut renderer = ProgressRenderer::new().unwrap_or_else(|_| ProgressRenderer::non_tty());
         let agent_key = agent.clone();
+        let mut last_text: Option<String> = None;
         match run_agent_events(&agent, &prompt, options, |event: AgentEvent| {
+            if let aikit_sdk::runner::AgentEventPayload::StreamMessage(sm) = &event.payload {
+                if matches!(sm.role, aikit_sdk::runner::MessageRole::Assistant)
+                    && !sm.text.trim().is_empty()
+                {
+                    last_text = Some(sm.text.clone());
+                }
+            }
             progress.push(&agent_key, &event);
             let _ = renderer.render(&progress);
         }) {
             Ok(result) => {
-                let exit_code = result.exit_code().unwrap_or(1);
+                let exit_code = exit_code_for(result.exit_code(), None);
+                if let Some(t) = last_text.as_deref() {
+                    if let Some(p) = result_file.as_deref() {
+                        write_result_file(p, t);
+                    }
+                }
                 let _ = renderer.finalize(exit_code, progress.token_footer());
                 std::process::exit(exit_code);
             }
             Err(RunError::AgentNotRunnable(key)) => {
                 eprintln!("{}", RunError::AgentNotRunnable(key));
-                std::process::exit(1);
+                std::process::exit(exit_code_for(None, None));
             }
             Err(e) => {
                 eprintln!("Error: {}", e);
-                std::process::exit(1);
+                std::process::exit(exit_code_for(None, Some(&e)));
             }
         }
     } else {
@@ -336,17 +455,28 @@ pub fn execute(args: RunArgs) -> Result<()> {
             Ok(result) => {
                 io::stdout().write_all(&result.stdout)?;
                 io::stderr().write_all(&result.stderr)?;
-                let exit_code = result.status.code().unwrap_or(1);
-                std::process::exit(exit_code);
+                if let Some(p) = result_file.as_deref() {
+                    write_result_file(p, &String::from_utf8_lossy(&result.stdout));
+                }
+                std::process::exit(exit_code_for(result.status.code(), None));
             }
             Err(RunError::AgentNotRunnable(key)) => {
                 eprintln!("{}", RunError::AgentNotRunnable(key));
-                std::process::exit(1);
+                std::process::exit(exit_code_for(None, None));
             }
             Err(e) => {
                 eprintln!("Error: {}", e);
-                std::process::exit(1);
+                std::process::exit(exit_code_for(None, Some(&e)));
             }
         }
+    }
+}
+
+/// Write the `--output-result` file (spec 013 D3). Best-effort on error: the
+/// run already produced its output, so a write failure is reported on stderr
+/// rather than turning a successful run into a non-zero exit.
+fn write_result_file(path: &std::path::Path, text: &str) {
+    if let Err(e) = std::fs::write(path, text) {
+        eprintln!("--output-result: cannot write {}: {}", path.display(), e);
     }
 }

--- a/tests/cli/spec013_invocation_test.rs
+++ b/tests/cli/spec013_invocation_test.rs
@@ -1,0 +1,54 @@
+//! CLI integration tests for spec 013 invocation-envelope flags. These exercise
+//! the agent-free paths (`--capabilities` short-circuits before any run) and
+//! flag registration, so no agent binary is required.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn spec013_capabilities_codex_matrix() {
+    let mut cmd = Command::cargo_bin("aikit").unwrap();
+    cmd.args(["agent", "run", "--agent", "codex", "--capabilities"]);
+    cmd.assert()
+        .success()
+        .stdout(contains("backend: codex"))
+        .stdout(contains("sandbox:"))
+        .stdout(contains("supported (os-enforced)"))
+        .stdout(contains("auto-approve"))
+        .stdout(contains("working-dir"));
+}
+
+#[test]
+fn spec013_capabilities_cursor_marks_unsupported() {
+    let mut cmd = Command::cargo_bin("aikit").unwrap();
+    cmd.args(["agent", "run", "--agent", "cursor", "--capabilities"]);
+    cmd.assert()
+        .success()
+        .stdout(contains("backend: cursor"))
+        .stdout(contains("unsupported"));
+}
+
+#[test]
+fn spec013_capabilities_unknown_agent_fails() {
+    let mut cmd = Command::cargo_bin("aikit").unwrap();
+    cmd.args(["agent", "run", "--agent", "bogus", "--capabilities"]);
+    cmd.assert().failure().stderr(contains("unknown agent"));
+}
+
+#[test]
+fn spec013_flags_appear_in_help() {
+    let mut cmd = Command::cargo_bin("aikit").unwrap();
+    cmd.args(["agent", "run", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(contains("--sandbox"))
+        .stdout(contains("--auto-approve"))
+        .stdout(contains("--cd"))
+        .stdout(contains("--add-dir"))
+        .stdout(contains("--output-result"))
+        .stdout(contains("--output-schema"))
+        .stdout(contains("--bare"))
+        .stdout(contains("--ephemeral"))
+        .stdout(contains("--skip-git-repo-check"))
+        .stdout(contains("--capabilities"));
+}


### PR DESCRIPTION
Completes the spec 013 caller surface on top of #116 (slice 1's SDK core). This makes the invocation envelope usable from `aikit agent run`.

## What lands
- **CLI flags**: `--sandbox`, `--auto-approve`, `-C/--cd`, `--add-dir` (repeated), `--output-result/-o`, `--output-schema`, `--bare`, `--ephemeral`, `--skip-git-repo-check`, `--capabilities`.
- **`--capabilities`** prints the resolved per-Backend capability matrix (`format_capabilities`, added to `runner/invocation.rs`) and exits before any run — pure, unit-tested.
- **`--yolo`** is now a macro over `--sandbox unrestricted --auto-approve` (D1); an explicit `--sandbox` wins.
- **Exit codes** via `exit_code_for` (D6): fail-closed pre-flight → 3, timeout → 124, signal codes (130/137/143) and the backend exit pass through.
- **Result handle** (D3): `--output-result` writes the final answer; `--events` emits a terminal `AgentEventPayload::Result` (tracked from the last assistant StreamMessage).

## Tests
- Unit: `format_capabilities`, `exit_code_for`, `knob_support_label` (invocation.rs stays 100%).
- Agent-free E2E (`tests/cli/spec013_invocation_test.rs`): capabilities matrix for codex/cursor, unknown-agent failure, and flag-registration via `--help`.
- aikit-sdk 380, aikit-cli 222 green; clippy `-D warnings` clean; full workspace single-threaded suite + cargo doc green (pre-push hook).

## Notes / deferred
- The terminal `Result` event is emitted from the CLI in `--events` mode; moving it into the SDK run loop (so `serve`/agentrt get it canonically) is a small follow-up.
- Runtime sandbox-violation detection (D6 code 10) passes through the backend's own exit code; codex/gemini OS-sandbox fidelity (gemini `SEATBELT_PROFILE`/`SANDBOX_MOUNTS` env, claude `--allowedTools` mapping) is a backend-fidelity follow-up.