### PR TITLE
feat(session-sync): leveled, correlated observability (Tier 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ dotenv = "0.15"
 
 # Structured logging (spawn argv, run diagnostics)
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # YAML frontmatter parsing
 yaml-front-matter = "0.1"

--- a/aikit-session-sync/src/engine.rs
+++ b/aikit-session-sync/src/engine.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use aikit_session_capture::{
     Adapter, Registry, SecretScrubber, ToolKind, SCRUBBER_PATTERN_VERSION,
@@ -10,6 +10,7 @@ use chrono::Utc;
 use rand::Rng;
 use sha2::{Digest, Sha256};
 use tokio::time::sleep;
+use tracing::{debug, error, info, warn};
 
 use crate::key::object_key;
 use crate::state::{FileFingerprint, SyncStateEntry, SyncStateStore};
@@ -33,6 +34,18 @@ pub struct SyncConfig {
     pub log_level: String,
     pub host: String,
     pub state_path: Option<PathBuf>,
+    /// Correlation id stamped on every log event of one run. Empty → the engine
+    /// generates a time-sortable id in `SyncEngine::new`.
+    pub run_id: String,
+}
+
+/// A short, time-sortable correlation id: hex milliseconds + 4 random hex.
+pub fn new_run_id() -> String {
+    format!(
+        "{:x}{:04x}",
+        Utc::now().timestamp_millis().max(0),
+        rand::thread_rng().gen::<u16>()
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,6 +73,7 @@ impl Default for SyncConfig {
             log_level: "info".to_string(),
             host: default_host(),
             state_path: None,
+            run_id: String::new(),
         }
     }
 }
@@ -110,6 +124,7 @@ impl Default for WatchRetryPolicy {
 pub struct SyncEngine {
     config: SyncConfig,
     owner: String,
+    run_id: String,
     sink: Arc<dyn SyncSink>,
     state: Arc<dyn SyncStateStore>,
     scrubber: SecretScrubber,
@@ -122,9 +137,15 @@ impl SyncEngine {
         state: Arc<dyn SyncStateStore>,
     ) -> Result<Self, SyncError> {
         let owner = resolve_owner(config.owner.as_deref(), config.credential_owner.as_deref())?;
+        let run_id = if config.run_id.is_empty() {
+            new_run_id()
+        } else {
+            config.run_id.clone()
+        };
         Ok(Self {
             config,
             owner,
+            run_id,
             sink,
             state,
             scrubber: SecretScrubber::default(),
@@ -135,19 +156,96 @@ impl SyncEngine {
         &self.owner
     }
 
+    /// Correlation id stamped on every log event of this run.
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
     pub async fn sync_detected(&self, registry: &Registry) -> SyncRunSummary {
-        let mut summary = SyncRunSummary::default();
+        // Enumerate up front so progress has a denominator and an ETA.
+        let mut work: Vec<(&dyn Adapter, PathBuf)> = Vec::new();
         for adapter in jsonl_adapters(registry, self.config.tools.as_deref()) {
             for file in session_files(adapter) {
-                let outcome = match self.sync_file(adapter, &file).await {
-                    Ok(outcome) => outcome,
-                    Err(error) => SyncOutcome::Failed {
-                        error: error.to_string(),
-                    },
-                };
-                summary.record(&outcome);
+                work.push((adapter, file));
             }
         }
+        let total = work.len();
+        let started = Instant::now();
+        info!(
+            run = %self.run_id,
+            owner = %self.owner,
+            host = %self.config.host,
+            bucket = self.config.bucket.as_deref().unwrap_or(""),
+            key_prefix = %self.config.key_prefix,
+            dry_run = self.config.dry_run,
+            total,
+            "sync.run.start"
+        );
+
+        let mut summary = SyncRunSummary::default();
+        let step = (total / 20).max(1); // ~20 progress lines over the run
+        for (i, (adapter, file)) in work.iter().enumerate() {
+            let t0 = Instant::now();
+            match self.sync_file(*adapter, file).await {
+                Ok(outcome) => {
+                    // sync_file only ever returns Synced or SkippedUnchanged.
+                    let (decision, bytes) = match &outcome {
+                        SyncOutcome::Synced { bytes_uploaded, .. } => ("synced", *bytes_uploaded),
+                        _ => ("skipped", 0),
+                    };
+                    debug!(
+                        run = %self.run_id,
+                        file = %file.display(),
+                        decision,
+                        bytes,
+                        dur_ms = t0.elapsed().as_millis() as u64,
+                        "sync.file"
+                    );
+                    summary.record(&outcome);
+                }
+                Err(error) => {
+                    error!(
+                        run = %self.run_id,
+                        file = %file.display(),
+                        kind = error.kind(),
+                        err = %error,
+                        dur_ms = t0.elapsed().as_millis() as u64,
+                        "sync.file.fail"
+                    );
+                    summary.record(&SyncOutcome::Failed {
+                        error: error.to_string(),
+                    });
+                }
+            }
+            let done = i + 1;
+            if done % step == 0 || done == total {
+                let secs = started.elapsed().as_secs_f64().max(0.001);
+                let rate = done as f64 / secs;
+                let eta_s = ((total - done) as f64 / rate.max(f64::MIN_POSITIVE)) as u64;
+                info!(
+                    run = %self.run_id,
+                    done,
+                    total,
+                    synced = summary.synced,
+                    skipped = summary.skipped_unchanged,
+                    failed = summary.failed,
+                    bytes = summary.bytes_uploaded,
+                    rate_per_s = rate as u64,
+                    eta_s,
+                    "sync.progress"
+                );
+            }
+        }
+
+        info!(
+            run = %self.run_id,
+            synced = summary.synced,
+            skipped = summary.skipped_unchanged,
+            failed = summary.failed,
+            bytes = summary.bytes_uploaded,
+            dur_ms = started.elapsed().as_millis() as u64,
+            "sync.run.end"
+        );
         summary
     }
 
@@ -261,11 +359,24 @@ impl SyncEngine {
             match self.sync_file(adapter, path).await {
                 Ok(outcome) => return Ok(outcome),
                 Err(error) => {
-                    last_error = Some(error);
                     if attempt + 1 < attempts {
                         let jitter = rand::thread_rng().gen_range(0..=delay.as_millis() / 4);
-                        sleep(delay + Duration::from_millis(jitter as u64)).await;
+                        let backoff = delay + Duration::from_millis(jitter as u64);
+                        warn!(
+                            run = %self.run_id,
+                            file = %path.display(),
+                            attempt = attempt + 1,
+                            max = attempts,
+                            kind = error.kind(),
+                            err = %error,
+                            backoff_ms = backoff.as_millis() as u64,
+                            "sync.retry"
+                        );
+                        last_error = Some(error);
+                        sleep(backoff).await;
                         delay = delay.saturating_mul(2).min(policy.cap);
+                    } else {
+                        last_error = Some(error);
                     }
                 }
             }
@@ -718,5 +829,50 @@ mod tests {
         resumed.sync_file(&adapter, &two).await.unwrap();
         resumed.sync_file(&adapter, &one).await.unwrap();
         assert_eq!(sink.object_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn sync_detected_records_and_logs_failures() {
+        // A failing sink drives sync_detected's error branch (sync.file.fail +
+        // SyncError::kind) and the failure is counted, not fatal.
+        let tmp = tempfile::tempdir().unwrap();
+        tokio::fs::write(tmp.path().join("a.jsonl"), "{\"m\":\"a\"}\n")
+            .await
+            .unwrap();
+        let mut registry = Registry::new();
+        registry.register(Box::new(FakeAdapter {
+            kind: ToolKind::Codex,
+            root: tmp.path().to_path_buf(),
+        }));
+        let engine = engine(
+            InMemorySink::with_backend_failure(),
+            InMemorySyncStateStore::default(),
+        );
+        let summary = engine.sync_detected(&registry).await;
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.synced, 0);
+    }
+
+    #[test]
+    fn sync_error_kind_labels() {
+        assert_eq!(SyncError::Io(std::io::Error::other("x")).kind(), "io");
+        assert_eq!(SyncError::Backend("x".into()).kind(), "backend");
+        assert_eq!(SyncError::Auth("x".into()).kind(), "auth");
+    }
+
+    #[test]
+    fn new_run_id_is_nonempty_and_varies() {
+        let a = new_run_id();
+        let b = new_run_id();
+        assert!(!a.is_empty());
+        // Same-ms collisions are possible but the random suffix makes repeats
+        // across a handful of calls astronomically unlikely.
+        assert!(a.len() >= 4 && b.len() >= 4);
+    }
+
+    #[tokio::test]
+    async fn engine_generates_run_id_when_unset() {
+        let e = engine(InMemorySink::new(), InMemorySyncStateStore::default());
+        assert!(!e.run_id().is_empty());
     }
 }

--- a/aikit-session-sync/src/sink.rs
+++ b/aikit-session-sync/src/sink.rs
@@ -43,6 +43,19 @@ pub enum SyncError {
     Auth(String),
 }
 
+impl SyncError {
+    /// Stable, low-cardinality label for logs/metrics: `io` | `backend` | `auth`.
+    /// Lets an analyst filter `kind=auth` (creds) vs `kind=backend` (S3/network)
+    /// vs `kind=io` (local file) without parsing the message.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            SyncError::Io(_) => "io",
+            SyncError::Backend(_) => "backend",
+            SyncError::Auth(_) => "auth",
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct InMemorySink {
     inner: Arc<Mutex<InMemoryInner>>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -376,6 +376,7 @@ pub fn build_app() -> Result<AikitApp> {
                 allow_http: args.allow_http,
                 format: args.format,
                 log_level: args.log_level,
+                log_format: args.log_format,
             })
             .await?;
             if code == 0 {
@@ -1363,6 +1364,7 @@ struct SessionSyncArgs {
     allow_http: bool,
     format: String,
     log_level: Option<String>,
+    log_format: String,
 }
 
 impl IntoCommandSpec for SessionSyncArgs {
@@ -1401,6 +1403,7 @@ impl IntoCommandSpec for SessionSyncArgs {
                 flag_spec("allow-http", "Allow plain HTTP endpoints for local MinIO"),
                 opt_spec("format", "Output format: default or json"),
                 opt_spec("log-level", "Log level (default: info or RUST_LOG)"),
+                opt_spec("log-format", "Log output: text (default) or json (ndjson)"),
             ],
             ..CommandSpec::default()
         }
@@ -1421,6 +1424,7 @@ impl FromArgValueMap for SessionSyncArgs {
             allow_http: get_bool_val(map, "allow-http"),
             format: get_str_default(map, "format", "default"),
             log_level: get_opt_val(map, "log-level"),
+            log_format: get_str_default(map, "log-format", "text"),
         }
     }
 }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -57,6 +57,7 @@ pub struct SyncSessionsArgs {
     pub allow_http: bool,
     pub format: String,
     pub log_level: Option<String>,
+    pub log_format: String,
 }
 
 // ── new session ───────────────────────────────────────────────────────────────
@@ -179,8 +180,40 @@ pub fn execute_list(args: ListSessionsArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Install a stderr tracing subscriber for the sync run. No-op if one already
+/// exists (a global `--debug` or `RUST_LOG` setup wins). `json` emits ndjson.
+#[cfg(feature = "agent-adapters")]
+fn init_sync_logging(level: &str, json: bool) {
+    use tracing_subscriber::EnvFilter;
+    let filter = std::env::var("RUST_LOG")
+        .ok()
+        .map(EnvFilter::new)
+        .unwrap_or_else(|| EnvFilter::new(format!("aikit_session_sync={level},warn")));
+    let builder = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .with_writer(std::io::stderr);
+    let _ = if json {
+        builder.json().flatten_event(true).try_init()
+    } else {
+        builder.try_init()
+    };
+}
+
 #[cfg(feature = "agent-adapters")]
 pub async fn execute_sync(args: SyncSessionsArgs) -> anyhow::Result<i32> {
+    // Turn on leveled sync logging to stderr. No-op if a subscriber is already
+    // installed (RUST_LOG / global --debug take precedence). --log-format json
+    // emits ndjson for log ingestion.
+    {
+        let level = args
+            .log_level
+            .clone()
+            .or_else(|| std::env::var("RUST_LOG").ok())
+            .unwrap_or_else(|| "info".to_string());
+        init_sync_logging(&level, args.log_format.eq_ignore_ascii_case("json"));
+    }
+
     let bucket = args
         .bucket
         .or_else(|| std::env::var("AIKIT_SYNC_BUCKET").ok());

--- a/tests/session_sync_cli_test.rs
+++ b/tests/session_sync_cli_test.rs
@@ -53,6 +53,7 @@ fn args() -> SyncSessionsArgs {
         allow_http: false,
         format: "default".to_string(),
         log_level: None,
+        log_format: "text".to_string(),
     }
 }
 

--- a/webdocs/cli-commands.mdx
+++ b/webdocs/cli-commands.mdx
@@ -346,7 +346,8 @@ aikit session sync --owner alice --bucket my-sessions \
 | `--dry-run` | — | off | Detect + scrub + hash + summarize, upload nothing |
 | `--allow-http` | `AIKIT_SYNC_ALLOW_HTTP` | `false` | Permit plain-HTTP endpoints (local MinIO dev) |
 | `--format` | — | `default` | `default` (human) or `json` (machine-readable summary) |
-| `--log-level` | `RUST_LOG` | `info` | Log verbosity |
+| `--log-level` | `RUST_LOG` | `info` | Log verbosity: `error`, `warn`, `info`, `debug`, `trace` |
+| `--log-format` | — | `text` | Log output: `text` (human) or `json` (ndjson for log ingestion) |
 
 **Credentials** are read from the standard AWS environment
 (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, or a workload-identity chain) and
@@ -362,6 +363,30 @@ are **never** accepted as flags. Two additional env-only knobs:
 **Idempotency & retention:** the object key is the SHA-256 of the scrubbed
 bytes, so re-syncing unchanged content is a no-op; a grown transcript produces a
 new version object and **all versions are retained** (v1 keeps everything).
+
+**Observability.** The sync run emits structured events to **stderr** (the JSON
+summary still goes to stdout), each carrying a `run` correlation id so one run's
+lines can be grepped together. Verbosity is `--log-level`; `--log-format json`
+emits ndjson for Loki/ELK/CloudWatch.
+
+| Level | Events |
+|-------|--------|
+| `error` | `sync.file.fail` — with `kind` (`auth` \| `backend` \| `io`) so creds vs S3/network vs local-file failures are filterable without parsing the message |
+| `warn` | `sync.retry` — attempt/max, backoff, error (watch mode) |
+| `info` | `sync.run.start` (owner, host, bucket, total), `sync.progress` (done/total, synced/skipped/failed, bytes, rate, ETA), `sync.run.end` (totals, duration) |
+| `debug` | `sync.file` — per file: decision (`synced`/`skipped`), bytes, duration |
+
+```bash
+# watch a large run with progress + per-file detail
+aikit session sync … --log-level debug
+
+# structured logs for ingestion
+aikit session sync … --log-format json
+# {"level":"INFO","message":"sync.progress","run":"19f9…","done":342,"total":992,"synced":342,"bytes":220300000,"rate_per_s":47,"eta_s":14}
+```
+
+`RUST_LOG` (or a global `--debug`) takes precedence over `--log-level`/`--log-format`
+if set.
 
 **Exit codes:** `0` everything synced or already current · `1` one or more files
 failed after retries · `2` configuration/auth error before any upload (missing


### PR DESCRIPTION
Built for the "support analyst debugging the microservice at 3am" case. The sync engine was silent except for the final JSON summary; now it emits structured, leveled, correlated events so you can see progress, per-file decisions, and — crucially — *why* something failed.

## What you get (by `--log-level`)

| Level | Events |
|-------|--------|
| `error` | `sync.file.fail` with `kind` = `auth` \| `backend` \| `io` — filter creds vs S3/network vs local-file without parsing messages |
| `warn` | `sync.retry` (attempt/max, backoff, kind) — watch mode |
| `info` (default) | `sync.run.start` (owner/host/bucket/total), `sync.progress` (~20 lines: done/total, counts, bytes, rate, ETA), `sync.run.end` (totals, duration) |
| `debug` | `sync.file` per file: decision (synced/skipped), bytes, duration |

Every line carries a **`run` correlation id** so one run greps together. `--log-format json` emits ndjson for Loki/ELK/CloudWatch. Logs go to **stderr**; the JSON summary stays on **stdout**.

```
INFO sync.run.start run=19f9… owner=me host=server02 bucket=agsessions total=992
INFO sync.progress  run=19f9… done=342 total=992 synced=342 failed=0 bytes=220300000 rate_per_s=47 eta_s=14
ERROR sync.file.fail run=19f9… file=…/c3d4.jsonl kind=auth err="403 SignatureDoesNotMatch"
INFO sync.run.end   run=19f9… synced=990 failed=2 bytes=705… dur_ms=21400
```
```json
{"level":"INFO","message":"sync.progress","run":"19f9…","done":342,"total":992,"synced":342,"bytes":220300000,"rate_per_s":47,"eta_s":14}
```

## Scope (as agreed)
- Tier 2: leveled logs + run_id + progress + actionable errors + wired `--log-level` + `--log-format json`. **No HTTP server** (health/metrics endpoint was the deferred Tier 3).
- Failure handling unchanged: best-effort, exit 1 if any file failed (no `--fail-fast`).
- `RUST_LOG` / global `--debug` still take precedence over `--log-level`/`--log-format`.

## Validation
- 27 lib + watch_sync + session_sync + cli tests pass; new tests cover the failure-log path, `SyncError::kind()`, and run_id generation.
- clippy `--all-targets --all-features -D warnings` clean.
- coverage **95.67%** lines (gate ≥95%).
- Manually exercised end-to-end against a fake `~/.claude` session — text + json output verified (screenshots of both in the commit description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)