### PR TITLE
fix(agent-e2e): non-root container + pinned model — nightly smoke now passes live

### DIFF
--- a/.github/workflows/nightly-agent-e2e.yml
+++ b/.github/workflows/nightly-agent-e2e.yml
@@ -78,10 +78,15 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.LLM_GATEWAY_URL }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_GATEWAY_KEY }}
+          # Model the gateway key is allowed to serve. Set the repo variable
+          # LLM_GATEWAY_MODEL to change it without editing code; falls back to
+          # the model the gateway currently permits.
+          AGENT_E2E_MODEL: ${{ vars.LLM_GATEWAY_MODEL || 'claude-sonnet-4-6' }}
         run: |
           # --network host lets the container use the runner's Tailnet
           # connectivity and MagicDNS resolution to reach the internal gateway.
           docker run --rm --network host \
             -e ANTHROPIC_BASE_URL \
             -e ANTHROPIC_AUTH_TOKEN \
+            -e AGENT_E2E_MODEL \
             aikit-agent-e2e

--- a/ci/agent-e2e/Dockerfile.agent-e2e
+++ b/ci/agent-e2e/Dockerfile.agent-e2e
@@ -31,9 +31,12 @@ COPY --from=build /src/target/release/aikit /usr/local/bin/aikit
 COPY ci/agent-e2e/smoke.sh /usr/local/bin/agent-smoke
 RUN chmod +x /usr/local/bin/agent-smoke
 
-# A non-root home so ~/.claude/projects is writable and isolated.
+# Run as a non-root user. Claude Code refuses `--dangerously-skip-permissions`
+# (which aikit's headless claude backend passes) under root/sudo, so the smoke
+# must run as an unprivileged user with a writable home for ~/.claude/projects.
+RUN useradd --create-home --home-dir /home/agent --shell /bin/bash agent
 ENV HOME=/home/agent
-RUN mkdir -p /home/agent && chmod 777 /home/agent
+USER agent
 WORKDIR /home/agent
 
 # The gateway endpoint + key are provided at `docker run` time, never baked in.

--- a/ci/agent-e2e/smoke.sh
+++ b/ci/agent-e2e/smoke.sh
@@ -18,14 +18,20 @@ set -euo pipefail
 : "${ANTHROPIC_AUTH_TOKEN:?ANTHROPIC_AUTH_TOKEN (gateway key) is required}"
 export ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN
 
+# Pin the model the gateway key is allowed to serve. Claude Code otherwise
+# defaults to the newest model, which the gateway may reject (403 "key not
+# allowed to access model"). Override via AGENT_E2E_MODEL as the gateway config
+# changes.
+MODEL="${AGENT_E2E_MODEL:-claude-sonnet-4-6}"
+
 echo "== aikit version =="
 aikit --version || true
-echo "== gateway: ${ANTHROPIC_BASE_URL} =="
+echo "== gateway: ${ANTHROPIC_BASE_URL}  model: ${MODEL} =="
 
 # 1. A real agent turn via the gateway. We don't assert the reply text (the
 #    backing model may be small); a clean exit means a turn round-tripped.
 echo "== [1/3] running a real claude turn =="
-aikit agent run --agent claude --prompt "Reply with the single word: pong"
+aikit agent run --agent claude --model "${MODEL}" --prompt "Reply with the single word: pong"
 echo "   turn completed (exit 0)"
 
 # 2. The turn must have produced a captured session transcript.


### PR DESCRIPTION
Makes the nightly real-agent smoke actually pass against the Tailnet gateway. **Verified live** on this branch (run 30134581965): real turn → 1 session captured → `synced=1` → **SMOKE PASS**.

Two fixes, found by running it:

1. **Non-root container.** Claude Code refuses `--dangerously-skip-permissions` (which aikit's headless claude backend passes) under root — the image ran as root, so the first turn died instantly with *"cannot be used with root/sudo privileges"*. Added an `agent` user + `USER agent` with a writable home for `~/.claude/projects`.

2. **Pinned model.** With #1 fixed, the turn reached the gateway but got `403 key not allowed to access model` — Claude Code defaulted to the newest model while the gateway key is scoped to `claude-sonnet-4-6`. The smoke now passes `--model` to `aikit agent run` (default `claude-sonnet-4-6`, override via repo variable `LLM_GATEWAY_MODEL` / `AGENT_E2E_MODEL`).

## Proof (branch run)
```
turn completed (exit 0)
captured 1 session file(s)
summary: {"synced":1,"skipped_unchanged":0,"failed":0,"bytes_uploaded":9187}
SMOKE PASS: real agent turn captured and sync-detected (synced=1)
```

Infra confirmed working: Tailnet join ✓, image build ✓, gateway auth over Tailnet ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)