### PR TITLE
docs: list Pi in runnable-backend docs and catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ aikit agent run --agent claude --events -p "Summarize the project"
 aikit agent run --agent claude --events --stream -p "Refactor this module"
 ```
 
-**Runnable backends:** `codex`, `claude`, `gemini`, `opencode`, `agent`,
-`aikit` (built-in), `auto` (route to whatever is installed).
+**Runnable backends:** `codex`, `claude`, `gemini`, `opencode`, `cursor`,
+`pi`, `aikit` (built-in), `auto` (route to whatever is installed).
 
 **Options:**
 
@@ -367,11 +367,11 @@ GITHUB_TOKEN=your_github_token_here
 
 ## Supported AI assistants
 
-The catalog covers **18** coding assistants for install/template mapping.
+The catalog covers **19** coding assistants for install/template mapping.
 `aikit agent run` accepts: `codex`, `claude`, `gemini`, `opencode`,
-`agent`, `aikit`, `auto`.
+`cursor`, `pi`, `aikit`, `auto`.
 
-**CLI-based:** Claude, Gemini, Qwen, OpenCode, Codex, Auggie, CodeBuddy,
+**CLI-based:** Claude, Gemini, Qwen, OpenCode, Codex, Pi, Auggie, CodeBuddy,
 Qoder, Q, Amp, Shai
 
 **IDE-based:** GitHub Copilot, Cursor, Windsurf, KiloCode, Roo, Bob

--- a/aikit-sdk/CONTEXT.md
+++ b/aikit-sdk/CONTEXT.md
@@ -5,11 +5,11 @@ The uniform layer for driving external coding-agent CLIs over a transport, decod
 ## Language
 
 **Backend**:
-A runnable agent that aikit drives over a Transport — Claude, Codex, Gemini, OpenCode, Cursor, and the built-in `aikit`. A Backend is an identity (the closed set, parsed from a key string) that produces a Transport, a Decoder, and a declared set of capabilities. The built-in `aikit` is the in-process Backend: it establishes an in-process Transport and emits canonical events directly (no Dialect to decode), and is the richest Backend (tools, subagents, context compression, step lifecycle).
+A runnable agent that aikit drives over a Transport — Claude, Codex, Gemini, OpenCode, Cursor, Pi, and the built-in `aikit`. A Backend is an identity (the closed set, parsed from a key string) that produces a Transport, a Decoder, and a declared set of capabilities. The built-in `aikit` is the in-process Backend: it establishes an in-process Transport and emits canonical events directly (no Dialect to decode), and is the richest Backend (tools, subagents, context compression, step lifecycle).
 _Avoid_: Codec, provider (that's the LLM-gateway layer), adapter, engine
 
 **Transport**:
-How a Backend's channel is established and how messages move across it — in **both** directions. Two impls exist initially: subprocess-stdout-lines (spawn the CLI, build its argv, read newline-delimited output) for the five external Backends, and in-process (direct canonical emission) for the built-in `aikit`. The seam is designed so JSON-RPC-over-stdio (Codex `app-server`), the Claude SDK, websockets, and unix sockets plug in later as additional Transports without reworking Backends. A Transport splits into a reader half (inbound messages) and a writer half (outbound). Modelled on `claude-agent-sdk-rust`'s `Transport`/`TransportReader`/`TransportWriter`.
+How a Backend's channel is established and how messages move across it — in **both** directions. Two impls exist initially: subprocess-stdout-lines (spawn the CLI, build its argv, read newline-delimited output) for the six external Backends, and in-process (direct canonical emission) for the built-in `aikit`. The seam is designed so JSON-RPC-over-stdio (Codex `app-server`), the Claude SDK, websockets, and unix sockets plug in later as additional Transports without reworking Backends. A Transport splits into a reader half (inbound messages) and a writer half (outbound). Modelled on `claude-agent-sdk-rust`'s `Transport`/`TransportReader`/`TransportWriter`.
 _Avoid_: Launch, spawn-spec (spawning is just the subprocess Transport's connect step), channel
 
 **Decode**:

--- a/aikit-sdk/README.md
+++ b/aikit-sdk/README.md
@@ -136,7 +136,7 @@ These helpers provide deterministic paths and fallback behavior per agent.
 
 ## Run agents
 
-Runnable keys: `codex`, `claude`, `gemini`, `opencode`, `agent`.
+Runnable keys: `codex`, `claude`, `gemini`, `opencode`, `cursor`, `pi`.
 
 ```rust
 use aikit_sdk::{run_agent, RunOptions};


### PR DESCRIPTION
## Summary

Docs-only follow-up to #121 (Pi backend). The user-facing docs still listed the pre-Pi runnable backends and the stale \`agent\` key. This updates them to match the code (\`runnable_agents()\` = \`codex, claude, gemini, opencode, cursor, pi, aikit\`).

- **README.md** — \`Runnable backends\` and \`aikit agent run accepts\` lists: add \`pi\`, fix \`agent\`→\`cursor\` (ADR 0006); deploy-catalog count \`18\`→\`19\`; add Pi to the CLI-based assistant list.
- **aikit-sdk/README.md** — \`Runnable keys\`: add \`cursor\`, \`pi\`.
- **aikit-sdk/CONTEXT.md** — Backend glossary: add \`Pi\`; Transport glossary: \`five external Backends\`→\`six\`.

MCP catalog keys are intentionally left unchanged (Pi has no MCP upstream).

## Test plan

Docs-only — no code or test changes. Pre-commit + pre-push hooks (fmt, clippy, full suite) passed.