### PR TITLE
fix(runner): use correct Pi RPC prompt field (message, not prompt)

### DIFF
--- a/aikit-sdk/src/runner/backends/pi.rs
+++ b/aikit-sdk/src/runner/backends/pi.rs
@@ -257,13 +257,15 @@ pub(crate) fn extract_usage(line: &serde_json::Value) -> Option<(TokenUsage, Usa
     ))
 }
 
-/// True when an event signals the run is fully settled — automatic retries,
-/// compaction, and queued follow-ups have completed (spec 014). The live run
-/// drains until this fires, then tears the session down.
+/// True when an event signals the run is fully settled — no automatic retry,
+/// compaction retry, or queued follow-up remains. Only `agent_settled` is the
+/// terminal; `agent_end` may be followed by retry/compaction/continuations
+/// (Pi RPC spec), so the live run drains until `agent_settled` fires, then
+/// tears the session down. Falls back to process EOF if it never arrives.
 pub(crate) fn is_settled_event(value: &serde_json::Value) -> bool {
     matches!(
         value.get("type").and_then(|v| v.as_str()),
-        Some("agent_settled") | Some("agent_end")
+        Some("agent_settled")
     )
 }
 
@@ -318,10 +320,12 @@ pub(crate) fn extract_quota(payload: &AgentEventPayload) -> Option<QuotaExceeded
 }
 
 /// The bytes to write to `pi`'s stdin to issue a one-shot prompt command,
-/// newline-terminated (JSONL framing). Kept pure so it is shared by the live
-/// path and the test path.
+/// newline-terminated (JSONL framing). The Pi RPC protocol names the prompt
+/// field `message` (not `prompt`); an incorrect field is rejected with a
+/// `Cannot read properties of undefined` error before any agent run starts.
+/// Kept pure so it is shared by the live path and the test path.
 pub(crate) fn prompt_command(prompt: &str) -> String {
-    let cmd = serde_json::json!({ "type": "prompt", "prompt": prompt });
+    let cmd = serde_json::json!({ "type": "prompt", "message": prompt });
     format!("{cmd}\n")
 }
 
@@ -581,7 +585,9 @@ mod tests {
     #[test]
     fn is_settled_detects_terminal_events() {
         assert!(is_settled_event(&json(r#"{"type":"agent_settled"}"#)));
-        assert!(is_settled_event(&json(r#"{"type":"agent_end"}"#)));
+        // agent_end is NOT terminal — it may be followed by retry/compaction/
+        // queued continuations (Pi RPC spec), so the run must keep draining.
+        assert!(!is_settled_event(&json(r#"{"type":"agent_end"}"#)));
         assert!(!is_settled_event(&json(r#"{"type":"turn_end"}"#)));
         assert!(!is_settled_event(&json(r#"{"type":"response"}"#)));
         assert!(!is_settled_event(&json(r#"{}"#)));
@@ -640,7 +646,7 @@ mod tests {
         let line = cmd.trim_end();
         let v: serde_json::Value = serde_json::from_str(line).unwrap();
         assert_eq!(v["type"], "prompt");
-        assert_eq!(v["prompt"], "write a haiku");
+        assert_eq!(v["message"], "write a haiku");
     }
 
     #[test]
@@ -651,7 +657,7 @@ mod tests {
         // single valid JSON value — embedded newline must not split records.
         let line = cmd.trim_end_matches('\n');
         let v: serde_json::Value = serde_json::from_str(line).unwrap();
-        assert_eq!(v["prompt"], "line\nwith \"quotes\"");
+        assert_eq!(v["message"], "line\nwith \"quotes\"");
     }
 
     #[test]

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -1905,6 +1905,6 @@ mod tests {
         let captured_line = std::fs::read_to_string(&captured).unwrap();
         let v: serde_json::Value = serde_json::from_str(captured_line.trim()).unwrap();
         assert_eq!(v["type"], "prompt");
-        assert_eq!(v["prompt"], "write tests");
+        assert_eq!(v["message"], "write tests");
     }
 }


### PR DESCRIPTION
## Summary

`aikit agent run -a pi` failed on every prompt with:
\`\`\`
{"type":"response","command":"prompt","success":false,"error":"Cannot read properties of undefined (reading 'startsWith')"}
\`\`\`

**Root cause:** the [Pi RPC protocol](https://pi.dev/docs/latest/rpc) expects the prompt command as \`{\"type\":\"prompt\",\"message\":\"...\"}\`, but the implementation sent \`\"prompt\"\` as the field name. Pi's handler read \`message\`, found it undefined, and crashed on its extension-command check (\`message.startsWith(\"/\")\`) — before any agent turn started. Confirmed against the official RPC doc.

**Fixes:**
1. \`pi::prompt_command\` — field is now \`message\` (matching the ADR, which was correct; only the code deviated).
2. \`pi::is_settled_event\` — drain only to \`agent_settled\`. \`agent_end\` is **not** terminal per the doc (\"may still be followed by retry, compaction, or queued continuations\"), so the previous code that treated either as terminal could return a run before retries/compaction finished.

## Test plan

- Existing unit tests updated: \`prompt_command\` asserts \`v[\"message\"]\`; \`is_settled_event\` now asserts \`agent_end\` is **not** settled.
- Stub integration test asserts the framed stdin command carries \`message\`.
- \`cargo test -p aikit-sdk --test-threads=1\` (418 lib), \`cargo clippy -p aikit-sdk --all-targets --all-features -- -D warnings\`, \`cargo fmt --check\` all green.

This is the prompt-framing item the spec flagged as \"verify during implementation\" — now verified against the real protocol.