### PR TITLE
feat(runner): spec 013 follow-ups — canonical Result event + sandbox fidelity

### DIFF
--- a/aikit-sdk/src/runner/argv.rs
+++ b/aikit-sdk/src/runner/argv.rs
@@ -549,6 +549,31 @@ mod tests {
     }
 
     #[test]
+    fn spec013_claude_read_only_restricts_tools() {
+        let env = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::ReadOnly),
+            ..Default::default()
+        };
+        let argv = build_argv_envelope("claude", None, false, false, false, None, Some(&env));
+        let read_pos = argv.iter().position(|a| a == "--allowedTools").unwrap();
+        assert_eq!(argv[read_pos + 1], OsString::from("Read"));
+        // bounded-write / unrestricted do not restrict the toolset
+        let bw = build_argv_envelope(
+            "claude",
+            None,
+            false,
+            false,
+            false,
+            None,
+            Some(&InvocationEnvelope {
+                sandbox: Some(SandboxPolicy::BoundedWrite),
+                ..Default::default()
+            }),
+        );
+        assert!(!bw.contains(&OsString::from("--allowedTools")));
+    }
+
+    #[test]
     fn spec013_gemini_sandbox_toggle() {
         // restrictive policy ⇒ `-s`; unrestricted/none ⇒ no `-s`
         let on = build_argv_envelope(

--- a/aikit-sdk/src/runner/backends/claude.rs
+++ b/aikit-sdk/src/runner/backends/claude.rs
@@ -346,9 +346,14 @@ pub(crate) fn argv(ctx: ArgvCtx) -> Vec<OsString> {
         OsString::from("--dangerously-skip-permissions"),
     ];
     SPEC.push_model(&mut argv, ctx.model);
-    // spec 013 D6: claude's reproducible-run flag. claude's sandbox (AppLevel)
-    // is enforced via the session persona / tool-policy layer, not an argv flag.
+    // spec 013 D1/D6: claude honors read-only cooperatively via --allowedTools
+    // (AppLevel fidelity — claude has no OS sandbox), and --bare for
+    // reproducible runs.
     if let Some(e) = ctx.envelope {
+        if matches!(e.sandbox, Some(p) if p.as_kebab_str() == "read-only") {
+            argv.push(OsString::from("--allowedTools"));
+            argv.push(OsString::from("Read"));
+        }
         if e.bare {
             argv.push(OsString::from("--bare"));
         }

--- a/aikit-sdk/src/runner/invocation.rs
+++ b/aikit-sdk/src/runner/invocation.rs
@@ -267,6 +267,32 @@ pub fn exit_code_for(status_code: Option<i32>, run_error: Option<&super::types::
     status_code.unwrap_or(1)
 }
 
+/// Env vars to apply to the spawned agent Command for the envelope's sandbox
+/// knobs (spec 013 D1/D2). gemini configures its OS sandbox via env
+/// (`SEATBELT_PROFILE` / `SANDBOX_MOUNTS`) rather than argv; other backends
+/// return empty (their sandbox knobs are argv-mapped or unsupported).
+pub fn sandbox_env_for(backend: Backend, env: &InvocationEnvelope) -> Vec<(String, String)> {
+    if !matches!(backend, Backend::Gemini) {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    // read-only ⇒ strict profile (read+write restrictions); bounded-write uses
+    // gemini's default permissive-open (writes confined to the workspace);
+    // unrestricted leaves the sandbox off (no `-s`).
+    if matches!(env.sandbox, Some(SandboxPolicy::ReadOnly)) {
+        out.push(("SEATBELT_PROFILE".to_string(), "strict-open".to_string()));
+    }
+    if !env.extra_writable_roots.is_empty() {
+        let mounts: Vec<String> = env
+            .extra_writable_roots
+            .iter()
+            .map(|r| format!("{}:{}:rw", r.display(), r.display()))
+            .collect();
+        out.push(("SANDBOX_MOUNTS".to_string(), mounts.join(",")));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -633,5 +659,59 @@ mod tests {
             stderr: vec![],
         };
         assert_eq!(exit_code_for(None, Some(&timed_out)), 124);
+    }
+
+    // ── gemini sandbox env (follow-up 2) ───────────────────────────────────────
+
+    #[test]
+    fn sandbox_env_only_gemini_emits() {
+        let env = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::ReadOnly),
+            ..Default::default()
+        };
+        assert!(sandbox_env_for(Backend::Codex, &env).is_empty());
+        assert!(sandbox_env_for(Backend::Claude, &env).is_empty());
+        assert!(!sandbox_env_for(Backend::Gemini, &env).is_empty());
+    }
+
+    #[test]
+    fn gemini_sandbox_env_read_only_sets_strict_profile() {
+        let env = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::ReadOnly),
+            ..Default::default()
+        };
+        assert_eq!(
+            sandbox_env_for(Backend::Gemini, &env),
+            vec![("SEATBELT_PROFILE".to_string(), "strict-open".to_string())]
+        );
+    }
+
+    #[test]
+    fn gemini_sandbox_env_bounded_write_no_profile_override() {
+        // bounded-write uses gemini's default profile (writes confined to the
+        // workspace); unrestricted leaves the sandbox off.
+        let bw = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::BoundedWrite),
+            ..Default::default()
+        };
+        assert!(sandbox_env_for(Backend::Gemini, &bw).is_empty());
+        let un = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::Unrestricted),
+            ..Default::default()
+        };
+        assert!(sandbox_env_for(Backend::Gemini, &un).is_empty());
+    }
+
+    #[test]
+    fn gemini_sandbox_env_mounts_extra_roots() {
+        let env = InvocationEnvelope {
+            extra_writable_roots: vec![PathBuf::from("/a"), PathBuf::from("/b")],
+            ..Default::default()
+        };
+        let e = sandbox_env_for(Backend::Gemini, &env);
+        assert_eq!(e.len(), 1);
+        assert_eq!(e[0].0, "SANDBOX_MOUNTS");
+        assert!(e[0].1.contains("/a:/a:rw"), "{}", e[0].1);
+        assert!(e[0].1.contains("/b:/b:rw"), "{}", e[0].1);
     }
 }

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -38,7 +38,8 @@ pub use codex_session::{
     open_codex_session, CodexControlHandle, CodexSession, CodexSessionError, CodexSessionOptions,
 };
 pub use invocation::{
-    exit_code_for, format_capabilities, resolve_envelope, InvocationEnvelope, UnsupportedKnob,
+    exit_code_for, format_capabilities, resolve_envelope, sandbox_env_for, InvocationEnvelope,
+    UnsupportedKnob,
 };
 // Shared approval types; available when at least one session feature is enabled.
 #[cfg(any(feature = "claude-control", feature = "codex-app-server"))]
@@ -445,6 +446,10 @@ where
     let mut json_lines_seen: u64 = 0;
     let mut stream_messages_emitted: u64 = 0;
     let mut json_lines_unmapped: u64 = 0;
+    // spec 013 D3: track the final assistant message so a terminal Result
+    // event can be emitted once the run completes (canonical for every event
+    // consumer: serve, agentrt, the CLI).
+    let mut last_result_text: Option<String> = None;
 
     let emit_raw = options.emit_raw_transport;
 
@@ -506,6 +511,11 @@ where
                             let payload = match frame {
                                 backend::Decoded::Stream(m) => {
                                     stream_messages_emitted += 1;
+                                    if matches!(m.role, types::MessageRole::Assistant)
+                                        && !m.text.trim().is_empty()
+                                    {
+                                        last_result_text = Some(m.text.clone());
+                                    }
                                     AgentEventPayload::StreamMessage(m)
                                 }
                                 backend::Decoded::ToolUse {
@@ -735,6 +745,26 @@ where
         .first()
         .map(|(_, source)| source.clone())
         .and_then(|source| aggregate_token_usage(&usage_entries, source));
+
+    // spec 013 D3: emit one terminal Result event (the final assistant message)
+    // so every event consumer gets a canonical result handle without scraping
+    // the stream. Best-effort: a panicking callback here must not discard the
+    // already-determined RunResult.
+    if let Some(text) = last_result_text {
+        let result_event = AgentEvent {
+            agent_key: agent_key.to_string(),
+            seq,
+            stream: types::AgentEventStream::Stdout,
+            payload: AgentEventPayload::Result {
+                text,
+                structured: None,
+                session_id: options.session_id.clone(),
+            },
+        };
+        let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            on_event(result_event);
+        }));
+    }
 
     Ok(RunResult {
         status,
@@ -1024,6 +1054,51 @@ mod tests {
             result.is_ok(),
             "codex with a supported sandbox should run: {:?}",
             result.err()
+        );
+    }
+
+    /// spec 013 D3: the SDK run loop emits one terminal `Result` event carrying
+    /// the final assistant message, so every event consumer (serve, agentrt,
+    /// CLI) gets a canonical result handle without scraping the stream.
+    #[cfg(unix)]
+    #[test]
+    fn test_spec013_result_event_emitted_at_run_end() {
+        let _guard = PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        // A codex stub whose single line decodes to an assistant StreamMessage.
+        let dir = tempfile::tempdir().unwrap();
+        let stub = dir.path().join("codex");
+        let mut f = std::fs::File::create(&stub).unwrap();
+        writeln!(
+            f,
+            "#!/bin/sh\necho '{{\"type\":\"item.completed\",\"item\":{{\"type\":\"agent_message\",\"text\":\"final answer\"}}}}'"
+        )
+        .unwrap();
+        let mut perms = f.metadata().unwrap().permissions();
+        perms.set_mode(0o755);
+        f.set_permissions(perms).unwrap();
+        drop(f);
+
+        let orig_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{}", dir.path().display(), orig_path));
+
+        let mut got_result = false;
+        let result = run_agent_events("codex", "hi", RunOptions::default(), |ev| {
+            if matches!(
+                ev.payload,
+                AgentEventPayload::Result { ref text, .. } if text == "final answer"
+            ) {
+                got_result = true;
+            }
+        });
+
+        std::env::set_var("PATH", orig_path);
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert!(
+            got_result,
+            "expected a terminal Result event with the final assistant text"
         );
     }
 

--- a/aikit-sdk/src/runner/transport/subprocess.rs
+++ b/aikit-sdk/src/runner/transport/subprocess.rs
@@ -118,6 +118,12 @@ pub(crate) fn connect(
         cmd.current_dir(dir);
     }
 
+    // spec 013 D1/D2: apply backend sandbox env for the resolved envelope
+    // (gemini SEATBELT_PROFILE / SANDBOX_MOUNTS).
+    for (k, v) in crate::runner::invocation::sandbox_env_for(backend, &envelope) {
+        cmd.env(k, v);
+    }
+
     // BUG-4 (ADR 0014): spawn the agent CLI as the leader of its own process
     // group. Termination is escalated over the whole group (see
     // `kill_process_group` below), which reaps grandchildren (tools the

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -326,9 +326,9 @@ pub fn execute(args: RunArgs) -> Result<()> {
         options = options.with_skip_git_repo_check(true);
     }
 
-    // spec 013 D3: capture the result-handle inputs before `options` is moved.
+    // spec 013 D3: capture the result-file path before `options` is moved; the
+    // SDK now emits the terminal Result event canonically.
     let result_file = options.result_file.clone();
-    let result_session_id = options.session_id.clone();
 
     let is_builtin = agent == "aikit" || agent == "agent";
 
@@ -369,15 +369,12 @@ pub fn execute(args: RunArgs) -> Result<()> {
             }
         }
     } else if args.events {
-        // spec 013 D3: track the final assistant text for the Result handle.
-        let mut last_text: Option<String> = None;
+        // spec 013 D3: the SDK emits a terminal Result event; capture its text
+        // for --output-result. No duplicate CLI emission.
+        let mut result_text: Option<String> = None;
         match run_agent_events(&agent, &prompt, options, |event: AgentEvent| {
-            if let aikit_sdk::runner::AgentEventPayload::StreamMessage(sm) = &event.payload {
-                if matches!(sm.role, aikit_sdk::runner::MessageRole::Assistant)
-                    && !sm.text.trim().is_empty()
-                {
-                    last_text = Some(sm.text.clone());
-                }
+            if let aikit_sdk::runner::AgentEventPayload::Result { text, .. } = &event.payload {
+                result_text = Some(text.clone());
             }
             if let Ok(line) = serde_json::to_string(&event) {
                 println!("{}", line);
@@ -385,24 +382,8 @@ pub fn execute(args: RunArgs) -> Result<()> {
         }) {
             Ok(result) => {
                 let _ = io::stderr().write_all(&result.stderr);
-                // spec 013 D3: emit one terminal Result event, then --output-result.
-                if let Some(t) = last_text.as_deref() {
-                    let res = AgentEvent {
-                        agent_key: agent.clone(),
-                        seq: 0,
-                        stream: aikit_sdk::runner::AgentEventStream::Stdout,
-                        payload: aikit_sdk::runner::AgentEventPayload::Result {
-                            text: t.to_string(),
-                            structured: None,
-                            session_id: result_session_id.clone(),
-                        },
-                    };
-                    if let Ok(line) = serde_json::to_string(&res) {
-                        println!("{}", line);
-                    }
-                    if let Some(p) = result_file.as_deref() {
-                        write_result_file(p, t);
-                    }
+                if let (Some(p), Some(t)) = (result_file.as_deref(), result_text.as_deref()) {
+                    write_result_file(p, t);
                 }
                 std::process::exit(exit_code_for(result.exit_code(), None));
             }
@@ -419,24 +400,18 @@ pub fn execute(args: RunArgs) -> Result<()> {
         let mut progress = RunProgress::new(ProgressViewConfig::default());
         let mut renderer = ProgressRenderer::new().unwrap_or_else(|_| ProgressRenderer::non_tty());
         let agent_key = agent.clone();
-        let mut last_text: Option<String> = None;
+        let mut result_text: Option<String> = None;
         match run_agent_events(&agent, &prompt, options, |event: AgentEvent| {
-            if let aikit_sdk::runner::AgentEventPayload::StreamMessage(sm) = &event.payload {
-                if matches!(sm.role, aikit_sdk::runner::MessageRole::Assistant)
-                    && !sm.text.trim().is_empty()
-                {
-                    last_text = Some(sm.text.clone());
-                }
+            if let aikit_sdk::runner::AgentEventPayload::Result { text, .. } = &event.payload {
+                result_text = Some(text.clone());
             }
             progress.push(&agent_key, &event);
             let _ = renderer.render(&progress);
         }) {
             Ok(result) => {
                 let exit_code = exit_code_for(result.exit_code(), None);
-                if let Some(t) = last_text.as_deref() {
-                    if let Some(p) = result_file.as_deref() {
-                        write_result_file(p, t);
-                    }
+                if let (Some(p), Some(t)) = (result_file.as_deref(), result_text.as_deref()) {
+                    write_result_file(p, t);
                 }
                 let _ = renderer.finalize(exit_code, progress.token_footer());
                 std::process::exit(exit_code);


### PR DESCRIPTION
Two non-blocking follow-ups to spec 013 (#116 + #122).

## 1. Canonical terminal `Result` event from the SDK (D3)
`run_agent_events` now emits one `AgentEventPayload::Result` (final assistant message + `session_id`) on successful completion, so **serve / agentrt / the CLI** all get a canonical result handle without scraping the stream. The CLI drops its duplicate emission and now derives `--output-result` from the SDK's `Result` event. (In-process `aikit` still writes `--output-result` from stdout; emitting `Result` from that path is a further small refinement.)

## 2. Backend sandbox fidelity (D1)
- **gemini**: `SEATBELT_PROFILE` (read-only ⇒ `strict-open`) and `SANDBOX_MOUNTS` (extra writable roots) applied via the spawned Command env — `sandbox_env_for` in `runner/invocation.rs`, applied in `subprocess::connect`. (gemini's `-s` toggle from #116 stays; this refines it.)
- **claude**: read-only honored cooperatively via `--allowedTools Read` (AppLevel fidelity — claude has no OS sandbox).

## Tests
- SDK stub proving the terminal `Result` event is emitted (`test_spec013_result_event_emitted_at_run_end`).
- gemini `sandbox_env` unit tests (profile for read-only, mounts for extra roots, empty for non-gemini / bounded-write).
- claude read-only argv test (`--allowedTools Read`).
- aikit-sdk **389**, aikit-cli **222**, spec013 E2E **4** — all green; clippy `-D warnings` clean; full pre-push suite green.

Note: pre-push hit a pre-existing flaky test (`serve_limits_test::test_concurrent_resume_returns_409`, ~33% failure — a timing race unrelated to this change); passed on retry.