### PR TITLE
fix(runner): map pi --bare/--ephemeral to native spec-013 knobs

### DIFF
--- a/aikit-sdk/src/runner/argv.rs
+++ b/aikit-sdk/src/runner/argv.rs
@@ -653,4 +653,52 @@ mod tests {
         let legacy = build_argv("cursor", None, false, false, false, None);
         assert_eq!(with_env, legacy);
     }
+
+    // ── spec 013: pi envelope argv mapping ────────────────────────────────────
+
+    #[test]
+    fn spec013_pi_ephemeral_and_bare_map_to_native_flags() {
+        // pi honors --bare and --ephemeral natively (--no-context-files family
+        // / --no-session); the envelope maps them onto those flags.
+        let env = InvocationEnvelope {
+            bare: true,
+            ephemeral: true,
+            ..Default::default()
+        };
+        let argv = build_argv_envelope("pi", None, false, false, false, None, Some(&env));
+        assert!(argv.contains(&OsString::from("rpc")));
+        assert!(argv.contains(&OsString::from("--no-session")));
+        assert!(argv.contains(&OsString::from("--no-context-files")));
+        assert!(argv.contains(&OsString::from("--no-extensions")));
+        assert!(argv.contains(&OsString::from("--no-skills")));
+        assert!(argv.contains(&OsString::from("--no-prompt-templates")));
+    }
+
+    #[test]
+    fn spec013_pi_inactive_envelope_is_identical_to_legacy() {
+        // An inactive envelope (no knobs set) must yield the identical argv to
+        // the legacy no-envelope path — pi adds nothing when nothing is asked.
+        let env = InvocationEnvelope::default();
+        let with_env = build_argv_envelope("pi", None, false, false, false, None, Some(&env));
+        let legacy = build_argv("pi", None, false, false, false, None);
+        assert_eq!(with_env, legacy);
+    }
+
+    #[test]
+    fn spec013_pi_security_knobs_are_not_argv_mapped() {
+        // sandbox / add-dir are Unsupported for pi and fail closed in
+        // resolve_envelope before argv; an envelope carrying only those must
+        // NOT sneak any sandbox flag into pi's argv (there is none to emit).
+        let env = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::BoundedWrite),
+            extra_writable_roots: vec![PathBuf::from("/shared")],
+            ..Default::default()
+        };
+        let argv = build_argv_envelope("pi", None, false, false, false, None, Some(&env));
+        assert!(
+            !argv.iter().any(|a| a == "--sandbox" || a == "--add-dir"),
+            "pi has no native sandbox/add-dir flag; got {:?}",
+            argv
+        );
+    }
 }

--- a/aikit-sdk/src/runner/backends/pi.rs
+++ b/aikit-sdk/src/runner/backends/pi.rs
@@ -331,7 +331,10 @@ pub(crate) fn prompt_command(prompt: &str) -> String {
 
 /// The spawn argv for `pi --mode rpc`. `model` and `session_id` are passed
 /// through verbatim as spawn flags (spec 014); `yolo`/`stream`/`events_mode`
-/// are unused — RPC mode always emits structured events.
+/// are unused — RPC mode always emits structured events. The spec-013
+/// lifecycle knobs the matrix declares `SupportedOsEnforced` (`--bare`,
+/// `--ephemeral`) map onto pi's native user-config / no-session flags; an
+/// inactive envelope leaves argv identical to the legacy argv.
 pub(crate) fn argv(ctx: crate::runner::backends::argv_spec::ArgvCtx) -> Vec<OsString> {
     let mut argv = vec![
         OsString::from(KEY),
@@ -348,6 +351,23 @@ pub(crate) fn argv(ctx: crate::runner::backends::argv_spec::ArgvCtx) -> Vec<OsSt
         argv.push(OsString::from("--session"));
         argv.push(OsString::from(id));
     }
+    // spec 013 D6: map honored lifecycle knobs onto pi's native flags. These
+    // are convenience knobs (never fail-closed by resolve_envelope), so an
+    // inactive envelope adds nothing.
+    if let Some(env) = ctx.envelope {
+        // --bare ⇒ skip user-config discovery (the pi analogue of codex
+        // --ignore-user-config / claude --bare).
+        if env.bare {
+            argv.push(OsString::from("--no-context-files"));
+            argv.push(OsString::from("--no-extensions"));
+            argv.push(OsString::from("--no-skills"));
+            argv.push(OsString::from("--no-prompt-templates"));
+        }
+        // --ephemeral ⇒ don't persist the session.
+        if env.ephemeral {
+            argv.push(OsString::from("--no-session"));
+        }
+    }
     argv
 }
 
@@ -355,6 +375,7 @@ pub(crate) fn argv(ctx: crate::runner::backends::argv_spec::ArgvCtx) -> Vec<OsSt
 mod tests {
     use super::*;
     use crate::runner::backends::argv_spec::ArgvCtx;
+    use crate::runner::invocation::InvocationEnvelope;
     use crate::runner::types::AgentEventStream;
 
     const STDOUT: AgentEventStream = AgentEventStream::Stdout;
@@ -711,6 +732,93 @@ mod tests {
         });
         let s: Vec<&str> = argv.iter().map(|a| a.to_str().unwrap()).collect();
         assert_eq!(s, vec!["pi", "--mode", "rpc"]);
+    }
+
+    // ---- spec 013 envelope mapping ---------------------------------------
+
+    #[test]
+    fn argv_ephemeral_emits_no_session() {
+        let argv = argv(ArgvCtx {
+            model: None,
+            yolo: false,
+            stream: false,
+            events_mode: false,
+            session_id: None,
+            envelope: Some(&InvocationEnvelope {
+                ephemeral: true,
+                ..Default::default()
+            }),
+        });
+        assert!(argv.contains(&OsString::from("--no-session")));
+    }
+
+    #[test]
+    fn argv_bare_emits_no_context_files_family() {
+        let argv = argv(ArgvCtx {
+            model: None,
+            yolo: false,
+            stream: false,
+            events_mode: false,
+            session_id: None,
+            envelope: Some(&InvocationEnvelope {
+                bare: true,
+                ..Default::default()
+            }),
+        });
+        assert!(argv.contains(&OsString::from("--no-context-files")));
+        assert!(argv.contains(&OsString::from("--no-extensions")));
+        assert!(argv.contains(&OsString::from("--no-skills")));
+        assert!(argv.contains(&OsString::from("--no-prompt-templates")));
+        // bare alone must not imply --no-session (that is --ephemeral's mapping)
+        assert!(!argv.contains(&OsString::from("--no-session")));
+    }
+
+    #[test]
+    fn argv_inactive_envelope_adds_no_flags() {
+        let argv = argv(ArgvCtx {
+            model: None,
+            yolo: false,
+            stream: false,
+            events_mode: false,
+            session_id: None,
+            envelope: Some(&InvocationEnvelope::default()),
+        });
+        let s: Vec<&str> = argv.iter().map(|a| a.to_str().unwrap()).collect();
+        assert_eq!(s, vec!["pi", "--mode", "rpc"]);
+    }
+
+    #[test]
+    fn argv_envelope_composes_with_model_and_session() {
+        let argv = argv(ArgvCtx {
+            model: Some(&"anthropic/claude-sonnet-4".to_string()),
+            yolo: false,
+            stream: false,
+            events_mode: false,
+            session_id: Some("sess-1"),
+            envelope: Some(&InvocationEnvelope {
+                bare: true,
+                ephemeral: true,
+                ..Default::default()
+            }),
+        });
+        let s: Vec<&str> = argv.iter().map(|a| a.to_str().unwrap()).collect();
+        assert_eq!(
+            s,
+            vec![
+                "pi",
+                "--mode",
+                "rpc",
+                "--model",
+                "anthropic/claude-sonnet-4",
+                "--session",
+                "sess-1",
+                "--no-context-files",
+                "--no-extensions",
+                "--no-skills",
+                "--no-prompt-templates",
+                "--no-session"
+            ]
+        );
     }
 
     // ---- capability honesty (spec 014 testing decisions) -----------------

--- a/aikit-sdk/src/runner/invocation.rs
+++ b/aikit-sdk/src/runner/invocation.rs
@@ -156,23 +156,24 @@ impl Backend {
         }
     }
 
-    /// `--bare` support (D6). codex (`--ignore-user-config`) and claude
-    /// (`--bare`); no native equivalent elsewhere.
+    /// `--bare` support (D6). codex (`--ignore-user-config`), claude (`--bare`),
+    /// and pi (`--no-context-files`/`--no-extensions`/`--no-skills`/
+    /// `--no-prompt-templates` skip user-config discovery); no native
+    /// equivalent elsewhere.
     pub fn bare_support(self) -> KnobSupport {
         match self {
-            Backend::Codex | Backend::Claude => KnobSupport::SupportedOsEnforced,
-            Backend::Gemini
-            | Backend::OpenCode
-            | Backend::Cursor
-            | Backend::Aikit
-            | Backend::Pi => KnobSupport::Unsupported,
+            Backend::Codex | Backend::Claude | Backend::Pi => KnobSupport::SupportedOsEnforced,
+            Backend::Gemini | Backend::OpenCode | Backend::Cursor | Backend::Aikit => {
+                KnobSupport::Unsupported
+            }
         }
     }
 
-    /// `--ephemeral` support (D6). codex only today.
+    /// `--ephemeral` support (D6). codex (`--ephemeral`) and pi
+    /// (`--no-session`); no native equivalent elsewhere.
     pub fn ephemeral_support(self) -> KnobSupport {
         match self {
-            Backend::Codex => KnobSupport::SupportedOsEnforced,
+            Backend::Codex | Backend::Pi => KnobSupport::SupportedOsEnforced,
             _ => KnobSupport::Unsupported,
         }
     }
@@ -432,33 +433,51 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_knobs_codex_only_or_codex_claude() {
+    fn lifecycle_knobs_matrix() {
+        // bare: codex + claude + pi
+        assert_eq!(
+            Backend::Codex.bare_support(),
+            KnobSupport::SupportedOsEnforced
+        );
+        assert_eq!(
+            Backend::Claude.bare_support(),
+            KnobSupport::SupportedOsEnforced
+        );
+        assert_eq!(Backend::Pi.bare_support(), KnobSupport::SupportedOsEnforced);
+        // ephemeral: codex + pi
+        assert_eq!(
+            Backend::Codex.ephemeral_support(),
+            KnobSupport::SupportedOsEnforced
+        );
+        assert_eq!(
+            Backend::Pi.ephemeral_support(),
+            KnobSupport::SupportedOsEnforced
+        );
+        // skip-git-repo-check: codex only
+        assert_eq!(
+            Backend::Codex.skip_git_repo_check_support(),
+            KnobSupport::SupportedOsEnforced
+        );
         for &b in ALL {
-            // bare: codex + claude
-            assert_eq!(
-                Backend::Codex.bare_support(),
-                KnobSupport::SupportedOsEnforced
-            );
-            assert_eq!(
-                Backend::Claude.bare_support(),
-                KnobSupport::SupportedOsEnforced
-            );
-            // ephemeral / skip-git-repo-check: codex only
-            assert_eq!(
-                Backend::Codex.ephemeral_support(),
-                KnobSupport::SupportedOsEnforced
-            );
-            assert_eq!(
-                Backend::Codex.skip_git_repo_check_support(),
-                KnobSupport::SupportedOsEnforced
-            );
-            // every non-codex lifecycle is unsupported except claude bare
+            // skip-git-repo-check is codex-only
             if !matches!(b, Backend::Codex) {
-                assert_eq!(b.ephemeral_support(), KnobSupport::Unsupported);
-                assert_eq!(b.skip_git_repo_check_support(), KnobSupport::Unsupported);
-                if !matches!(b, Backend::Claude) {
-                    assert_eq!(b.bare_support(), KnobSupport::Unsupported);
-                }
+                assert_eq!(
+                    b.skip_git_repo_check_support(),
+                    KnobSupport::Unsupported,
+                    "skip-git-repo-check for {b:?}"
+                );
+            }
+            // ephemeral is unsupported except codex + pi
+            if !matches!(b, Backend::Codex | Backend::Pi) {
+                assert_eq!(
+                    b.ephemeral_support(),
+                    KnobSupport::Unsupported,
+                    "ephemeral for {b:?}"
+                );
+            }
+            // bare is unsupported except codex + claude + pi
+            if !matches!(b, Backend::Codex | Backend::Claude | Backend::Pi) {
+                assert_eq!(b.bare_support(), KnobSupport::Unsupported, "bare for {b:?}");
             }
         }
     }
@@ -507,6 +526,49 @@ mod tests {
         assert!(resolve_envelope(Backend::Codex, &env).is_ok());
         assert!(resolve_envelope(Backend::Gemini, &env).is_ok());
         assert!(resolve_envelope(Backend::Aikit, &env).is_ok());
+    }
+
+    #[test]
+    fn resolve_pi_with_sandbox_fails_closed() {
+        // Pi has no native sandbox (Unsupported); any --sandbox policy fails
+        // closed rather than silently downgrading trust.
+        let env = InvocationEnvelope {
+            sandbox: Some(SandboxPolicy::BoundedWrite),
+            ..Default::default()
+        };
+        let err = resolve_envelope(Backend::Pi, &env).unwrap_err();
+        assert_eq!(err.backend, Backend::Pi);
+        assert_eq!(err.knob, "sandbox");
+    }
+
+    #[test]
+    fn resolve_pi_extra_roots_fails_closed() {
+        let env = InvocationEnvelope {
+            extra_writable_roots: vec![PathBuf::from("/tmp/x")],
+            ..Default::default()
+        };
+        let err = resolve_envelope(Backend::Pi, &env).unwrap_err();
+        assert_eq!(err.backend, Backend::Pi);
+        assert_eq!(err.knob, "add-dir");
+    }
+
+    #[test]
+    fn format_capabilities_pi_shows_native_lifecycle_unsupported_sandbox() {
+        let s = format_capabilities(Backend::Pi);
+        assert!(s.contains("backend: pi"), "{}", s);
+        // sandbox is unsupported for every policy
+        assert!(s.contains("unsupported"), "{}", s);
+        // bare + ephemeral are now natively supported
+        assert!(
+            s.lines()
+                .any(|l| l.trim_start().starts_with("bare") && l.contains("supported")),
+            "bare line must be supported:\n{s}"
+        );
+        assert!(
+            s.lines()
+                .any(|l| l.trim_start().starts_with("ephemeral") && l.contains("supported")),
+            "ephemeral line must be supported:\n{s}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Pi (added in spec 014 / #121) was wired into the spec-013 capability matrix, but two lifecycle knobs were declared `Unsupported` even though `pi` has native flags for them — so `aikit agent run -a pi --bare` / `--ephemeral` were **silently ignored**.

Verified against `pi --help` (v0.82.0):

| spec-013 knob | pi native flag | before | after |
|---|---|---|---|
| `--ephemeral` | `--no-session` | Unsupported (ignored) | **SupportedOsEnforced** |
| `--bare` | `--no-context-files --no-extensions --no-skills --no-prompt-templates` | Unsupported (ignored) | **SupportedOsEnforced** |
| `--sandbox` | none (read-only would need fragile tool-exclusion) | Unsupported | Unsupported (fail-closed) |
| `--add-dir` | none | Unsupported | Unsupported (fail-closed) |
| `--auto-approve` | `--approve` is file-trust, not tool-approval | Unsupported | Unsupported |

## Why

A declared-`Unsupported` convenience knob is silently dropped, so a caller asking for an ephemeral pi run got a persisted session anyway. Security knobs (`--sandbox`, `--add-dir`) stay `Unsupported` and fail closed (exit 3) — correct, since pi has no native sandbox.

## Changes
- `invocation.rs`: `bare_support`/`ephemeral_support` gain a `Backend::Pi` arm; matrix tests updated + pi-specific fail-closed / `--capabilities` tests added.
- `backends/pi.rs`: `argv()` emits `--no-session` / `--no-context-files` family from the envelope; inactive envelope stays identical to legacy argv. New argv tests.
- `argv.rs`: spec-013 pi envelope tests (mapping, inactive-identical, security-knobs-not-argv-mapped).

Pi runs over the same `subprocess::connect` path as the other backends, so `resolve_envelope` (fail-closed) and `Command::current_dir` (`--cd`, already `SupportedOsEnforced`) already apply to it.

## Verification
- `cargo fmt --check`, `cargo clippy -p aikit-sdk --all-features -- -D warnings` clean.
- `cargo test -p aikit-sdk --lib`: 429 passed (incl. new pi tests). Pre-commit + pre-push hooks green.
