### PR TITLE
ci(agent-e2e): read model override from secrets.LLM_GATEWAY_MODEL

### DIFF
--- a/.github/workflows/nightly-agent-e2e.yml
+++ b/.github/workflows/nightly-agent-e2e.yml
@@ -78,10 +78,10 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.LLM_GATEWAY_URL }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_GATEWAY_KEY }}
-          # Model the gateway key is allowed to serve. Set the repo variable
+          # Model the gateway key is allowed to serve. Set the repo secret
           # LLM_GATEWAY_MODEL to change it without editing code; falls back to
           # the model the gateway currently permits.
-          AGENT_E2E_MODEL: ${{ vars.LLM_GATEWAY_MODEL || 'claude-sonnet-4-6' }}
+          AGENT_E2E_MODEL: ${{ secrets.LLM_GATEWAY_MODEL || 'claude-sonnet-4-6' }}
         run: |
           # --network host lets the container use the runner's Tailnet
           # connectivity and MagicDNS resolution to reach the internal gateway.

--- a/docs/ci-nightly-agent-e2e.md
+++ b/docs/ci-nightly-agent-e2e.md
@@ -84,6 +84,7 @@ secrets** (or use `gh` below).
 | `TS_OAUTH_SECRET` | OAuth **client secret** from step 1 |
 | `LLM_GATEWAY_URL` | Gateway Anthropic-compatible base URL **on the Tailnet** — a MagicDNS name or `100.x` IP, e.g. `http://gateway.<tailnet>.ts.net:4000` |
 | `LLM_GATEWAY_KEY` | Gateway API key |
+| `LLM_GATEWAY_MODEL` | *(optional)* model to run, e.g. `claude-sonnet-4-6`. Must be one the gateway key is allowed to serve. Falls back to `claude-sonnet-4-6` if unset. |
 
 With `gh` (run the secret-bearing ones in your own terminal so values aren't
 echoed into logs):


### PR DESCRIPTION
Per preference to keep gateway config together under **Actions secrets**, the model override now reads `secrets.LLM_GATEWAY_MODEL` (was `vars.LLM_GATEWAY_MODEL`), still falling back to `claude-sonnet-4-6` when unset. Documented as an optional secret.

**Verified live** on this branch (run 30137625912): the model value now shows **masked** (`AGENT_E2E_MODEL: ***`) in the log — confirming it's sourced from the secret — and the run is green: `synced=1`, **SMOKE PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)