### PR TITLE
test(session-capture): harden notify watcher test against FSEvents latency

### DIFF
--- a/aikit-session-capture/src/watch.rs
+++ b/aikit-session-capture/src/watch.rs
@@ -217,7 +217,16 @@ mod tests {
         // The notify-based driver is what `aikit session sync --watch` uses.
         // Create the watch dir first (notify watches existing dirs), start the
         // driver, then drop a .jsonl file in and assert the event is delivered.
-        // Generous timeout because OS notification latency varies across CI.
+        //
+        // On macOS FSEvents (the backend on the GitHub Actions macos runners)
+        // the native event stream has high, variable startup latency and can
+        // drop the first event for a freshly registered watch. A single
+        // one-shot write therefore races the OS: the event may arrive late or
+        // not at all within a fixed window. We instead re-stimulate the file
+        // on a short cadence and poll the driver in a loop, so a dropped or
+        // delayed first delivery is recovered by a later round. The overall
+        // deadline is a safety net only — a healthy run resolves in well under
+        // a second.
         let tmp = tempfile::tempdir().unwrap();
         let watch_path = tmp.path().to_path_buf();
         let adapter = FakeAdapter {
@@ -229,15 +238,26 @@ mod tests {
             .expect("notify watcher builds");
 
         let sess_file = watch_path.join("sess.jsonl");
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            std::fs::write(&sess_file, "{\"type\":\"user\"}\n").unwrap();
-        });
+        let content = "{\"type\":\"user\"}\n";
 
-        let event = tokio::time::timeout(Duration::from_secs(10), driver.next_event()).await;
-        let path = event
-            .expect("notify driver should deliver an event within 10s")
-            .expect("event stream should not end");
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut path = None;
+        while Instant::now() < deadline {
+            // Re-stimulate: a fresh write produces a new FS event even when an
+            // earlier one was coalesced or dropped by the OS backend.
+            std::fs::write(&sess_file, content).unwrap();
+            match tokio::time::timeout(Duration::from_secs(2), driver.next_event()).await {
+                Ok(Some(p)) => {
+                    path = Some(p);
+                    break;
+                }
+                Ok(None) => panic!("notify driver event stream ended unexpectedly"),
+                Err(_) => {} // No event this round — retry with a fresh write.
+            }
+        }
+
+        let path =
+            path.expect("notify driver should deliver an event for sess.jsonl within the deadline");
         assert_eq!(path.extension().unwrap(), "jsonl");
     }
 


### PR DESCRIPTION
## Summary

`notify_driver_detects_created_file` in `aikit-session-capture` was a single one-shot write + a 10s wait. On the macOS GitHub runners FSEvents has high, variable startup latency and can drop the first event for a freshly registered watch, so the test raced the OS and failed intermittently — it did so on the 0.1.178 merge, which (combined with an unrelated ubuntu-link OOM) blocked the release chain and required manual reruns.

## Fix

Re-stimulate the fixture file on a short cadence and poll the driver in a loop:
- each round (re)writes `sess.jsonl` (a fresh write produces a new FS event even when an earlier one was coalesced or dropped),
- then polls `next_event()` with a short per-round timeout,
- with a 30s overall deadline as a safety net only.

A dropped/delayed first delivery is recovered by a later round; `Ok(None)` (stream end) fails fast and loudly rather than spinning.

## Verification

- 5/5 consecutive runs pass locally at ~0.05s each (the re-stimulation does not slow the happy path — on a healthy backend the first round resolves immediately).
- `cargo fmt --check`, `cargo clippy --features crossmount,mcp-tools,watcher -p aikit-session-capture -- -D warnings` clean.
- Watcher CI matrix (`--features crossmount,mcp-tools,watcher -p aikit-session-capture`) green.

## Notes

No production code changed — `NotifyWatchDriver` and the debounce logic are untouched; only the test's stimulus/wait strategy changed. The macOS-only flakiness was upstream of the debounce (the `notify` callback never fired within the window).