### PR TITLE
fix(runner): hold pi stdin open until the run settles

### DIFF
--- a/aikit-sdk/src/runner/backend.rs
+++ b/aikit-sdk/src/runner/backend.rs
@@ -287,6 +287,17 @@ impl Backend {
         }
         pi::is_settled_event(value)
     }
+
+    /// Whether the subprocess transport must keep the child's stdin open for
+    /// the whole run and only close it once the drain completes. Pi's RPC
+    /// server aborts the in-flight turn the moment it observes stdin EOF, so
+    /// the prompt-writer thread must hold stdin open until the run settles
+    /// (then EOF lets the server exit gracefully). Subprocess-lines Backends
+    /// read their prompt and finish before EOF matters, so they take the
+    /// default `false` (writer drops stdin immediately, as before).
+    pub(crate) fn holds_stdin_open(self) -> bool {
+        matches!(self, Backend::Pi)
+    }
 }
 
 #[cfg(test)]
@@ -410,6 +421,21 @@ mod tests {
         assert!(Backend::Claude.requires_cli());
         assert!(Backend::Cursor.requires_cli());
         assert!(!Backend::Aikit.requires_cli());
+    }
+
+    #[test]
+    fn only_pi_holds_stdin_open() {
+        // Pi's RPC server aborts the in-flight turn on stdin EOF, so the
+        // transport must hold stdin open until the run settles. Every other
+        // Backend reads its prompt and is unaffected by an early EOF, so it
+        // takes the default (writer drops stdin immediately).
+        for &b in ALL {
+            assert_eq!(
+                b.holds_stdin_open(),
+                b == Backend::Pi,
+                "holds_stdin_open for {b:?}"
+            );
+        }
     }
 
     // ---- shared invariant harness over every Backend (spec 006 §6) ----

--- a/aikit-sdk/src/runner/mod.rs
+++ b/aikit-sdk/src/runner/mod.rs
@@ -399,6 +399,7 @@ where
         stderr_thread,
         stdin_thread,
         argv: _argv,
+        stdin_done,
     } = transport::subprocess::connect(backend, prompt, &options, true)?;
 
     // Bind the cancel handle to the live child immediately — before the
@@ -694,6 +695,14 @@ where
     // Signal watchdog on natural exit path (no-op if it already fired).
     if let Some(done_tx) = watchdog_done {
         let _ = done_tx.send(());
+    }
+
+    // Release the stdin writer for Backends that hold it open (`holds_stdin_open`),
+    // so the child observes EOF and can exit gracefully. No-op for every
+    // subprocess-lines Backend. Done before the kill/join below so a settled
+    // RPC server shuts down cleanly rather than being SIGKILLed mid-flush.
+    if let Some(tx) = &stdin_done {
+        let _ = tx.send(());
     }
 
     // If the Backend signalled a terminal settle event (Pi RPC

--- a/aikit-sdk/src/runner/transport/subprocess.rs
+++ b/aikit-sdk/src/runner/transport/subprocess.rs
@@ -33,6 +33,10 @@ pub(crate) struct SubprocessConnection {
     pub stdin_thread: thread::JoinHandle<io::Result<()>>,
     /// argv used, retained for diagnostics.
     pub argv: Vec<OsString>,
+    /// When the Backend [`Backend::holds_stdin_open`], the drain loop signals
+    /// this to release the writer thread (drop stdin → EOF) once the run is
+    /// done. `None` for Backends whose writer drops stdin immediately.
+    pub stdin_done: Option<mpsc::Sender<()>>,
 }
 
 /// Spawn the Backend's CLI, start the stdout/stderr reader threads, and start
@@ -161,6 +165,8 @@ pub(crate) fn connect(
     // text (spec 014).
     let agent_key = backend.key();
     let stdin_bytes = backend.stdin_prompt_bytes(prompt);
+    let holds_stdin = backend.holds_stdin_open();
+    let (stdin_done_tx, stdin_done_rx) = mpsc::channel::<()>();
     let stdin_thread = thread::spawn(move || -> io::Result<()> {
         let mut stdin = stdin_pipe;
         let result = match stdin.write_all(&stdin_bytes) {
@@ -175,6 +181,14 @@ pub(crate) fn connect(
             }
             Err(e) => Err(e),
         };
+        if holds_stdin {
+            // A long-lived RPC server (pi) aborts the in-flight turn the
+            // moment it sees stdin EOF. Hold stdin open until the drain loop
+            // signals completion (or the Sender drops on teardown), so the
+            // server keeps running to `agent_settled`; the subsequent EOF
+            // then lets it exit gracefully.
+            let _ = stdin_done_rx.recv();
+        }
         // `stdin` drops here regardless of outcome, closing the write end
         // and signalling EOF to the child.
         result
@@ -187,6 +201,11 @@ pub(crate) fn connect(
         stderr_thread,
         stdin_thread,
         argv,
+        stdin_done: if holds_stdin {
+            Some(stdin_done_tx)
+        } else {
+            None
+        },
     })
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #128. Even with the correct prompt field, `aikit agent run -a pi` produced no assistant output: pi accepted the prompt (`success:true`, `agent_start`) then aborted before emitting any assistant message — no `turn_end`, no `agent_settled`.

**Root cause:** the subprocess transport's stdin writer drops stdin (EOF) immediately after writing the prompt. Pi's RPC server aborts the in-flight turn the moment it sees stdin EOF, so it bailed after echoing the user message.

**Fix:** the writer now holds stdin open for Backends that declare `holds_stdin_open()` (Pi only), until the drain loop signals completion — then drops it so the server exits gracefully. Every subprocess-lines Backend keeps the previous behavior (writer drops stdin immediately).

## Verification (run against real \`pi\` 0.82.0)

\`\`\`
$ aikit agent run -a pi -p "Reply with exactly one word: pong. Do not use any tools."
\`\`\`
Event stream now includes the full turn: `agent_start → message_update (text_delta "pong") → turn_end (assistant "pong") → agent_end → agent_settled`, and the run returns cleanly (exit 0). Before this fix it stopped at the user `message_end`.

## Test plan
- New unit test `only_pi_holds_stdin_open` locks the per-Backend decision.
- Existing stub tests (settle/teardown + framed-prompt) still pass with the held stdin.
- `cargo test -p aikit-sdk --test-threads=1` (419 lib), clippy `-D warnings`, fmt — all green.